### PR TITLE
system: de1: set script file attibute to 'x'

### DIFF
--- a/systems/de1/de1.system
+++ b/systems/de1/de1.system
@@ -13,4 +13,4 @@ tcl_files = data/pinmap.tcl
             data/options.tcl
 
 [scripts]
-post_build_scripts = scripts/build_summary.sh
+post_build_scripts = scripts/build_summary

--- a/systems/de1/scripts/build_summary
+++ b/systems/de1/scripts/build_summary
@@ -6,7 +6,7 @@ FITTER_REPORT_END=$(cat ${BUILD_ROOT}/bld-quartus/de1.fit.rpt | grep -nr "; Fitt
 FITTER_REPORT_START=$(($FITTER_REPORT_START - 1))
 FITTER_REPORT_END=$(($FITTER_REPORT_END - 4))
 
-echo -e "\033[31m" 
+echo -e "\033[31m"
 sed -n ${FITTER_REPORT_START},${FITTER_REPORT_END}p ${BUILD_ROOT}/bld-quartus/de1.fit.rpt
 
 
@@ -18,4 +18,4 @@ FMAX_REPORT_END=$(($FMAX_REPORT_END - 1))
 
 echo
 sed -n ${FMAX_REPORT_START},${FMAX_REPORT_END}p ${BUILD_ROOT}/bld-quartus/de1.sta.rpt
-echo -e "\033[0m" 
+echo -e "\033[0m"


### PR DESCRIPTION
ORPSoC now starts shell scripts without invoquing bash
(see commit 76dcafe76c92). So turn the script to an
executable.

Fix white spaces at the same time.

Signed-off-by: Franck Jullien franck.jullien@gmail.com
