### PR TITLE
wb_intercon: fix single slave connections

### DIFF
--- a/cores/wb_intercon/sw/wb_intercon_gen
+++ b/cores/wb_intercon/sw/wb_intercon_gen
@@ -244,9 +244,8 @@ class WbIntercon:
                 self.template_writer.add(Wire(wirename, p.width))
                 template_ports += [Port(portname, wirename)]
 
-            if len(master.slaves) > 1:
-                self._gen_mux(master)
-            
+            self._gen_mux(master)
+
         for slave in self.slaves.values():
             for p in WB_MASTER_PORTS:
                 portname = 'wb_{slave}_{port}_o'.format(slave=slave.name, port=p.name)


### PR DESCRIPTION
When a master only had a single slave, there would be no
connection made between the master and slave.
The reason was that _gen_mux was never called on
master.slaves == 1, even though _gen_mux has code to handle
the condition.
A note on that though, a wb_mux will still be instantiated,
but this is IMO correct behaviour instead of hard connect the
wires between the master and the slave, since additional
address matching logic will be added with wb_mux.
