### PR TITLE
Do not print file names for grep command

### DIFF
--- a/systems/de1/scripts/build_summary
+++ b/systems/de1/scripts/build_summary
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-FITTER_REPORT_START=$(cat ${BUILD_ROOT}/bld-quartus/de1.fit.rpt | grep -nr "; Fitter Summary" | gawk '{print $1}' FS=":")
-FITTER_REPORT_END=$(cat ${BUILD_ROOT}/bld-quartus/de1.fit.rpt | grep -nr "; Fitter Settings" | gawk '{print $1}' FS=":")
+FITTER_REPORT_START=$(cat ${BUILD_ROOT}/bld-quartus/de1.fit.rpt | grep -nhr "; Fitter Summary" | gawk '{print $1}' FS=":")
+FITTER_REPORT_END=$(cat ${BUILD_ROOT}/bld-quartus/de1.fit.rpt | grep -nhr "; Fitter Settings" | gawk '{print $1}' FS=":")
 
 FITTER_REPORT_START=$(($FITTER_REPORT_START - 1))
 FITTER_REPORT_END=$(($FITTER_REPORT_END - 4))
@@ -10,8 +10,8 @@ echo -e "\033[31m"
 sed -n ${FITTER_REPORT_START},${FITTER_REPORT_END}p ${BUILD_ROOT}/bld-quartus/de1.fit.rpt
 
 
-FMAX_REPORT_START=$(cat ${BUILD_ROOT}/bld-quartus/de1.sta.rpt | grep -nr "; Slow Model Fmax Summary" | gawk '{print $1}' FS=":")
-FMAX_REPORT_END=$(cat ${BUILD_ROOT}/bld-quartus/de1.sta.rpt | grep -nr "This panel reports FMAX" | gawk '{print $1}' FS=":")
+FMAX_REPORT_START=$(cat ${BUILD_ROOT}/bld-quartus/de1.sta.rpt | grep -nhr "; Slow Model Fmax Summary" | gawk '{print $1}' FS=":")
+FMAX_REPORT_END=$(cat ${BUILD_ROOT}/bld-quartus/de1.sta.rpt | grep -nhr "This panel reports FMAX" | gawk '{print $1}' FS=":")
 
 FMAX_REPORT_START=$(($FMAX_REPORT_START - 1))
 FMAX_REPORT_END=$(($FMAX_REPORT_END - 1))


### PR DESCRIPTION
The grep commands get as parameter `-nr` which still shows the file name, hence the `print $1` in the gawk command will select the file name instead the line number. So, one could either write `print $2` or add `-h` as parameter to grep to hide the file name. I did the latter one in this pull request.
