### PR TITLE
verilator_tb_utils: change all 'times' to uint64_t

### DIFF
--- a/cores/verilator_tb_utils/verilator_tb_utils.cpp
+++ b/cores/verilator_tb_utils/verilator_tb_utils.cpp
@@ -36,7 +36,7 @@ bool VerilatorTbUtils::doCycle() {
   }
 
   if (vcdDumping)
-    tfp->dump(t);
+    tfp->dump((vluint64_t)t);
 
   if(timeout && t >= timeout) {
     printf("Timeout reached\n");

--- a/cores/verilator_tb_utils/verilator_tb_utils.h
+++ b/cores/verilator_tb_utils/verilator_tb_utils.h
@@ -1,6 +1,7 @@
 #ifndef __VERILATOR_TB_UTILS_H__
 #define __VERILATOR_TB_UTILS_H__
 
+#include <stdint.h>
 #include <verilated.h>
 #include <verilated_vcd_c.h>
 
@@ -15,12 +16,12 @@ public:
 
   bool doCycle();
 
-  unsigned long getTime() { return t; }
+  uint64_t getTime() { return t; }
 
-  unsigned long getTimeout() { return timeout; }
+  uint64_t getTimeout() { return timeout; }
   bool getVcdDump() { return vcdDump; }
-  unsigned long getVcdDumpStart() { return vcdDumpStart; }
-  unsigned long getVcdDumpStop() { return vcdDumpStop; }
+  uint64_t getVcdDumpStart() { return vcdDumpStart; }
+  uint64_t getVcdDumpStop() { return vcdDumpStop; }
   char *getVcdFileName() { return vcdFileName; }
 
   bool getRspServerEnable() { return rspServerEnable; }
@@ -29,13 +30,13 @@ public:
   static int parseOpts(int key, char *arg, struct argp_state *state);
 
 private:
-  unsigned long t;
+  uint64_t t;
 
-  unsigned long timeout;
+  uint64_t timeout;
 
   bool vcdDump;
-  unsigned long vcdDumpStart;
-  unsigned long vcdDumpStop;
+  uint64_t vcdDumpStart;
+  uint64_t vcdDumpStop;
   char *vcdFileName;
   bool vcdDumping;
 


### PR DESCRIPTION
Franck Jullien reported that unsigned long is not a valid argument
for tfp->dump() on 32-bit machines.
This changes all 'time' (cycles, really) references to uint64_t.
