### PR TITLE
elf-loader: add missing headers in vpi_wrapper.c

### DIFF
--- a/cores/elf-loader/vpi_wrapper.c
+++ b/cores/elf-loader/vpi_wrapper.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+#include <ctype.h>
 #include <vpi_user.h>
 #include "elf-loader.h"
 


### PR DESCRIPTION
No error while using Icarus but Modelsim complains.

Add missing stdlib.h and ctype.h required for NULL, free() and
isspace().

Signed-off-by: Franck Jullien franck.jullien@gmail.com
