### PR TITLE
or1200-generic: verilator: add top_module param

### DIFF
--- a/systems/or1200-generic/or1200-generic.core
+++ b/systems/or1200-generic/or1200-generic.core
@@ -32,3 +32,4 @@ verilator_options = -Wno-fatal --trace
 src_files     = bench/verilator/or1k-elf-loader.c
 include_files = bench/verilator/or1k-elf-loader.h
 tb_toplevel   = bench/verilator/tb.cpp
+top_module    = orpsoc_top


### PR DESCRIPTION
In section verilator top_module in now mandatory for the
simulated system/core.

Signed-off-by: Franck Jullien franck.jullien@gmail.com
