### PR TITLE
systems: add atlys board port

### DIFF
--- a/systems/atlys/README
+++ b/systems/atlys/README
@@ -1,0 +1,9 @@
+OpenRISC system for Digilent Atlys development board.
+Basically lifted 'as is' from the orpsocv2 port at:
+git://git.openrisc.net/stefan/orpsoc
+
+TODO:
+ - Rewrite dvi_gen (currently a hacked up Xilinx whitepaper)
+ - Clean up the Xilinx MIG memory controller wrapper (and possibly generate the
+   MIG with coregen on fly)
+ - General cleanup and de-orpsocv2-fication

--- a/systems/atlys/atlys.core
+++ b/systems/atlys/atlys.core
@@ -1,0 +1,57 @@
+CAPI=1
+[main]
+depend =
+ adv_debug_sys
+ jtag_tap
+ simple_spi
+ gpio
+ vga_lcd
+ ethmac
+ ac97
+ ps2
+ diila
+ mor1kx
+ elf-loader
+ uart16550
+ vlog_tb_utils
+ wb_intercon
+ wb_sdram_ctrl
+
+simulators =
+ icarus
+
+[verilog]
+src_files =
+ rtl/verilog/orpsoc_top.v
+ rtl/verilog/clkgen.v
+ rtl/verilog/rom.v
+ rtl/verilog/wb_intercon.v
+ rtl/verilog/xilinx_ddr2/ddr2_mig.v
+ rtl/verilog/xilinx_ddr2/infrastructure.v
+ rtl/verilog/xilinx_ddr2/iodrp_controller.v
+ rtl/verilog/xilinx_ddr2/iodrp_mcb_controller.v
+ rtl/verilog/xilinx_ddr2/mcb_raw_wrapper.v
+ rtl/verilog/xilinx_ddr2/mcb_soft_calibration_top.v
+ rtl/verilog/xilinx_ddr2/mcb_soft_calibration.v
+ rtl/verilog/xilinx_ddr2/mcb_ui_top.v
+ rtl/verilog/xilinx_ddr2/memc_wrapper.v
+ rtl/verilog/xilinx_ddr2/xilinx_ddr2_if.v
+ rtl/verilog/xilinx_ddr2/xilinx_ddr2.v
+ rtl/verilog/dvi_gen/convert_30to15_fifo.v
+ rtl/verilog/dvi_gen/dcmspi.v
+ rtl/verilog/dvi_gen/DRAM16XN.v
+ rtl/verilog/dvi_gen/dvi_encoder.v
+ rtl/verilog/dvi_gen/dvi_gen_top.v
+ rtl/verilog/dvi_gen/encode.v
+ rtl/verilog/dvi_gen/serdes_n_to_1.v
+ rtl/verilog/dvi_gen/synchro.v
+
+tb_private_src_files =
+ bench/orpsoc_tb.v
+ bench/uart_decoder.v
+include_files =
+ rtl/verilog/include/orpsoc-defines.v
+ rtl/verilog/include/timescale.v
+ rtl/verilog/include/uart_defines.v
+ rtl/verilog/wb_intercon.vh
+ rtl/verilog/include/xilinx_ddr2_params.v

--- a/systems/atlys/atlys.system
+++ b/systems/atlys/atlys.system
@@ -1,0 +1,14 @@
+SAPI=1
+[main]
+name = atlys
+description = "OR1K system for the Digilent Atlys development board"
+
+backend = ise
+
+[ise]
+ucf_files = data/atlys.ucf
+family = spartan6
+device = xc6slx45
+package = csg324
+speed = -2
+top_module = orpsoc_top

--- a/systems/atlys/data/atlys.ucf
+++ b/systems/atlys/data/atlys.ucf
@@ -1,0 +1,390 @@
+## This file is a general .ucf for Atlys rev C board
+## To use it in a project:
+## - remove or comment the lines corresponding to unused pins
+## - rename the used signals according to the project
+#
+#
+CONFIG VCCAUX  = 3.3;
+## clock pin for Atlys rev C board
+ NET "sys_clk_pad_i"   LOC = "L15" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L42P_GCLK7_M1UDM, Type = GCLK, Sch name = GCLK
+#
+## onBoard USB controller
+# NET "EppAstb"   LOC = "B9";  # Bank = 0, Pin name = IO_L35P_GCLK17, Sch name = U1-FLAGA
+# NET "EppDstb"   LOC = "A9";  # Bank = 0, Pin name = IO_L35N_GCLK16, Sch name = U1-FLAGB
+# NET "UsbFlag"   LOC = "C15"; # Bank = 0, Pin name = IO_L64P_SCP5, 	 Sch name = U1-FLAGC
+# NET "EppWait"   LOC = "F13"; # Bank = 0, Pin name = IO_L63P_SCP7, 	 Sch name = U1-SLRD
+# NET "EppDB<0>"  LOC = "A2";  # Bank = 0, Pin name = IO_L2N, 		 Sch name = U1-FD0
+# NET "EppDB<1>"  LOC = "D6";  # Bank = 0, Pin name = IO_L3P, 		 Sch name = U1-FD1
+# NET "EppDB<2>"  LOC = "C6";  # Bank = 0, Pin name = IO_L3N, 		 Sch name = U1-FD2
+# NET "EppDB<3>"  LOC = "B3";  # Bank = 0, Pin name = IO_L4P, 		 Sch name = U1-FD3
+# NET "EppDB<4>"  LOC = "A3";  # Bank = 0, Pin name = IO_L4N, 		 Sch name = U1-FD4
+# NET "EppDB<5>"  LOC = "B4";  # Bank = 0, Pin name = IO_L5P, 		 Sch name = U1-FD5
+# NET "EppDB<6>"  LOC = "A4";  # Bank = 0, Pin name = IO_L5N, 		 Sch name = U1-FD6
+# NET "EppDB<7>"  LOC = "C5";  # Bank = 0, Pin name = IO_L6P, 		 Sch name = U1-FD7
+# 
+# NET "UsbClk" 	 LOC = "C10"; # Bank = 0, Pin name = IO_L37P_GCLK13, Sch name = U1-IFCLK 
+# NET "UsbOE" 	 LOC = "A15"; # Bank = 0, Pin name = IO_L64N_SCP4, 	 Sch name = U1-SLOE
+# NET "UsbWR" 	 LOC = "E13"; # Bank = 0, Pin name = IO_L63N_SCP6,	 Sch name = U1-SLWR
+# NET "UsbPktEnd" LOC = "C4";  # Bank = 0, Pin name = IO_L1N_VREF,	 Sch name = U1-PKTEND
+# NET "UsbDir" 	 LOC = "B2";  # Bank = 0, Pin name = IO_L2P,     	 Sch name = U1-SLCS
+# NET "UsbMode" 	 LOC = "A5";  # Bank = 0, Pin name = IO_L6N,     	 Sch name = U1-INT0#
+# 
+# NET "UsbAdr<0>" LOC = "A14"; # Bank = 0, Pin name = IO_L62N_VREF,	 Sch name = U1-FIFOAD0
+# NET "UsbAdr<1>" LOC = "B14"; # Bank = 0, Pin name = IO_L62P, 		 Sch name = U1-FIFOAD1
+# 
+## onBoard Quad-SPI Flash
+ NET "spi0_sck_o" 	LOC = "R15" | IOSTANDARD=LVCMOS33 | PULLUP; # Bank = 2, Pin name = IO_L1P_CCLK_2, 			 Sch name = SCK
+ NET "spi0_ss_o<0>" LOC = "V3"  | IOSTANDARD=LVCMOS33; # Bank = 2, Pin name = IO_L65N_CSO_B_2, 			 Sch name = CS
+ NET "spi0_mosi_o"  LOC = "T13" | IOSTANDARD=LVCMOS33; # Bank = 2, Pin name = IO_L3N_MOSI_CSI_B_MISO0_2,  Sch name = SDI
+ NET "spi0_miso_i"  LOC = "R13" | IOSTANDARD=LVCMOS33; # Bank = 2, Pin name = IO_L3P_D0_DIN_MISO_MISO1_2, Sch name = DQ1
+# NET "FlashMemDq<2>" LOC = "T14"; # Bank = 2, Pin name = IO_L12P_D1_MISO2_2, 		 Sch name = DQ2
+# NET "FlashMemDq<3>" LOC = "V14"; # Bank = 2, Pin name = IO_L12N_D2_MISO3_2, 		 Sch name = DQ3
+#
+## onBoard Leds
+NET "gpio0_io[0]" LOC = U18 | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L52N_M1DQ15, 	   Sch name = LD0
+NET "gpio0_io[1]" LOC = M14 | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L53P, 		 	   Sch name = LD1
+NET "gpio0_io[2]" LOC = N14 | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L53N_VREF, 	   Sch name = LD2
+NET "gpio0_io[3]" LOC = L14 | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L61P, 		 	   Sch name = LD3
+NET "gpio0_io[4]" LOC = M13 | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L61N, 		 	   Sch name = LD4
+NET "gpio0_io[5]" LOC = D4  | IOSTANDARD=LVCMOS33; # Bank = 0, Pin name = IO_L1P_HSWAPEN_0,	   Sch name = HSWAP/LD5
+NET "gpio0_io[6]" LOC = P16 | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L74N_DOUT_BUSY_1, Sch name = LD6
+NET "gpio0_io[7]" LOC = N12 | IOSTANDARD=LVCMOS33; # Bank = 2, Pin name = IO_L13P_M1_2,		   Sch name = M1/LD7
+
+# 
+## onBoard PUSH BUTTONS 
+ NET "rst_n_pad_i" LOC = "T15" | IOSTANDARD=LVCMOS33; # Bank = 2, Pin name = IO_L1N_M0_CMPMISO_2, Sch name = M0/RESET
+# NET "gpio0_io<16>" LOC = "N4" | IOSTANDARD=LVCMOS33;  # Bank = 3, Pin name = IO_L1P, 	   		   Sch name = BTNU
+# NET "gpio0_io<17>" LOC = "P4" | IOSTANDARD=LVCMOS33;  # Bank = 3, Pin name = IO_L2P, 	   		   Sch name = BTNL
+# NET "gpio0_io<18>" LOC = "P3" | IOSTANDARD=LVCMOS33;  # Bank = 3, Pin name = IO_L2N, 	   		   Sch name = BTND
+# NET "gpio0_io<19>" LOC = "F6" | IOSTANDARD=LVCMOS33;  # Bank = 3, Pin name = IO_L55P_M3A13, 	   Sch name = BTNR
+# NET "gpio0_io<20>" LOC = "F5" | IOSTANDARD=LVCMOS33;  # Bank = 3, Pin name = IO_L55N_M3A14, 	   Sch name = BTNC
+# 
+## onBoard SWITCHES
+# NET "gpio0_io<8>"  LOC = "A10" | IOSTANDARD=LVCMOS33; # Bank = 0, Pin name = IO_L37N_GCLK12,      	Sch name = SW0
+# NET "gpio0_io<9>"  LOC = "D14" | IOSTANDARD=LVCMOS33; # Bank = 0, Pin name = IO_L65P_SCP3,      	Sch name = SW1
+# NET "gpio0_io<10>" LOC = "C14" | IOSTANDARD=LVCMOS33; # Bank = 0, Pin name = IO_L65N_SCP2,      	Sch name = SW2
+# NET "gpio0_io<11>" LOC = "P15" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L74P_AWAKE_1,       Sch name = SW3
+# NET "gpio0_io<12>" LOC = "P12" | IOSTANDARD=LVCMOS33; # Bank = 2, Pin name = IO_L13N_D10,      		Sch name = SW4
+# NET "gpio0_io<13>" LOC = "R5"  | IOSTANDARD=LVCMOS33; # Bank = 2, Pin name = IO_L48P_D7,      		Sch name = SW5
+# NET "gpio0_io<14>" LOC = "T5"  | IOSTANDARD=LVCMOS33; # Bank = 2, Pin name = IO_L48N_RDWR_B_VREF_2, Sch name = SW6
+# NET "gpio0_io<15>" LOC = "E4"  | IOSTANDARD=LVCMOS33; # Bank = 3, Pin name = IO_L54P_M3RESET,       Sch name = SW7
+#
+## TEMAC Ethernet MAC
+ NET "eth0_rst_n_o"    LOC = "G13" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L32N_A16_M1A9,       	 Sch name = E-RESET
+ NET "eth0_tx_clk"     LOC = "K16" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L41N_GCLK8_M1CASN,       Sch name = E-TXCLK
+ 
+ NET "eth0_tx_data<0>" LOC = "H16" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L37N_A6_M1A1,       	 Sch name = E-TXD0
+ NET "eth0_tx_data<1>" LOC = "H13" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L36P_A9_M1BA0,       	 Sch name = E-TXD1
+ NET "eth0_tx_data<2>" LOC = "K14" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L39N_M1ODT,       		 Sch name = E-TXD2
+ NET "eth0_tx_data<3>" LOC = "K13" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L34N_A12_M1BA2,       	 Sch name = E-TXD3
+# NET "phyTXD<4>" LOC = "J13" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L39P_M1A3,       		 Sch name = E-TXD4
+# NET "phyTXD<5>" LOC = "G14" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L30N_A20_M1A11,       	 Sch name = E-TXD5
+# NET "phyTXD<6>" LOC = "H12" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L32P_A17_M1A8,       	 Sch name = E-TXD6
+# NET "phyTXD<7>" LOC = "K12" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L34P_A13_M1WE,       	 Sch name = E-TXD7
+# 
+ NET "eth0_tx_en"   LOC = "H15" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L37P_A7_M1A0,       	 Sch name = E-TXEN
+ NET "eth0_tx_er"   LOC = "G18" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L38N_A4_M1CLKN,       	 Sch name = E-TXER
+# NET "phygtxclk" LOC = "L12" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L40P_GCLK11_M1A5,        Sch name = E-GTXCLK
+ 
+ NET "eth0_rx_data<0>" LOC = "G16" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L38P_A5_M1CLK,       	 Sch name = E-RXD0
+ NET "eth0_rx_data<1>" LOC = "H14" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L36N_A8_M1BA1,       	 Sch name = E-RXD1
+ NET "eth0_rx_data<2>" LOC = "E16" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L33P_A15_M1A10,       	 Sch name = E-RXD2
+ NET "eth0_rx_data<3>" LOC = "F15" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L1P_A25,       			 Sch name = E-RXD3
+# NET "phyRXD<4>" LOC = "F14" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L30P_A21_M1RESET,        Sch name = E-RXD4
+# NET "phyRXD<5>" LOC = "E18" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L33N_A14_M1A4,       	 Sch name = E-RXD5
+# NET "phyRXD<6>" LOC = "D18" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L31N_A18_M1A12,       	 Sch name = E-RXD6
+# NET "phyRXD<7>" LOC = "D17" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L31P_A19_M1CKE,       	 Sch name = E-RXD7
+ 
+ NET "eth0_dv"        LOC = "F17" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L35P_A11_M1A7,       	 Sch name = E-RXDV
+ NET "eth0_rx_er"     LOC = "F18" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L35N_A10_M1A2,           Sch name = E-RXER
+ NET "eth0_rx_clk"    LOC = "K15" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L41P_GCLK9_IRDY1_M1RASN, Sch name = E-RXCLK
+ NET "eth0_mdc_pad_o" LOC = "F16" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L1N_A24_VREF,       	 Sch name = E-MDC
+ NET "eth0_md_pad_io" LOC = "N17" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L48P_HDC_M1DQ8,       	 Sch name = E-MDIO
+ NET "eth0_col"       LOC = "C17" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L29P_A23_M1A13, Sch name = E-COL
+ NET "eth0_crs"       LOC = "C18" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L29N_A22_M1A14, Sch name = E-CRS
+
+# NET "phyint"    LOC = "L16" | IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L42N_GCLK6_TRDY1_M1LDM,  Sch name = E-INT
+#
+## DDR2
+############################################################################
+## I/O TERMINATION                                                          
+############################################################################
+NET "ddr2_dq[*]"                                 IN_TERM = NONE;
+NET "ddr2_dqs"                                   IN_TERM = NONE;
+NET "ddr2_dqs_n"                                 IN_TERM = NONE;
+NET "ddr2_udqs"                                  IN_TERM = NONE;
+NET "ddr2_udqs_n"                                IN_TERM = NONE;
+
+############################################################################
+# I/O STANDARDS 
+############################################################################
+NET  "ddr2_dq[*]"                               IOSTANDARD = SSTL18_II;
+NET  "ddr2_a[*]"                                IOSTANDARD = SSTL18_II;
+NET  "ddr2_ba[*]"                               IOSTANDARD = SSTL18_II;
+NET  "ddr2_dqs"                                 IOSTANDARD = DIFF_SSTL18_II;
+NET  "ddr2_udqs"                                IOSTANDARD = DIFF_SSTL18_II;
+NET  "ddr2_dqs_n"                               IOSTANDARD = DIFF_SSTL18_II;
+NET  "ddr2_udqs_n"                              IOSTANDARD = DIFF_SSTL18_II;
+NET  "ddr2_ck"                                  IOSTANDARD = DIFF_SSTL18_II;
+NET  "ddr2_ck_n"                                IOSTANDARD = DIFF_SSTL18_II;
+NET  "ddr2_cke"                                 IOSTANDARD = SSTL18_II;
+NET  "ddr2_ras_n"                               IOSTANDARD = SSTL18_II;
+NET  "ddr2_cas_n"                               IOSTANDARD = SSTL18_II;
+NET  "ddr2_we_n"                                IOSTANDARD = SSTL18_II;
+NET  "ddr2_odt"                                 IOSTANDARD = SSTL18_II;
+NET  "ddr2_dm"                                  IOSTANDARD = SSTL18_II;
+NET  "ddr2_udm"                                 IOSTANDARD = SSTL18_II;
+NET  "ddr2_rzq"                                      IOSTANDARD = SSTL18_II;
+NET  "ddr2_zio"                                      IOSTANDARD = SSTL18_II;
+#NET  "c3_sys_clk"                                  IOSTANDARD = LVCMOS25;
+#NET  "c3_sys_rst_n"                                IOSTANDARD = LVCMOS18;
+ NET "ddr2_ck"       LOC = "G3"; # Bank = 3, Pin name = IO_L46P_M3CLK,     		  Sch name = DDR-CK_P
+ NET "ddr2_ck_n"     LOC = "G1"; # Bank = 3, Pin name = IO_L46N_M3CLKN,    		  Sch name = DDR-CK_N
+ NET "ddr2_cke"      LOC = "H7"; # Bank = 3, Pin name = IO_L53P_M3CKE,       		  Sch name = DDR-CKE
+ NET "ddr2_ras_n"    LOC = "L5"; # Bank = 3, Pin name = IO_L43P_GCLK23_M3RASN,		  Sch name = DDR-RAS
+ NET "ddr2_cas_n"    LOC = "K5"; # Bank = 3, Pin name = IO_L43N_GCLK22_IRDY2_M3CASN, Sch name = DDR-CAS
+ NET "ddr2_we_n"     LOC = "E3"; # Bank = 3, Pin name = IO_L50P_M3WE,   			  Sch name = DDR-WE
+ NET "ddr2_rzq"      LOC = "L6"; # Bank = 3, Pin name = IO_L31P,   				  Sch name = RZQ
+ NET "ddr2_zio"      LOC = "C2"; # Bank = 3, Pin name = IO_L83P,   				  Sch name = ZIO
+ NET "ddr2_ba<0>"    LOC = "F2"; # Bank = 3, Pin name = IO_L48P_M3BA0,        		  Sch name = DDR-BA0
+ NET "ddr2_ba<1>"    LOC = "F1"; # Bank = 3, Pin name = IO_L48N_M3BA1,        		  Sch name = DDR-BA1
+ NET "ddr2_ba<2>"    LOC = "E1"; # Bank = 3, Pin name = IO_L50N_M3BA2,       		  Sch name = DDR-BA2
+ NET "ddr2_a<0>"     LOC = "J7"; # Bank = 3, Pin name = IO_L47P_M3A0,        		  Sch name = DDR-A0
+ NET "ddr2_a<1>"     LOC = "J6"; # Bank = 3, Pin name = IO_L47N_M3A1,        		  Sch name = DDR-A1
+ NET "ddr2_a<2>"     LOC = "H5"; # Bank = 3, Pin name = IO_L49N_M3A2,     			  Sch name = DDR-A2
+ NET "ddr2_a<3>"     LOC = "L7"; # Bank = 3, Pin name = IO_L45P_M3A3,     			  Sch name = DDR-A3
+ NET "ddr2_a<4>"     LOC = "F3"; # Bank = 3, Pin name = IO_L51N_M3A4,     			  Sch name = DDR-A4
+ NET "ddr2_a<5>"     LOC = "H4"; # Bank = 3, Pin name = IO_L44P_GCLK21_M3A5,     	  Sch name = DDR-A5
+ NET "ddr2_a<6>"     LOC = "H3"; # Bank = 3, Pin name = IO_L44N_GCLK20_M3A6,    	  Sch name = DDR-A6
+ NET "ddr2_a<7>"     LOC = "H6"; # Bank = 3, Pin name = IO_L49P_M3A7,    			  Sch name = DDR-A7
+ NET "ddr2_a<8>"     LOC = "D2"; # Bank = 3, Pin name = IO_L52P_M3A8,    			  Sch name = DDR-A8
+ NET "ddr2_a<9>"     LOC = "D1"; # Bank = 3, Pin name = IO_L52N_M3A9,   			  Sch name = DDR-A9
+ NET "ddr2_a<10>"    LOC = "F4"; # Bank = 3, Pin name = IO_L51P_M3A10,        		  Sch name = DDR-A10
+ NET "ddr2_a<11>"    LOC = "D3"; # Bank = 3, Pin name = IO_L54N_M3A11,   			  Sch name = DDR-A11
+ NET "ddr2_a<12>"    LOC = "G6"; # Bank = 3, Pin name = IO_L53N_M3A12,       		  Sch name = DDR-A12
+ NET "ddr2_dq<0>"    LOC = "L2"; # Bank = 3, Pin name = IO_L37P_M3DQ0,       		  Sch name = DDR-DQ0
+ NET "ddr2_dq<1>"    LOC = "L1"; # Bank = 3, Pin name = IO_L37N_M3DQ1,       		  Sch name = DDR-DQ1
+ NET "ddr2_dq<2>"    LOC = "K2"; # Bank = 3, Pin name = IO_L38P_M3DQ2,       		  Sch name = DDR-DQ2
+ NET "ddr2_dq<3>"    LOC = "K1"; # Bank = 3, Pin name = IO_L38N_M3DQ3,       		  Sch name = DDR-DQ3
+ NET "ddr2_dq<4>"    LOC = "H2"; # Bank = 3, Pin name = IO_L41P_GCLK27_M3DQ4,        Sch name = DDR-DQ4
+ NET "ddr2_dq<5>"    LOC = "H1"; # Bank = 3, Pin name = IO_L41N_GCLK26_M3DQ5,        Sch name = DDR-DQ5
+ NET "ddr2_dq<6>"    LOC = "J3"; # Bank = 3, Pin name = IO_L40P_M3DQ6,       		  Sch name = DDR-DQ6
+ NET "ddr2_dq<7>"    LOC = "J1"; # Bank = 3, Pin name = IO_L40N_M3DQ7,       		  Sch name = DDR-DQ7
+ NET "ddr2_dq<8>"    LOC = "M3"; # Bank = 3, Pin name = IO_L36P_M3DQ8,    			  Sch name = DDR-DQ8
+ NET "ddr2_dq<9>"    LOC = "M1"; # Bank = 3, Pin name = IO_L36N_M3DQ9,        		  Sch name = DDR-DQ9
+ NET "ddr2_dq<10>"   LOC = "N2"; # Bank = 3, Pin name = IO_L35P_M3DQ10,        	  Sch name = DDR-DQ10
+ NET "ddr2_dq<11>"   LOC = "N1"; # Bank = 3, Pin name = IO_L35N_M3DQ11,        	  Sch name = DDR-DQ11
+ NET "ddr2_dq<12>"   LOC = "T2"; # Bank = 3, Pin name = IO_L33P_M3DQ12,       		  Sch name = DDR-DQ12
+ NET "ddr2_dq<13>"   LOC = "T1"; # Bank = 3, Pin name = IO_L33N_M3DQ13,    		  Sch name = DDR-DQ13
+ NET "ddr2_dq<14>"   LOC = "U2"; # Bank = 3, Pin name = IO_L32P_M3DQ14,        	  Sch name = DDR-DQ14
+ NET "ddr2_dq<15>"   LOC = "U1"; # Bank = 3, Pin name = IO_L32N_M3DQ15,        	  Sch name = DDR-DQ15
+ NET "ddr2_udqs"     LOC="P2"; # Bank = 3, Pin name = IO_L34P_M3UDQS,       		  Sch name = DDR-UDQS_P
+ NET "ddr2_udqs_n"   LOC="P1"; # Bank = 3, Pin name = IO_L34N_M3UDQSN,        		  Sch name = DDR-UDQS_N
+ NET "ddr2_dqs"      LOC="L4"; # Bank = 3, Pin name = IO_L39P_M3LDQS,        		  Sch name = DDR-LDQS_P
+ NET "ddr2_dqs_n"    LOC="L3"; # Bank = 3, Pin name = IO_L39N_M3LDQSN,        		  Sch name = DDR-LDQS_N
+ NET "ddr2_dm"       LOC="K3"; # Bank = 3, Pin name = IO_L42N_GCLK24_M3LDM,          Sch name = DDR-LDM
+ NET "ddr2_udm"      LOC="K4"; # Bank = 3, Pin name = IO_L42P_GCLK25_TRDY2_M3UDM,	  Sch name = DDR-UDM
+ NET "ddr2_odt"      LOC="K6"; # Bank = 3, Pin name = IO_L45N_M3ODT,        		  Sch name = DDR-ODT
+
+# onboard HDMI OUT
+# Bank = 0, Pin name = IO_L8P,		  Sch name = TMDS-TX-CLK_P
+NET "tmds_o[3]" IOSTANDARD = TMDS_33;
+NET "tmds_o[3]" LOC = B6;
+ # Bank = 0, Pin name = IO_L8N_VREF,	  Sch name = TMDS-TX-CLK_N
+NET "tmdsb_o[3]" IOSTANDARD = TMDS_33;
+NET "tmdsb_o[3]" LOC = A6; 
+# Bank = 0, Pin name = IO_L11P,		  Sch name = TMDS-TX-0_P
+NET "tmds_o[0]" IOSTANDARD = TMDS_33;
+NET "tmds_o[0]" LOC = D8;
+# Bank = 0, Pin name = IO_L11N,		  Sch name = TMDS-TX-0_N
+NET "tmdsb_o[0]" IOSTANDARD = TMDS_33;
+NET "tmdsb_o[0]" LOC = C8;
+# Bank = 0, Pin name = IO_L10P,		  Sch name = TMDS-TX-1_P
+NET "tmds_o[1]" IOSTANDARD = TMDS_33;
+NET "tmds_o[1]" LOC = C7;
+# Bank = 0, Pin name = IO_L10N,		  Sch name = TMDS-TX-1_N
+NET "tmdsb_o[1]" IOSTANDARD = TMDS_33;
+NET "tmdsb_o[1]" LOC = A7;
+# Bank = 0, Pin name = IO_L33P,		  Sch name = TMDS-TX-2_P
+NET "tmds_o[2]" IOSTANDARD = TMDS_33;
+NET "tmds_o[2]" LOC = B8;
+# Bank = 0, Pin name = IO_L33N,		  Sch name = TMDS-TX-2_N
+NET "tmdsb_o[2]" IOSTANDARD = TMDS_33;
+NET "tmdsb_o[2]" LOC = A8;
+# NET "HDMIOUTSCL"  LOC = "D9"; # Bank = 0, Pin name = IO_L34P_GCLK19, Sch name = TMDS-TX-SCL
+# NET "HDMIOUTSDA"  LOC = "C9"; # Bank = 0, Pin name = IO_L34N_GCLK18, Sch name = TMDS-TX-SDA
+#
+## onboard HDMI IN1 (PMODA)
+# NET "HDMIIN1CLKP" LOC = "D11"; # Bank = 0, Pin name = IO_L36P_GCLK15, Sch name = TMDS-RXB-CLK_P
+# NET "HDMIIN1CLKN" LOC = "C11"; # Bank = 0, Pin name = IO_L36N_GCLK14, Sch name = TMDS-RXB-CLK_N
+# NET "HDMIIN1D0P"  LOC = "G9";  # Bank = 0, Pin name = IO_L38P,		   Sch name = TMDS-RXB-0_P
+# NET "HDMIIN1D0N"  LOC = "F9";  # Bank = 0, Pin name = IO_L38N_VREF,   Sch name = TMDS-RXB-0_N
+# NET "HDMIIN1D1P"  LOC = "B11"; # Bank = 0, Pin name = IO_L39P,        Sch name = TMDS-RXB-1_P
+# NET "HDMIIN1D1N"  LOC = "A11"; # Bank = 0, Pin name = O_L39N,         Sch name = TMDS-RXB-1_N
+# NET "HDMIIN1D2P"  LOC = "B12"; # Bank = 0, Pin name = IO_L41P,        Sch name = TMDS-RXB-2_P
+# NET "HDMIIN1D2N"  LOC = "A12"; # Bank = 0, Pin name = IO_L41N,        Sch name = TMDS-RXB-2_N
+# NET "HDMIIN1SCL"  LOC = "C13"; # Bank = 0, Pin name = IO_L50P,        Sch name = PMOD-SCL
+# NET "HDMIIN1SDA"  LOC = "A13"; # Bank = 0, Pin name = IO_L50N,        Sch name = PMOD-SDA
+#
+## onboard HDMI IN2
+# NET "HDMIIN2CLKP" LOC = "H17"; # Bank = 1, Pin name = IO_L43P_GCLK5_M1DQ4, Sch name = TMDS-RX-CLK_P
+# NET "HDMIIN2CLKN" LOC = "H18"; # Bank = 1, Pin name = IO_L43N_GCLK4_M1DQ5, Sch name = TMDS-RX-CLK_N
+# NET "HDMIIN2D0P"  LOC = "K17"; # Bank = 1, Pin name = IO_L45P_A1_M1LDQS,   Sch name = TMDS-RX-0_P
+# NET "HDMIIN2D0N"  LOC = "K18"; # Bank = 1, Pin name = IO_L45N_A0_M1LDQSN,  Sch name = TMDS-RX-0_N
+# NET "HDMIIN2D1P"  LOC = "L17"; # Bank = 1, Pin name = IO_L46P_FCS_B_M1DQ2, Sch name = TMDS-RX-1_P
+# NET "HDMIIN2D1N"  LOC = "L18"; # Bank = 1, Pin name = IO_L46N_FOE_B_M1DQ3, Sch name = TMDS-RX-1_N
+# NET "HDMIIN2D2P"  LOC = "J16"; # Bank = 1, Pin name = IO_L44P_A3_M1DQ6,    Sch name = TMDS-RX-2_P
+# NET "HDMIIN2D2N"  LOC = "J18"; # Bank = 1, Pin name = IO_L44N_A2_M1DQ7,    Sch name = TMDS-RX-2_N
+# NET "HDMIIN2SCL"  LOC = "M16"; # Bank = 1, Pin name = IO_L47P_FWE_B_M1DQ0, Sch name = TMDS-RX-SCL
+# NET "HDMIIN2SDA"  LOC = "M18"; # Bank = 1, Pin name = IO_L47N_LDC_M1DQ1,   Sch name = TMDS-RX-SDA
+
+# PS/2
+# keyboard
+ NET "ps2_0_clk" LOC = P17  |  SLEW = SLOW  |  DRIVE = 2  |  IOSTANDARD = LVCMOS33 | PULLUP;
+ NET "ps2_0_dat" LOC = N15  |  SLEW = SLOW  |  DRIVE = 2  |  IOSTANDARD = LVCMOS33 | PULLUP;
+# mouse
+ NET "ps2_1_clk" LOC = P18  |  SLEW = SLOW  |  DRIVE = 2  |  IOSTANDARD = LVCMOS33 | PULLUP;
+ NET "ps2_1_dat" LOC = N18  |  SLEW = SLOW  |  DRIVE = 2  |  IOSTANDARD = LVCMOS33 | PULLUP;
+
+# Audio
+ NET "ac97_bit_clk_pad_i" LOC = "L13" |  IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L40N_GCLK10_M1A6, Sch name = AUD-BIT-CLK
+ NET "ac97_sdata_pad_i"   LOC = "T18" |  IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L51N_M1DQ13,      Sch name = AUD-SDI
+ NET "ac97_sdata_pad_o"   LOC = "N16" |  IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L50N_M1UDQSN,     Sch name = AUD-SDO
+ NET "ac97_sync_pad_o"    LOC = "U17" |  IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L52P_M1DQ14,      Sch name = AUD-SYNC
+ NET "ac97_reset_pad_o"   LOC = "T17" |  IOSTANDARD=LVCMOS33; # Bank = 1, Pin name = IO_L51P_M1DQ12,      Sch name = AUD-RESET
+# 
+## PMOD Connector
+NET "tdo_pad_o"  LOC = "T3" |  IOSTANDARD=LVCMOS33; # Bank = 2,  Pin name = IO_L62N_D6,     Sch name = JA-D0_N
+NET "tms_pad_i"  LOC = "R3" |  IOSTANDARD=LVCMOS33; # Bank = 2,  Pin name = IO_L62P_D5,     Sch name = JA-D0_P
+NET "tdi_pad_i"  LOC = "P6" |  IOSTANDARD=LVCMOS33; # Bank = 2,  Pin name = IO_L64N_D9,     Sch name = JA-D2_N
+NET "ps2_2_clk"  LOC = "N5" |  SLEW = SLOW  |  DRIVE = 2  |  IOSTANDARD = LVCMOS33 | PULLUP; # Bank = 2,  Pin name = IO_L64P_D8,     Sch name = JA-D2_P
+NET "ps2_2_dat"  LOC = "V9" |  SLEW = SLOW  |  DRIVE = 2  |  IOSTANDARD = LVCMOS33 | PULLUP; # Bank = 2,  Pin name = IO_L32N_GCLK28, Sch name = JA-CLK_N
+NET "tck_pad_i"  LOC = "T9" |  IOSTANDARD=LVCMOS33; # Bank = 2,  Pin name = IO_L32P_GCLK29, Sch name = JA-CLK_P
+# NET "JB<6>"  LOC = "V4"; # Bank = 2,  Pin name = IO_L63N,        Sch name = JA-D1_N
+# NET "JB<7>"  LOC = "T4"; # Bank = 2,  Pin name = IO_L63P,        Sch name = JA-D1_P
+#
+## onboard VHDCI
+## Channnel 1 connects to P signals, Channel 2 to N signals
+# NET "VHDCIIO1<0>"  LOC = "U16"; # Bank = 2,  Pin name = IO_L2P_CMPCLK,        	Sch name = EXP-IO1_P
+# NET "VHDCIIO1<1>"  LOC = "U15"; # Bank = 2,  Pin name = *IO_L5P,        		Sch name = EXP-IO2_P
+# NET "VHDCIIO1<2>"  LOC = "U13"; # Bank = 2,  Pin name = IO_L14P_D11,        	Sch name = EXP-IO3_P
+# NET "VHDCIIO1<3>"  LOC = "M11"; # Bank = 2,  Pin name = *IO_L15P,        		Sch name = EXP-IO4_P
+# NET "VHDCIIO1<4>"  LOC = "R11"; # Bank = 2,  Pin name = IO_L16P,        		Sch name = EXP-IO5_P
+# NET "VHDCIIO1<5>"  LOC = "T12"; # Bank = 2,  Pin name = *IO_L19P,        		Sch name = EXP-IO6_P
+# NET "VHDCIIO1<6>"  LOC = "N10"; # Bank = 2,  Pin name = *IO_L20P,        		Sch name = EXP-IO7_P
+# NET "VHDCIIO1<7>"  LOC = "M10"; # Bank = 2,  Pin name = *IO_L22P,        		Sch name = EXP-IO8_P
+# NET "VHDCIIO1<8>"  LOC = "U11"; # Bank = 2,  Pin name = IO_L23P,        		Sch name = EXP-IO9_P
+# NET "VHDCIIO1<9>"  LOC = "R10"; # Bank = 2,  Pin name = IO_L29P_GCLK3,        	Sch name = EXP-IO10_P
+# NET "VHDCIIO1<10>" LOC = "U10"; # Bank = 2,  Pin name = IO_L30P_GCLK1_D13,      Sch name = EXP-IO11_P
+# NET "VHDCIIO1<11>" LOC = "R8";  # Bank = 2,  Pin name = IO_L31P_GCLK31_D14,     Sch name = EXP-IO12_P
+# NET "VHDCIIO1<12>" LOC = "M8";  # Bank = 2,  Pin name = *IO_L40P,        		Sch name = EXP-IO13_P
+# NET "VHDCIIO1<13>" LOC = "U8";  # Bank = 2,  Pin name = IO_L41P,        		Sch name = EXP-IO14_P
+# NET "VHDCIIO1<14>" LOC = "U7";  # Bank = 2,  Pin name = IO_L43P,        		Sch name = EXP-IO15_P
+# NET "VHDCIIO1<15>" LOC = "N7";  # Bank = 2,  Pin name = *IO_L44P,        		Sch name = EXP-IO16_P
+# NET "VHDCIIO1<16>" LOC = "T6";  # Bank = 2,  Pin name = IO_L45P,        		Sch name = EXP-IO17_P
+# NET "VHDCIIO1<17>" LOC = "R7";  # Bank = 2,  Pin name = IO_L46P,        		Sch name = EXP-IO18_P
+# NET "VHDCIIO1<18>" LOC = "N6";  # Bank = 2,  Pin name = *IO_L47P,        		Sch name = EXP-IO19_P
+# NET "VHDCIIO1<19>" LOC = "U5";  # Bank = 2,  Pin name = IO_49P_D3,        		Sch name = EXP-IO20_P
+#
+# NET "VHDCIIO2<0>"  LOC = "V16"; # Bank = 2,  Pin name = IO_L2N_CMPMOSI,        	Sch name = EXP-IO1_N
+# NET "VHDCIIO2<1>"  LOC = "V15"; # Bank = 2,  Pin name = *IO_L5N,        		Sch name = EXP-IO2_N
+# NET "VHDCIIO2<2>"  LOC = "V13"; # Bank = 2,  Pin name = IO_L14N_D12,        	Sch name = EXP-IO3_N
+# NET "VHDCIIO2<3>"  LOC = "N11"; # Bank = 2,  Pin name = *IO_L15N,        		Sch name = EXP-IO4_N
+# NET "VHDCIIO2<4>"  LOC = "T11"; # Bank = 2,  Pin name = IO_L16N_VREF,        	Sch name = EXP-IO5_N
+# NET "VHDCIIO2<5>"  LOC = "V12"; # Bank = 2,  Pin name = *IO_L19N,        		Sch name = EXP-IO6_N
+# NET "VHDCIIO2<6>"  LOC = "P11"; # Bank = 2,  Pin name = *IO_L20N,        		Sch name = EXP-IO7_N
+# NET "VHDCIIO2<7>"  LOC = "N9";  # Bank = 2,  Pin name = *IO_L22N,        		Sch name = EXP-IO8_N
+# NET "VHDCIIO2<8>"  LOC = "V11"; # Bank = 2,  Pin name = IO_L23N,        		Sch name = EXP-IO9_N
+# NET "VHDCIIO2<9>"  LOC = "T10"; # Bank = 2,  Pin name = IO_L29N_GCLK2,          Sch name = EXP-IO10_N
+# NET "VHDCIIO2<10>" LOC = "V10"; # Bank = 2,  Pin name = IO_L30N_GCLK0_USERCCLK, Sch name = EXP-IO11_N
+# NET "VHDCIIO2<11>" LOC = "T8";  # Bank = 2,  Pin name = IO_L31N_GCLK30_D15,     Sch name = EXP-IO12_N
+# NET "VHDCIIO2<12>" LOC = "N8";  # Bank = 2,  Pin name = *IO_L40N,        		Sch name = EXP-IO13_N
+# NET "VHDCIIO2<13>" LOC = "V8";  # Bank = 2,  Pin name = IO_L41N_VREF,        	Sch name = EXP-IO14_N
+# NET "VHDCIIO2<14>" LOC = "V7";  # Bank = 2,  Pin name = IO_L43N,        		Sch name = EXP-IO15_N
+# NET "VHDCIIO2<15>" LOC = "P8";  # Bank = 2,  Pin name = *IO_L44N,        		Sch name = EXP-IO16_N
+# NET "VHDCIIO2<16>" LOC = "V6";  # Bank = 2,  Pin name = IO_L45N,        		Sch name = EXP-IO17_N
+# NET "VHDCIIO2<17>" LOC = "T7";  # Bank = 2,  Pin name = IO_L46N,        		Sch name = EXP-IO18_N
+# NET "VHDCIIO2<18>" LOC = "P7";  # Bank = 2,  Pin name = *IO_L47N,        		Sch name = EXP-IO19_N
+# NET "VHDCIIO2<19>" LOC = "V5";  # Bank = 2,  Pin name = IO_49N_D4,        		Sch name = EXP-IO20_N 
+# 
+## USB UART Connector
+# Bank = 0, Pin name = IO_L66N_SCP0, Sch name = USBB-RXD
+NET "uart0_srx_pad_i" LOC = A16 | IOSTANDARD = LVCMOS33;
+# Bank = 0, Pin name = IO_L66P_SCP1, Sch name = USBB-TXD
+NET "uart0_stx_pad_o" LOC = B16 | IOSTANDARD = LVCMOS33;
+#
+#
+# Constraints
+
+NET "sys_clk_pad_i" TNM_NET = "sys_clk_pad_i";
+TIMESPEC TS_sys_clk_pad_i = PERIOD "sys_clk_pad_i" 100 MHz HIGH 50 %;
+
+NET "wb_clk" TNM_NET = "wb_clk";
+TIMESPEC TS_wb_clk = PERIOD "wb_clk" 50 MHz high 50%;
+
+NET rst_n_pad_i TIG;
+
+NET "gpio0_io<*>" TIG;
+
+# ethernet constraints
+NET eth0_rst_n_o      TIG;
+
+NET "eth0_tx_clk" TNM_NET = "eth0_tx_clk";
+TIMESPEC TS_eth0_tx_clk = PERIOD "eth0_tx_clk" 25 MHz high 50% PRIORITY 0;
+
+NET "eth0_rx_clk" TNM_NET = "eth0_rx_clk";
+TIMESPEC TS_eth0_rx_clk = PERIOD "eth0_rx_clk" 25 MHz high 50% PRIORITY 0;
+
+TIMESPEC TS_eth0_rx_to_wb_clk = FROM "eth0_rx_clk" TO "wb_clk" TIG;
+TIMESPEC TS_eth0_tx_to_wb_clk = FROM "eth0_tx_clk" TO "wb_clk" TIG;
+TIMESPEC TS_wb_to_eth0_rx_clk = FROM "wb_clk" TO "eth0_rx_clk" TIG;
+TIMESPEC TS_wb_to_eth0_tx_clk = FROM "wb_clk" TO "eth0_tx_clk" TIG;
+TIMESPEC TS_eth0_tx_to_eth0_rx_clk = FROM "eth0_tx_clk" TO "eth0_rx_clk" TIG;
+TIMESPEC TS_eth0_rx_to_eth0_tx_clk = FROM "eth0_rx_clk" TO "eth0_tx_clk" TIG;
+
+# JTAG constraints
+NET "tck_pad_i" TNM_NET = "tck_pad_i";
+TIMESPEC TS_tck_pad_i = PERIOD "tck_pad_i" 10 MHz high 50% PRIORITY 0;
+
+TIMESPEC TS_tck_to_wb_clk = FROM "tck_pad_i" TO "wb_clk" TIG;
+TIMESPEC TS_wb_to_tck_clk = FROM "wb_clk" TO "tck_pad_i" TIG;
+
+# HDMI constraints
+NET "dvi_gen0/clk50m_bufg" TNM_NET = "TNM_CLK50M";
+TIMESPEC "TS_CLK50M" = PERIOD "TNM_CLK50M" 50 MHz HIGH 50 % PRIORITY 0 ;
+
+NET "pclk" TNM_NET = "TNM_PCLK";
+TIMESPEC "TS_PCLK" = PERIOD "TNM_PCLK" 25.2 MHz HIGH 50 % PRIORITY 0 ;
+
+NET "dvi_gen0/pclkx2" TNM_NET = "TNM_PCLKX2";
+TIMESPEC "TS_PCLKX2" = PERIOD "TNM_PCLKX2" TS_PCLK * 2;
+
+NET "dvi_gen0/pclkx10" TNM_NET = "TNM_PCLKX10";
+TIMESPEC "TS_PCLKX10" = PERIOD "TNM_PCLKX10" TS_PCLK * 10;
+
+TIMEGRP "bramgrp" = RAMS(dvi_gen0/enc0/pixel2x/dataint<*>);
+TIMEGRP "fddbgrp" = FFS(dvi_gen0/enc0/pixel2x/db<*>);
+TIMEGRP "bramra" = FFS(dvi_gen0/enc0/pixel2x/ra<*>);
+
+TIMESPEC "TS_ramdo" = FROM "bramgrp" TO "fddbgrp" TS_PCLK;
+TIMESPEC "TS_ramra" = FROM "bramra" TO "fddbgrp" TS_PCLK;
+
+# VGA constraints
+
+
+# AC97 constraints
+NET "ac97_bit_clk_pad_i" TNM_NET = "ac97_bit_clk_pad_i";
+TIMESPEC TS_ac97_bit_clk_pad_i = PERIOD "ac97_bit_clk_pad_i" 12.288 MHz high 50% PRIORITY 0;
+
+TIMESPEC TS_ac97_to_wb_clk = FROM "ac97_bit_clk_pad_i" TO "wb_clk" TIG;
+TIMESPEC TS_wb_to_ac97_clk = FROM "wb_clk" TO "ac97_bit_clk_pad_i" TIG;
+
+# DDR2 Constraints
+NET "xilinx_ddr2_0/xilinx_ddr2_if0/ddr2_mig/memc?_wrapper_inst/mcb_ui_top_inst/mcb_raw_wrapper_inst/selfrefresh_mcb_mode" TIG;
+NET "xilinx_ddr2_0/xilinx_ddr2_if0/ddr2_mig/c?_pll_lock" TIG;
+
+NET "xilinx_ddr2_0/xilinx_ddr2_if0/ddr2_mig/memc?_wrapper_inst/mcb_ui_top_inst/mcb_raw_wrapper_inst/gen_term_calib.mcb_soft_calibration_top_inst/mcb_soft_calibration_inst/CKE_Train" TIG; ##This path exists for DDR2 only
+NET "xilinx_ddr2_0/xilinx_ddr2_if0/ddr2_mig/memc?_wrapper_inst/mcb_ui_top_inst/mcb_raw_wrapper_inst/gen_term_calib.mcb_soft_calibration_top_inst/mcb_soft_calibration_inst/DONE_SOFTANDHARD_CAL" TIG;
+
+NET "xilinx_ddr2_0/xilinx_ddr2_if0/ddr2_mig/memc3_infrastructure_inst/sys_clk_ibufg" TNM_NET = "SYS_CLK3";
+TIMESPEC "TS_SYS_CLK3" = PERIOD "SYS_CLK3"  3.75  ns HIGH 50 %;

--- a/systems/atlys/data/wb_intercon.conf
+++ b/systems/atlys/data/wb_intercon.conf
@@ -1,0 +1,109 @@
+; or1k instruction bus master
+[master or1k_i]
+slaves =
+ ddr2_ibus
+ rom0
+
+; or1k data bus master
+[master or1k_d]
+slaves =
+ ddr2_dbus
+ uart0
+ gpio0
+ spi0
+ vga0
+ eth0
+ ps2_0
+ ps2_1
+ ps2_2
+
+; debug master
+[master dbg]
+slaves =
+ ddr2_dbus
+ uart0
+ gpio0
+ spi0
+ vga0
+ eth0
+ ps2_0
+ ps2_1
+ ps2_2
+ diila
+
+[master vga0_master]
+slaves =
+ ddr2_vga0
+
+[master eth0_master]
+slaves =
+ ddr2_eth0
+
+; DDR2 SDRAM
+; Have several ports with buffering features,
+; so we split each port into a seperate slave
+[slave ddr2_dbus]
+offset=0
+size=0x8000000 ; 128MB
+
+[slave ddr2_ibus]
+offset=0
+size=0x8000000 ; 128MB
+
+[slave ddr2_vga0]
+offset=0
+size=0x8000000 ; 128MB
+
+[slave ddr2_eth0]
+offset=0
+size=0x8000000 ; 128MB
+
+[slave uart0]
+datawidth=8
+offset=0x90000000
+size=32
+
+[slave gpio0]
+datawidth=8
+offset=0x91000000
+size=2
+
+[slave eth0]
+offset=0x92000000
+size=4096
+
+[slave ac97]
+offset=0x93000000
+size=4096
+
+[slave ps2_0]
+datawidth=8
+offset=0x94000000
+size=8
+
+[slave ps2_1]
+datawidth=8
+offset=0x95000000
+size=8
+
+[slave ps2_2]
+datawidth=8
+offset=0x9a000000
+size=8
+
+[slave vga0]
+offset=0x97000000
+size=4096
+
+[slave spi0]
+datawidth=8
+offset=0xb0000000
+size=8
+
+[slave diila]
+offset=0x96000000
+size=0x500000 ; 5MB
+
+[slave rom0]
+offset=0xf0000100
+size=64

--- a/systems/atlys/rtl/verilog/clkgen.v
+++ b/systems/atlys/rtl/verilog/clkgen.v
@@ -1,0 +1,204 @@
+/*
+ *
+ * Clock, reset generation unit for Atlys board
+ *
+ * Implements clock generation according to design defines
+ *
+ */
+`include "orpsoc-defines.v"
+
+module clkgen
+       (
+	// Main clocks in, depending on board
+	input  sys_clk_pad_i,
+	// Asynchronous, active low reset in
+	input  rst_n_pad_i,
+	// Input reset - through a buffer, asynchronous
+	output async_rst_o,
+
+	// Wishbone clock and reset out
+	output wb_clk_o,
+	output wb_rst_o,
+
+	// JTAG clock
+	input  tck_pad_i,
+	output dbg_tck_o,
+
+	// VGA CLK
+	output dvi_clk_o,
+
+	// Main memory clocks
+	output ddr2_if_clk_o,
+	output ddr2_if_rst_o,
+	output clk100_o
+);
+
+// First, deal with the asychronous reset
+wire	async_rst_n;
+
+assign async_rst_n = rst_n_pad_i;
+
+// Everyone likes active-high reset signals...
+assign async_rst_o = ~async_rst_n;
+
+assign dbg_tck_o = tck_pad_i;
+
+//
+// Declare synchronous reset wires here
+//
+
+// An active-low synchronous reset signal (usually a PLL lock signal)
+wire	sync_wb_rst_n;
+wire	sync_ddr2_rst_n;
+
+// An active-low synchronous reset from ethernet PLL
+wire	sync_eth_rst_n;
+
+
+wire	sys_clk_pad_ibufg;
+/* DCM0 wires */
+wire	dcm0_clk0_prebufg, dcm0_clk0;
+wire	dcm0_clk90_prebufg, dcm0_clk90;
+wire	dcm0_clkfx_prebufg, dcm0_clkfx;
+wire	dcm0_clkdv_prebufg, dcm0_clkdv;
+wire	dcm0_clk2x_prebufg, dcm0_clk2x;
+wire	dcm0_locked;
+
+wire	pll0_clkfb;
+wire	pll0_locked;
+wire	pll0_clk1_prebufg, pll0_clk1;
+
+IBUFG sys_clk_in_ibufg (
+	.I	(sys_clk_pad_i),
+	.O	(sys_clk_pad_ibufg)
+);
+
+
+// DCM providing main system/Wishbone clock
+DCM_SP dcm0 (
+	// Outputs
+	.CLK0		(dcm0_clk0_prebufg),
+	.CLK180		(),
+	.CLK270		(),
+	.CLK2X180	(),
+	.CLK2X		(dcm0_clk2x_prebufg),
+	.CLK90		(dcm0_clk90_prebufg),
+	.CLKDV		(dcm0_clkdv_prebufg),
+	.CLKFX180	(dcm0_clkfx_prebufg),
+	.CLKFX		(),
+	.LOCKED		(dcm0_locked),
+	// Inputs
+	.CLKFB		(dcm0_clk0),
+	.CLKIN		(sys_clk_pad_ibufg),
+	.PSEN		(1'b0),
+	.RST		(async_rst_o)
+);
+
+// Daisy chain DCM-PLL to reduce jitter
+PLL_BASE #(
+	.BANDWIDTH("OPTIMIZED"),
+	// .CLKFBOUT_MULT(8), // 80 MHz
+	.CLKFBOUT_MULT(5), // 50 MHz
+	.CLKFBOUT_PHASE(0.0),
+	.CLKIN_PERIOD(10),
+	.CLKOUT1_DIVIDE(10),
+	.CLKOUT2_DIVIDE(1),
+	.CLKOUT3_DIVIDE(1),
+	.CLKOUT4_DIVIDE(1),
+	.CLKOUT5_DIVIDE(1),
+	.CLKOUT1_DUTY_CYCLE(0.5),
+	.CLKOUT2_DUTY_CYCLE(0.5),
+	.CLKOUT3_DUTY_CYCLE(0.5),
+	.CLKOUT4_DUTY_CYCLE(0.5),
+	.CLKOUT5_DUTY_CYCLE(0.5),
+	.CLKOUT1_PHASE(0.0),
+	.CLKOUT2_PHASE(0.0),
+	.CLKOUT3_PHASE(0.0),
+	.CLKOUT4_PHASE(0.0),
+	.CLKOUT5_PHASE(0.0),
+	.CLK_FEEDBACK("CLKFBOUT"),
+	.COMPENSATION("DCM2PLL"),
+	.DIVCLK_DIVIDE(1),
+	.REF_JITTER(0.1),
+	.RESET_ON_LOSS_OF_LOCK("FALSE")
+) pll0 (
+	.CLKFBOUT	(pll0_clkfb),
+	.CLKOUT1	(pll0_clk1_prebufg),
+	.CLKOUT2	(),
+	.CLKOUT3	(CLKOUT3),
+	.CLKOUT4	(CLKOUT4),
+	.CLKOUT5	(CLKOUT5),
+	.LOCKED		(pll0_locked),
+	.CLKFBIN	(pll0_clkfb),
+	.CLKIN		(dcm0_clk90_prebufg),
+	.RST		(async_rst_o)
+);
+
+// Generate 266 MHz from CLKFX
+defparam    dcm0.CLKFX_MULTIPLY    = 8;
+defparam    dcm0.CLKFX_DIVIDE      = 3;
+
+// Generate 50 MHz from CLKDV
+defparam    dcm0.CLKDV_DIVIDE      = 2.0;
+
+BUFG dcm0_clk0_bufg
+       (// Outputs
+	.O	(dcm0_clk0),
+	// Inputs
+	.I	(dcm0_clk0_prebufg)
+);
+
+BUFG dcm0_clk2x_bufg
+       (// Outputs
+	.O	(dcm0_clk2x),
+	// Inputs
+	.I	(dcm0_clk2x_prebufg)
+);
+
+BUFG dcm0_clkfx_bufg
+       (// Outputs
+	.O	(dcm0_clkfx),
+	// Inputs
+	.I	(dcm0_clkfx_prebufg)
+);
+
+BUFG dcm0_clkdv_bufg
+       (// Outputs
+	.O	(dcm0_clkdv),
+	// Inputs
+	.I	(dcm0_clkdv_prebufg)
+);
+
+BUFG pll0_clk1_bufg
+       (// Outputs
+	.O	(pll0_clk1),
+	// Inputs
+	.I	(pll0_clk1_prebufg));
+
+assign wb_clk_o = pll0_clk1;
+assign sync_wb_rst_n = pll0_locked;
+assign sync_ddr2_rst_n = dcm0_locked;
+
+assign ddr2_if_clk_o = dcm0_clkfx; // 266MHz
+assign clk100_o = dcm0_clk0; // 100MHz
+
+assign dvi_clk_o = sys_clk_pad_ibufg;
+
+//
+// Reset generation
+//
+//
+
+// Reset generation for wishbone
+reg [15:0] 	   wb_rst_shr;
+always @(posedge wb_clk_o or posedge async_rst_o)
+	if (async_rst_o)
+		wb_rst_shr <= 16'hffff;
+	else
+		wb_rst_shr <= {wb_rst_shr[14:0], ~(sync_wb_rst_n)};
+
+assign wb_rst_o = wb_rst_shr[15];
+
+assign ddr2_if_rst_o = async_rst_o;
+
+endmodule // clkgen

--- a/systems/atlys/rtl/verilog/dvi_gen/DRAM16XN.v
+++ b/systems/atlys/rtl/verilog/dvi_gen/DRAM16XN.v
@@ -1,0 +1,51 @@
+//
+// Module: 	DRAM16XN
+//
+// Description: Distributed SelectRAM example
+//		Dual Port 16 x N-bit
+//
+// Device: 	Spartan-3 Family
+//---------------------------------------------------------------------------------------
+
+module DRAM16XN #(parameter data_width = 20)
+                 (
+                  DATA_IN,
+                  ADDRESS,
+                  ADDRESS_DP,
+                  WRITE_EN,
+                  CLK,
+                  O_DATA_OUT,
+                  O_DATA_OUT_DP);
+
+input [data_width-1:0]DATA_IN;
+input [3:0] ADDRESS;
+input [3:0] ADDRESS_DP;
+input WRITE_EN;
+input CLK;
+
+output [data_width-1:0]O_DATA_OUT_DP;
+output [data_width-1:0]O_DATA_OUT;
+
+genvar i;
+generate
+  for(i = 0 ; i < data_width ; i = i + 1) begin : dram16s
+    RAM16X1D i_RAM16X1D_U(  
+      .D(DATA_IN[i]),        //insert input signal
+      .WE(WRITE_EN),         //insert Write Enable signal
+      .WCLK(CLK),            //insert Write Clock signal
+      .A0(ADDRESS[0]),       //insert Address 0 signal port SPO
+      .A1(ADDRESS[1]),       //insert Address 1 signal port SPO
+      .A2(ADDRESS[2]),       //insert Address 2 signal port SPO
+      .A3(ADDRESS[3]),       //insert Address 3 signal port SPO
+      .DPRA0(ADDRESS_DP[0]), //insert Address 0 signal dual port DPO
+      .DPRA1(ADDRESS_DP[1]), //insert Address 1 signal dual port DPO
+      .DPRA2(ADDRESS_DP[2]), //insert Address 2 signal dual port DPO
+      .DPRA3(ADDRESS_DP[3]), //insert Address 3 signal dual port DPO
+      .SPO(O_DATA_OUT[i]),   //insert output signal SPO
+      .DPO(O_DATA_OUT_DP[i]) //insert output signal DPO
+    );
+  end
+endgenerate
+
+endmodule
+

--- a/systems/atlys/rtl/verilog/dvi_gen/convert_30to15_fifo.v
+++ b/systems/atlys/rtl/verilog/dvi_gen/convert_30to15_fifo.v
@@ -1,0 +1,168 @@
+module convert_30to15_fifo(
+  input  wire rst,   // reset
+  input  wire clk,   // clock input
+  input  wire clkx2, // 2x clock input
+  input  wire [29:0] datain,   // input data for 2:1 serialisation
+  output wire [14:0] dataout); // 5-bit data out
+
+  ////////////////////////////////////////////////////
+  // Here we instantiate a 16x10 Dual Port RAM
+  // and fill first it with data aligned to
+  // clk domain
+  ////////////////////////////////////////////////////
+  wire  [3:0]   wa;       // RAM read address
+  reg   [3:0]   wa_d;     // RAM read address
+  wire  [3:0]   ra;       // RAM read address
+  reg   [3:0]   ra_d;     // RAM read address
+  wire  [29:0]  dataint;  // RAM output
+
+  parameter ADDR0  = 4'b0000;
+  parameter ADDR1  = 4'b0001;
+  parameter ADDR2  = 4'b0010;
+  parameter ADDR3  = 4'b0011;
+  parameter ADDR4  = 4'b0100;
+  parameter ADDR5  = 4'b0101;
+  parameter ADDR6  = 4'b0110;
+  parameter ADDR7  = 4'b0111;
+  parameter ADDR8  = 4'b1000;
+  parameter ADDR9  = 4'b1001;
+  parameter ADDR10 = 4'b1010;
+  parameter ADDR11 = 4'b1011;
+  parameter ADDR12 = 4'b1100;
+  parameter ADDR13 = 4'b1101;
+  parameter ADDR14 = 4'b1110;
+  parameter ADDR15 = 4'b1111;
+
+  always@(wa) begin
+    case (wa)
+      ADDR0   : wa_d = ADDR1 ;
+      ADDR1   : wa_d = ADDR2 ;
+      ADDR2   : wa_d = ADDR3 ;
+      ADDR3   : wa_d = ADDR4 ;
+      ADDR4   : wa_d = ADDR5 ;
+      ADDR5   : wa_d = ADDR6 ;
+      ADDR6   : wa_d = ADDR7 ;
+      ADDR7   : wa_d = ADDR8 ;
+      ADDR8   : wa_d = ADDR9 ;
+      ADDR9   : wa_d = ADDR10;
+      ADDR10  : wa_d = ADDR11;
+      ADDR11  : wa_d = ADDR12;
+      ADDR12  : wa_d = ADDR13;
+      ADDR13  : wa_d = ADDR14;
+      ADDR14  : wa_d = ADDR15;
+      default : wa_d = ADDR0;
+    endcase
+  end
+
+  FDC fdc_wa0 (.C(clk),  .D(wa_d[0]), .CLR(rst), .Q(wa[0]));
+  FDC fdc_wa1 (.C(clk),  .D(wa_d[1]), .CLR(rst), .Q(wa[1]));
+  FDC fdc_wa2 (.C(clk),  .D(wa_d[2]), .CLR(rst), .Q(wa[2]));
+  FDC fdc_wa3 (.C(clk),  .D(wa_d[3]), .CLR(rst), .Q(wa[3]));
+
+  //Dual Port fifo to bridge data from clk to clkx2
+  DRAM16XN #(.data_width(30))
+  fifo_u (
+         .DATA_IN(datain),
+         .ADDRESS(wa),
+         .ADDRESS_DP(ra),
+         .WRITE_EN(1'b1),
+         .CLK(clk),
+         .O_DATA_OUT(),
+         .O_DATA_OUT_DP(dataint));
+
+  /////////////////////////////////////////////////////////////////
+  // Here starts clk2x domain for fifo read out 
+  // FIFO read is set to be once every 2 cycles of clk2x in order
+  // to keep up pace with the fifo write speed
+  // Also FIFO read reset is delayed a bit in order to avoid
+  // underflow.
+  /////////////////////////////////////////////////////////////////
+
+  always@(ra) begin
+    case (ra)
+      ADDR0   : ra_d = ADDR1 ;
+      ADDR1   : ra_d = ADDR2 ;
+      ADDR2   : ra_d = ADDR3 ;
+      ADDR3   : ra_d = ADDR4 ;
+      ADDR4   : ra_d = ADDR5 ;
+      ADDR5   : ra_d = ADDR6 ;
+      ADDR6   : ra_d = ADDR7 ;
+      ADDR7   : ra_d = ADDR8 ;
+      ADDR8   : ra_d = ADDR9 ;
+      ADDR9   : ra_d = ADDR10;
+      ADDR10  : ra_d = ADDR11;
+      ADDR11  : ra_d = ADDR12;
+      ADDR12  : ra_d = ADDR13;
+      ADDR13  : ra_d = ADDR14;
+      ADDR14  : ra_d = ADDR15;
+      default : ra_d = ADDR0;
+    endcase
+  end
+
+  wire rstsync, rstsync_q, rstp;
+  (* ASYNC_REG = "TRUE" *) FDP fdp_rst  (.C(clkx2),  .D(rst), .PRE(rst), .Q(rstsync));
+
+  FD fd_rstsync (.C(clkx2),  .D(rstsync), .Q(rstsync_q));
+  FD fd_rstp    (.C(clkx2),  .D(rstsync_q), .Q(rstp));
+
+  wire sync;
+  FDR sync_gen (.Q (sync), .C (clkx2), .R(rstp), .D(~sync));
+
+  FDRE fdc_ra0 (.C(clkx2),  .D(ra_d[0]), .R(rstp), .CE(sync), .Q(ra[0]));
+  FDRE fdc_ra1 (.C(clkx2),  .D(ra_d[1]), .R(rstp), .CE(sync), .Q(ra[1]));
+  FDRE fdc_ra2 (.C(clkx2),  .D(ra_d[2]), .R(rstp), .CE(sync), .Q(ra[2]));
+  FDRE fdc_ra3 (.C(clkx2),  .D(ra_d[3]), .R(rstp), .CE(sync), .Q(ra[3]));
+
+  wire [29:0] db;
+
+  FDE fd_db0 (.C(clkx2), .D(dataint[0]),   .CE(sync), .Q(db[0]));
+  FDE fd_db1 (.C(clkx2), .D(dataint[1]),   .CE(sync), .Q(db[1]));
+  FDE fd_db2 (.C(clkx2), .D(dataint[2]),   .CE(sync), .Q(db[2]));
+  FDE fd_db3 (.C(clkx2), .D(dataint[3]),   .CE(sync), .Q(db[3]));
+  FDE fd_db4 (.C(clkx2), .D(dataint[4]),   .CE(sync), .Q(db[4]));
+  FDE fd_db5 (.C(clkx2), .D(dataint[5]),   .CE(sync), .Q(db[5]));
+  FDE fd_db6 (.C(clkx2), .D(dataint[6]),   .CE(sync), .Q(db[6]));
+  FDE fd_db7 (.C(clkx2), .D(dataint[7]),   .CE(sync), .Q(db[7]));
+  FDE fd_db8 (.C(clkx2), .D(dataint[8]),   .CE(sync), .Q(db[8]));
+  FDE fd_db9 (.C(clkx2), .D(dataint[9]),   .CE(sync), .Q(db[9]));
+  FDE fd_db10 (.C(clkx2), .D(dataint[10]), .CE(sync), .Q(db[10]));
+  FDE fd_db11 (.C(clkx2), .D(dataint[11]), .CE(sync), .Q(db[11]));
+  FDE fd_db12 (.C(clkx2), .D(dataint[12]), .CE(sync), .Q(db[12]));
+  FDE fd_db13 (.C(clkx2), .D(dataint[13]), .CE(sync), .Q(db[13]));
+  FDE fd_db14 (.C(clkx2), .D(dataint[14]), .CE(sync), .Q(db[14]));
+  FDE fd_db15 (.C(clkx2), .D(dataint[15]), .CE(sync), .Q(db[15]));
+  FDE fd_db16 (.C(clkx2), .D(dataint[16]), .CE(sync), .Q(db[16]));
+  FDE fd_db17 (.C(clkx2), .D(dataint[17]), .CE(sync), .Q(db[17]));
+  FDE fd_db18 (.C(clkx2), .D(dataint[18]), .CE(sync), .Q(db[18]));
+  FDE fd_db19 (.C(clkx2), .D(dataint[19]), .CE(sync), .Q(db[19]));
+  FDE fd_db20 (.C(clkx2), .D(dataint[20]), .CE(sync), .Q(db[20]));
+  FDE fd_db21 (.C(clkx2), .D(dataint[21]), .CE(sync), .Q(db[21]));
+  FDE fd_db22 (.C(clkx2), .D(dataint[22]), .CE(sync), .Q(db[22]));
+  FDE fd_db23 (.C(clkx2), .D(dataint[23]), .CE(sync), .Q(db[23]));
+  FDE fd_db24 (.C(clkx2), .D(dataint[24]), .CE(sync), .Q(db[24]));
+  FDE fd_db25 (.C(clkx2), .D(dataint[25]), .CE(sync), .Q(db[25]));
+  FDE fd_db26 (.C(clkx2), .D(dataint[26]), .CE(sync), .Q(db[26]));
+  FDE fd_db27 (.C(clkx2), .D(dataint[27]), .CE(sync), .Q(db[27]));
+  FDE fd_db28 (.C(clkx2), .D(dataint[28]), .CE(sync), .Q(db[28]));
+  FDE fd_db29 (.C(clkx2), .D(dataint[29]), .CE(sync), .Q(db[29]));
+
+  wire [14:0] mux;
+  assign mux = (~sync) ? db[14:0] : db[29:15];
+
+  FD fd_out0 (.C(clkx2), .D(mux[0]), .Q(dataout[0]));
+  FD fd_out1 (.C(clkx2), .D(mux[1]), .Q(dataout[1]));
+  FD fd_out2 (.C(clkx2), .D(mux[2]), .Q(dataout[2]));
+  FD fd_out3 (.C(clkx2), .D(mux[3]), .Q(dataout[3]));
+  FD fd_out4 (.C(clkx2), .D(mux[4]), .Q(dataout[4]));
+  FD fd_out5 (.C(clkx2), .D(mux[5]), .Q(dataout[5]));
+  FD fd_out6 (.C(clkx2), .D(mux[6]), .Q(dataout[6]));
+  FD fd_out7 (.C(clkx2), .D(mux[7]), .Q(dataout[7]));
+  FD fd_out8 (.C(clkx2), .D(mux[8]), .Q(dataout[8]));
+  FD fd_out9 (.C(clkx2), .D(mux[9]), .Q(dataout[9]));
+  FD fd_out10 (.C(clkx2), .D(mux[10]), .Q(dataout[10]));
+  FD fd_out11 (.C(clkx2), .D(mux[11]), .Q(dataout[11]));
+  FD fd_out12 (.C(clkx2), .D(mux[12]), .Q(dataout[12]));
+  FD fd_out13 (.C(clkx2), .D(mux[13]), .Q(dataout[13]));
+  FD fd_out14 (.C(clkx2), .D(mux[14]), .Q(dataout[14]));
+
+endmodule

--- a/systems/atlys/rtl/verilog/dvi_gen/dcmspi.v
+++ b/systems/atlys/rtl/verilog/dvi_gen/dcmspi.v
@@ -1,0 +1,142 @@
+/////////////////////////////////////////////////////
+// DCM SPI Controller
+/////////////////////////////////////////////////////
+`timescale 1ns / 1ps
+
+module dcmspi (
+    input  RST,                //Synchronous Reset
+    input  PROGCLK,            //SPI clock
+    input  PROGDONE,           //DCM is ready to take next command
+    input  DFSLCKD,
+    input  [7:0] M,            //DCM M value
+    input  [7:0] D,            //DCM D value
+    input  GO,                 //Go programme the M and D value into DCM(1 cycle pulse)
+    output reg BUSY,
+    output reg PROGEN,         //SlaveSelect,
+    output reg PROGDATA        //CommandData
+);
+
+parameter TCQ = 1;
+
+wire [9:0] mval = {M, 1'b1, 1'b1}; //M command: 11,M0-M7
+wire [9:0] dval = {D, 1'b0, 1'b1}; //D command: 10,D0-D7
+
+reg dfslckd_q;
+reg dfslckd_rising;
+always @ (posedge PROGCLK)
+begin
+  dfslckd_q <=#TCQ DFSLCKD;
+  dfslckd_rising <=#TCQ !dfslckd_q & DFSLCKD;
+end
+
+always @ (posedge PROGCLK)
+begin
+  if(RST || (PROGDONE & dfslckd_rising))
+    BUSY <=#TCQ 1'b0;
+  else if (GO)
+    BUSY <=#TCQ 1'b1;
+end
+
+reg [9:0] sndval;
+reg sndm = 1'b0;
+reg sndd = 1'b0;
+
+wire ddone;
+SRL16E VCNT (
+  .Q(ddone), // SRL data output
+  .A0(1'b1), // Select[0] input
+  .A1(1'b0), // Select[1] input
+  .A2(1'b0), // Select[2] input
+  .A3(1'b1), // Select[3] input
+  .CE(1'b1), //clock enable
+  .CLK(PROGCLK), // Clock input
+  .D(GO) // SRL data input
+);
+// The following defparam declaration 
+defparam VCNT.INIT = 16'h0;
+
+always @ (posedge PROGCLK)
+begin
+  if(RST || ddone)
+    sndd <=#TCQ 1'b0;
+  else if(GO)
+    sndd <=#TCQ 1'b1;
+end
+
+//V has been sent now it is M's turn
+wire ldm;
+SRL16E DMGAP (
+  .Q(ldm), // SRL data output
+  .A0(1'b0), // Select[0] input
+  .A1(1'b0), // Select[1] input
+  .A2(1'b1), // Select[2] input
+  .A3(1'b0), // Select[3] input
+  .CE(1'b1), //clock enable
+  .CLK(PROGCLK), // Clock input
+  .D(ddone) // SRL data input
+);
+// The following defparam declaration 
+defparam DMGAP.INIT = 16'h0;
+
+wire mdone;
+SRL16E MCNT (
+  .Q(mdone), // SRL data output
+  .A0(1'b1), // Select[0] input
+  .A1(1'b0), // Select[1] input
+  .A2(1'b0), // Select[2] input
+  .A3(1'b1), // Select[3] input
+  .CE(1'b1), //clock enable
+  .CLK(PROGCLK), // Clock input
+  .D(ldm) // SRL data input
+);
+// The following defparam declaration 
+defparam MCNT.INIT = 16'h0;
+
+always @ (posedge PROGCLK)
+begin
+  if(RST || mdone)
+    sndm <=#TCQ 1'b0;
+  else if(ldm)
+    sndm <=#TCQ 1'b1;
+end
+
+wire gocmd;
+SRL16E GOGAP (
+  .Q(gocmd), // SRL data output
+  .A0(1'b0), // Select[0] input
+  .A1(1'b0), // Select[1] input
+  .A2(1'b1), // Select[2] input
+  .A3(1'b0), // Select[3] input
+  .CE(1'b1), //clock enable
+  .CLK(PROGCLK), // Clock input
+  .D(mdone) // SRL data input
+);
+// The following defparam declaration 
+defparam GOGAP.INIT = 16'h0;
+
+always @ (posedge PROGCLK)
+begin
+  if(RST)
+    sndval <=#TCQ 10'h0;
+  else if(GO) //send D first
+    sndval <=#TCQ dval;
+  else if(ldm)
+    sndval <=#TCQ mval;
+  else if(sndm || sndd)
+    sndval <=#TCQ sndval >> 1;
+end
+
+always @ (posedge PROGCLK)
+begin
+  PROGEN <=#TCQ sndd | sndm | gocmd;
+end
+
+always @ (posedge PROGCLK)
+begin
+  if(sndm || sndd)
+    PROGDATA <=#TCQ sndval[0];
+  else
+    PROGDATA <=#TCQ 1'b0;
+end
+
+endmodule

--- a/systems/atlys/rtl/verilog/dvi_gen/dvi_encoder.v
+++ b/systems/atlys/rtl/verilog/dvi_gen/dvi_encoder.v
@@ -1,0 +1,103 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+//  Xilinx, Inc. 2009                 www.xilinx.com
+//
+//  XAPP xyz
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//  File name :       dvi_encoder.v
+//
+//  Description :     dvi_encoder 
+//
+//  Date - revision : April 2009 - 1.0.0
+//
+//  Author :          Bob Feng
+//
+//  Disclaimer: LIMITED WARRANTY AND DISCLAMER. These designs are
+//              provided to you "as is". Xilinx and its licensors makeand you
+//              receive no warranties or conditions, express, implied,
+//              statutory or otherwise, and Xilinx specificallydisclaims any
+//              implied warranties of merchantability, non-infringement,or
+//              fitness for a particular purpose. Xilinx does notwarrant that
+//              the functions contained in these designs will meet your
+//              requirements, or that the operation of these designswill be
+//              uninterrupted or error free, or that defects in theDesigns
+//              will be corrected. Furthermore, Xilinx does not warrantor
+//              make any representations regarding use or the results ofthe
+//              use of the designs in terms of correctness, accuracy,
+//              reliability, or otherwise.
+//
+//              LIMITATION OF LIABILITY. In no event will Xilinx or its
+//              licensors be liable for any loss of data, lost profits,cost
+//              or procurement of substitute goods or services, or forany
+//              special, incidental, consequential, or indirect damages
+//              arising from the use or operation of the designs or
+//              accompanying documentation, however caused and on anytheory
+//              of liability. This limitation will apply even if Xilinx
+//              has been advised of the possibility of such damage. This
+//              limitation shall apply not-withstanding the failure ofthe
+//              essential purpose of any limited remedies herein.
+//
+//  Copyright © 2009 Xilinx, Inc.
+//  All rights reserved
+//
+//////////////////////////////////////////////////////////////////////////////
+`timescale 1 ns / 1ps
+
+module dvi_encoder (
+input  wire       clkin,          // pixel clock
+input  wire       clkx2in,        // pixel clock x2
+input  wire       rstin,          // reset
+input  wire [7:0] blue_din,       // Blue data in
+input  wire [7:0] green_din,      // Green data in
+input  wire [7:0] red_din,        // Red data in
+input  wire       hsync,          // hsync data
+input  wire       vsync,          // vsync data
+input  wire       de,             // data enable
+output wire [4:0] tmds_data0,
+output wire [4:0] tmds_data1,
+output wire [4:0]	tmds_data2);		// 5-bit busses converted from 10-bit
+	
+wire 	[9:0]	red ;
+wire 	[9:0]	green ;
+wire 	[9:0]	blue ;
+
+encode encb (
+	.clkin	(clkin),
+	.rstin	(rstin),
+	.din		(blue_din),
+	.c0			(hsync),
+	.c1			(vsync),
+	.de			(de),
+	.dout		(blue)) ;
+
+encode encg (
+	.clkin	(clkin),
+	.rstin	(rstin),
+	.din		(green_din),
+	.c0			(1'b0),
+	.c1			(1'b0),
+	.de			(de),
+	.dout		(green)) ;
+	
+encode encr (
+	.clkin	(clkin),
+	.rstin	(rstin),
+	.din		(red_din),
+	.c0			(1'b0),
+	.c1			(1'b0),
+	.de			(de),
+	.dout		(red)) ;
+
+wire [29:0] s_data = {red[9:5], green[9:5], blue[9:5],
+                      red[4:0], green[4:0], blue[4:0]};
+
+convert_30to15_fifo pixel2x (
+  .rst     (rstin),
+  .clk     (clkin),
+  .clkx2   (clkx2in),
+  .datain  (s_data),
+  .dataout ({tmds_data2, tmds_data1, tmds_data0}));
+
+endmodule

--- a/systems/atlys/rtl/verilog/dvi_gen/dvi_gen_top.v
+++ b/systems/atlys/rtl/verilog/dvi_gen/dvi_gen_top.v
@@ -1,0 +1,578 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2009 Xilinx, Inc.
+// This design is confidential and proprietary of Xilinx, All Rights Reserved.
+//////////////////////////////////////////////////////////////////////////////
+//   ____  ____
+//  /   /\/   /
+// /___/  \  /   Vendor:        Xilinx
+// \   \   \/    Version:       1.0.0
+//  \   \        Filename:      vtc_demo.v
+//  /   /        Date Created:  April 8, 2009
+// /___/   /\    Author:        Bob Feng   
+// \   \  /  \
+//  \___\/\___\
+//
+// Devices:   Spartan-6 Generation FPGA
+// Purpose:   SP601 board demo top level
+// Contact:   
+// Reference: None
+//
+// Revision History:
+// 
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+// LIMITED WARRANTY AND DISCLAIMER. These designs are provided to you "as is".
+// Xilinx and its licensors make and you receive no warranties or conditions,
+// express, implied, statutory or otherwise, and Xilinx specifically disclaims
+// any implied warranties of merchantability, non-infringement, or fitness for
+// a particular purpose. Xilinx does not warrant that the functions contained
+// in these designs will meet your requirements, or that the operation of
+// these designs will be uninterrupted or error free, or that defects in the
+// designs will be corrected. Furthermore, Xilinx does not warrant or make any
+// representations regarding use or the results of the use of the designs in
+// terms of correctness, accuracy, reliability, or otherwise.
+//
+// LIMITATION OF LIABILITY. In no event will Xilinx or its licensors be liable
+// for any loss of data, lost profits, cost or procurement of substitute goods
+// or services, or for any special, incidental, consequential, or indirect
+// damages arising from the use or operation of the designs or accompanying
+// documentation, however caused and on any theory of liability. This
+// limitation will apply even if Xilinx has been advised of the possibility
+// of such damage. This limitation shall apply not-withstanding the failure
+// of the essential purpose of any limited remedies herein.
+//
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2009 Xilinx, Inc.
+// This design is confidential and proprietary of Xilinx, All Rights Reserved.
+//////////////////////////////////////////////////////////////////////////////
+
+`timescale 1 ps / 1 ps
+
+module dvi_gen_top (
+  input  wire        rst_n_pad_i,
+  input  wire        dvi_clk_i,
+  input  wire [15:0] hlen,
+  input  wire [15:0] vlen,
+  output wire [3:0]  TMDS,
+  output wire [3:0]  TMDSB,
+  output wire        pclk_o,
+  input  wire        hsync_i, 
+  input  wire        vsync_i, 
+  input  wire        blank_i, 
+  input  wire [7:0]  red_data_i,
+  input  wire [7:0]  green_data_i,
+  input  wire [7:0]  blue_data_i
+);
+
+  //******************************************************************//
+  // Create global clock and synchronous system reset.                //
+  //******************************************************************//
+  wire          locked;
+  wire          reset;
+
+  wire          clk50m, clk50m_bufg;
+
+  wire          pwrup;
+
+  BUFIO2 #(.DIVIDE_BYPASS("FALSE"), .DIVIDE(2))
+  sysclk_div (.DIVCLK(clk50m), .IOCLK(), .SERDESSTROBE(), .I(dvi_clk_i));
+  
+  BUFG clk50m_bufgbufg (.I(clk50m), .O(clk50m_bufg));
+
+  
+  wire pclk_lckd;
+  wire RSTBTN;
+  // transform rst button into active high
+  assign RSTBTN = ~rst_n_pad_i; 
+//`ifdef SIMULATION
+//  assign pwrup = 1'b0;
+//`else
+  SRL16E #(.INIT(16'h1)) pwrup_0 (
+    .Q(pwrup),
+    .A0(1'b1),
+    .A1(1'b1),
+    .A2(1'b1),
+    .A3(1'b1),
+    .CE(pclk_lckd),
+    .CLK(clk50m_bufg),
+    .D(1'b0)
+  );
+//`endif
+
+  //////////////////////////////////////
+  /// Switching screen formats
+  //////////////////////////////////////
+  wire busy;
+  reg switch = 1'b0;
+  reg [15:0] hlen_q, vlen_q;
+
+  always @ (posedge clk50m_bufg)
+  begin
+    switch <= pwrup | ({hlen_q,vlen_q} != {hlen,vlen});
+  end
+
+  wire gopclk;
+  SRL16E SRL16E_0 (
+    .Q(gopclk),
+    .A0(1'b1),
+    .A1(1'b1),
+    .A2(1'b1),
+    .A3(1'b1),
+    .CE(1'b1),
+    .CLK(clk50m_bufg),
+    .D(switch)
+  );
+  // The following defparam declaration 
+  defparam SRL16E_0.INIT = 16'h0;
+
+  reg [7:0] pclk_M, pclk_D;
+
+  always @(posedge clk50m_bufg)
+  begin
+    hlen_q <= hlen;
+    vlen_q <= vlen;
+    if (switch) begin
+      case ({hlen,vlen})
+        32'h031f01c1:  // 640x400@70, pclk = 21.600000MHz
+        begin
+          pclk_M <= 8'd54 - 8'd1;
+          pclk_D <= 8'd125 - 8'd1;
+        end
+        32'h031f020c:  // 640x480@60, pclk = 25.200000MHz
+        begin
+          pclk_M <= 8'd63 - 8'd1;
+          pclk_D <= 8'd125 - 8'd1;
+        end
+        32'h03ff0270:  // 800x600@56, pclk = 38.400000MHz
+        begin
+          pclk_M <= 8'd96 - 8'd1;
+          pclk_D <= 8'd125 - 8'd1;
+        end
+        32'h04ef0330:  // 1024x768@87, pclk = 61.961280MHz
+        begin
+          pclk_M <= 8'd202 - 8'd1;
+          pclk_D <= 8'd163 - 8'd1;
+        end
+        32'h033f01bc:  // 640x400@85, pclk = 22.214400MHz
+        begin
+          pclk_M <= 8'd4 - 8'd1;
+          pclk_D <= 8'd9 - 8'd1;
+        end
+        32'h035f0208:  // 640x480@72, pclk = 27.008640MHz
+        begin
+          pclk_M <= 8'd121 - 8'd1;
+          pclk_D <= 8'd224 - 8'd1;
+        end
+        32'h041f0273:  // 800x600@60, pclk = 39.790080MHz
+        begin
+          pclk_M <= 8'd152 - 8'd1;
+          pclk_D <= 8'd191 - 8'd1;
+        end
+        32'h033f01fc:  // 640x480@85, pclk = 25.409280MHz
+        begin
+          pclk_M <= 8'd31 - 8'd1;
+          pclk_D <= 8'd61 - 8'd1;
+        end
+        32'h05c703d8:  // 1152x864@89, pclk = 87.468000MHz
+        begin
+          pclk_M <= 8'd7 - 8'd1;
+          pclk_D <= 8'd4 - 8'd1;
+        end
+        32'h040f0299:  // 800x600@72, pclk = 41.558400MHz
+        begin
+          pclk_M <= 8'd64 - 8'd1;
+          pclk_D <= 8'd77 - 8'd1;
+        end
+        32'h053f0325:  // 1024x768@60, pclk = 64.995840MHz
+        begin
+          pclk_M <= 8'd13 - 8'd1;
+          pclk_D <= 8'd10 - 8'd1;
+        end
+        32'h035f0211:  // 640x480@100, pclk = 27.475200MHz
+        begin
+          pclk_M <= 8'd111 - 8'd1;
+          pclk_D <= 8'd202 - 8'd1;
+        end
+        32'h068f037b:  // 1152x864@60, pclk = 89.913600MHz
+        begin
+          pclk_M <= 8'd205 - 8'd1;
+          pclk_D <= 8'd114 - 8'd1;
+        end
+        32'h043f0290:  // 800x600@85, pclk = 42.888960MHz
+        begin
+          pclk_M <= 8'd193 - 8'd1;
+          pclk_D <= 8'd225 - 8'd1;
+        end
+        32'h052f0325:  // 1024x768@70, pclk = 64.222080MHz
+        begin
+          pclk_M <= 8'd140 - 8'd1;
+          pclk_D <= 8'd109 - 8'd1;
+        end
+        32'h061f048c:  // 1280x1024@87, pclk = 109.603200MHz
+        begin
+          pclk_M <= 8'd217 - 8'd1;
+          pclk_D <= 8'd99 - 8'd1;
+        end
+        32'h043f027f:  // 800x600@100, pclk = 41.779200MHz
+        begin
+          pclk_M <= 8'd188 - 8'd1;
+          pclk_D <= 8'd225 - 8'd1;
+        end
+        32'h054f0336:  // 1024x768@76, pclk = 67.156800MHz
+        begin
+          pclk_M <= 8'd137 - 8'd1;
+          pclk_D <= 8'd102 - 8'd1;
+        end
+        32'h05c1037e:  // 1152x864@70, pclk = 79.153800MHz
+        begin
+          pclk_M <= 8'd19 - 8'd1;
+          pclk_D <= 8'd12 - 8'd1;
+        end
+        32'h06af041d:  // 1280x1024@61, pclk = 108.266880MHz
+        begin
+          pclk_M <= 8'd249 - 8'd1;
+          pclk_D <= 8'd115 - 8'd1;
+        end
+        32'h0697042a:  // 1400x1050@60, pclk = 108.065760MHz
+        begin
+          pclk_M <= 8'd67 - 8'd1;
+          pclk_D <= 8'd31 - 8'd1;
+        end
+        32'h06970447:  // 1400x1050@75, pclk = 111.002880MHz
+        begin
+          pclk_M <= 8'd111 - 8'd1;
+          pclk_D <= 8'd50 - 8'd1;
+        end
+        32'h068f0428:  // 1400x1050@60, pclk = 107.352000MHz
+        begin
+          pclk_M <= 8'd73 - 8'd1;
+          pclk_D <= 8'd34 - 8'd1;
+        end
+        32'h057f0335:  // 1024x768@85, pclk = 69.442560MHz
+        begin
+          pclk_M <= 8'd25 - 8'd1;
+          pclk_D <= 8'd18 - 8'd1;
+        end
+        32'h060f038b:  // 1152x864@78, pclk = 84.552960MHz
+        begin
+          pclk_M <= 8'd208 - 8'd1;
+          pclk_D <= 8'd123 - 8'd1;
+        end
+        32'h069f042b:  // 1280x1024@70, pclk = 108.679680MHz
+        begin
+          pclk_M <= 8'd213 - 8'd1;
+          pclk_D <= 8'd98 - 8'd1;
+        end
+        32'h086f04e1:  // 1600x1200@60, pclk = 162.000000MHz
+        begin
+          pclk_M <= 8'd81 - 8'd1;
+          pclk_D <= 8'd25 - 8'd1;
+        end
+        32'h06ef038b:  // 1152x864@84, pclk = 96.756480MHz
+        begin
+          pclk_M <= 8'd209 - 8'd1;
+          pclk_D <= 8'd108 - 8'd1;
+        end
+        32'h06af0427:  // 1280x1024@74, pclk = 109.294080MHz
+        begin
+          pclk_M <= 8'd247 - 8'd1;
+          pclk_D <= 8'd113 - 8'd1;
+        end
+        32'h059f0321:  // 1024x768@100, pclk = 69.292800MHz
+        begin
+          pclk_M <= 8'd255 - 8'd1;
+          pclk_D <= 8'd184 - 8'd1;
+        end
+        32'h067f0427:  // 1280x1024@76, pclk = 106.229760MHz
+        begin
+          pclk_M <= 8'd17 - 8'd1;
+          pclk_D <= 8'd8 - 8'd1;
+        end
+        32'h05ff0385:  // 1152x864@100, pclk = 83.128320MHz
+        begin
+          pclk_M <= 8'd133 - 8'd1;
+          pclk_D <= 8'd80 - 8'd1;
+        end
+        32'h06bf042f:  // 1280x1024@85, pclk = 111.144960MHz
+        begin
+          pclk_M <= 8'd249 - 8'd1;
+          pclk_D <= 8'd112 - 8'd1;
+        end
+        32'h08bf0440:  // 1680x1050@60, pclk = 146.361600MHz
+        begin
+          pclk_M <= 8'd161 - 8'd1;
+          pclk_D <= 8'd55 - 8'd1;
+        end
+        32'h081f04db:  // 1600x1200@85, pclk = 155.251200MHz
+        begin
+          pclk_M <= 8'd59 - 8'd1;
+          pclk_D <= 8'd19 - 8'd1;
+        end
+        32'h069f042f:  // 1280x1024@100, pclk = 109.086720MHz
+        begin
+          pclk_M <= 8'd24 - 8'd1;
+          pclk_D <= 8'd11 - 8'd1;
+        end
+        32'h095705d1:  // 1800x1440@64, pclk = 213.844800MHz
+        begin
+          pclk_M <= 8'd201 - 8'd1;
+          pclk_D <= 8'd47 - 8'd1;
+        end
+        32'h027f0193:  // 512x384@78, pclk = 15.513600MHz
+        begin
+          pclk_M <= 8'd76 - 8'd1;
+          pclk_D <= 8'd245 - 8'd1;
+        end
+        32'h018f00e0:  // 320x200@70, pclk = 5.400000MHz
+        begin
+          pclk_M <= 8'd27 - 8'd1;
+          pclk_D <= 8'd250 - 8'd1;
+        end
+        32'h018f0105:  // 320x240@60, pclk = 6.288000MHz
+        begin
+          pclk_M <= 8'd21 - 8'd1;
+          pclk_D <= 8'd167 - 8'd1;
+        end
+        32'h01ff0137:  // 400x300@56, pclk = 9.584640MHz
+        begin
+          pclk_M <= 8'd37 - 8'd1;
+          pclk_D <= 8'd193 - 8'd1;
+        end
+        32'h020f0139:  // 400x300@60, pclk = 9.947520MHz
+        begin
+          pclk_M <= 8'd38 - 8'd1;
+          pclk_D <= 8'd191 - 8'd1;
+        end
+        32'h0207014c:  // 400x300@72, pclk = 10.389600MHz
+        begin
+          pclk_M <= 8'd16 - 8'd1;
+          pclk_D <= 8'd77 - 8'd1;
+        end
+        32'h02670137:  // 480x300@56, pclk = 11.531520MHz
+        begin
+          pclk_M <= 8'd3 - 8'd1;
+          pclk_D <= 8'd13 - 8'd1;
+        end
+        32'h02770139:  // 480x300@60, pclk = 11.906880MHz
+        begin
+          pclk_M <= 8'd5 - 8'd1;
+          pclk_D <= 8'd21 - 8'd1;
+        end
+        32'h026f014c:  // 480x300@72, pclk = 12.467520MHz
+        begin
+          pclk_M <= 8'd63 - 8'd1;
+          pclk_D <= 8'd253 - 8'd1;
+        end
+        32'h0a1f04d9:  // 1920x1200@60, pclk = 193.155840MHz
+        begin
+          pclk_M <= 8'd197 - 8'd1;
+          pclk_D <= 8'd51 - 8'd1;
+        end
+        32'h05bf0325:  // 1152x768@60, pclk = 71.185920MHz
+        begin
+          pclk_M <= 8'd84 - 8'd1;
+          pclk_D <= 8'd59 - 8'd1;
+        end
+        32'h05f70315:  // 1366x768@60, pclk = 72.427200MHz
+        begin
+          pclk_M <= 8'd197 - 8'd1;
+          pclk_D <= 8'd136 - 8'd1;
+        end
+        32'h068f033b:  // 1280x800@60, pclk = 83.462400MHz
+        begin
+          pclk_M <= 8'd217 - 8'd1;
+          pclk_D <= 8'd130 - 8'd1;
+        end
+        32'h035f0270:  // 720x576@50, pclk = 32.400000MHz
+        begin
+          pclk_M <= 8'd81 - 8'd1;
+          pclk_D <= 8'd125 - 8'd1;
+        end
+        32'h043f0270:  // 800x520@50, pclk = 40.800000MHz
+        begin
+          pclk_M <= 8'd102 - 8'd1;
+          pclk_D <= 8'd125 - 8'd1;
+        end
+        default:
+        begin
+          pclk_M <= 8'd2 - 8'd1;
+          pclk_D <= 8'd4 - 8'd1;
+        end
+      endcase
+    end
+  end
+
+  //
+  // DCM_CLKGEN SPI controller
+  //
+  wire progdone, progen, progdata;
+  dcmspi dcmspi_0 (
+    .RST(switch),          //Synchronous Reset
+    .PROGCLK(clk50m_bufg), //SPI clock
+    .PROGDONE(progdone),   //DCM is ready to take next command
+    .DFSLCKD(pclk_lckd),
+    .M(pclk_M),            //DCM M value
+    .D(pclk_D),            //DCM D value
+    .GO(gopclk),           //Go programme the M and D value into DCM(1 cycle pulse)
+    .BUSY(busy),
+    .PROGEN(progen),       //SlaveSelect,
+    .PROGDATA(progdata)    //CommandData
+  );
+
+  //
+  // DCM_CLKGEN to generate a pixel clock with a variable frequency
+  //
+  wire          clkfx, pclk;
+  DCM_CLKGEN #(
+    .CLKFX_DIVIDE (21),
+    .CLKFX_MULTIPLY (31),
+    .CLKIN_PERIOD(20.000)
+  )
+  PCLK_GEN_INST (
+    .CLKFX(clkfx),
+    .CLKFX180(),
+    .CLKFXDV(),
+    .LOCKED(pclk_lckd),
+    .PROGDONE(progdone),
+    .STATUS(),
+    .CLKIN(clk50m),
+    .FREEZEDCM(1'b0),
+    .PROGCLK(clk50m_bufg),
+    .PROGDATA(progdata),
+    .PROGEN(progen),
+    .RST(1'b0)
+  );
+
+
+  wire pllclk0, pllclk1, pllclk2;
+  wire pclkx2, pclkx10, pll_lckd;
+  wire clkfbout;
+
+  //
+  // Pixel Rate clock buffer
+  //
+  BUFG pclkbufg (.I(pllclk1), .O(pclk));
+  assign pclk_o = pclk;
+  //////////////////////////////////////////////////////////////////
+  // 2x pclk is going to be used to drive OSERDES2
+  // on the GCLK side
+  //////////////////////////////////////////////////////////////////
+  BUFG pclkx2bufg (.I(pllclk2), .O(pclkx2));
+
+  //////////////////////////////////////////////////////////////////
+  // 10x pclk is used to drive IOCLK network so a bit rate reference
+  // can be used by OSERDES2
+  //////////////////////////////////////////////////////////////////
+  PLL_BASE # (
+    .CLKIN_PERIOD(13),
+    .CLKFBOUT_MULT(10), //set VCO to 10x of CLKIN
+    .CLKOUT0_DIVIDE(1),
+    .CLKOUT1_DIVIDE(10),
+    .CLKOUT2_DIVIDE(5),
+    .COMPENSATION("INTERNAL")
+  ) PLL_OSERDES (
+    .CLKFBOUT(clkfbout),
+    .CLKOUT0(pllclk0),
+    .CLKOUT1(pllclk1),
+    .CLKOUT2(pllclk2),
+    .CLKOUT3(),
+    .CLKOUT4(),
+    .CLKOUT5(),
+    .LOCKED(pll_lckd),
+    .CLKFBIN(clkfbout),
+    .CLKIN(clkfx),
+    .RST(~pclk_lckd)
+  );
+
+  wire serdesstrobe;
+  wire bufpll_lock;
+  BUFPLL #(.DIVIDE(5)) ioclk_buf (.PLLIN(pllclk0), .GCLK(pclkx2), .LOCKED(pll_lckd),
+           .IOCLK(pclkx10), .SERDESSTROBE(serdesstrobe), .LOCK(bufpll_lock));
+
+  synchro #(.INITIALIZE("LOGIC1"))
+  synchro_reset (.async(!pll_lckd),.sync(reset),.clk(pclk));
+
+  ////////////////////////////////////////////////////////////////
+  // DVI Encoder
+  ////////////////////////////////////////////////////////////////
+  wire [4:0] tmds_data0, tmds_data1, tmds_data2;
+  wire not_blank = !blank_i;
+  dvi_encoder enc0 (
+    .clkin      (pclk),
+    .clkx2in    (pclkx2),
+    .rstin      (reset),
+    .blue_din   (blue_data_i),
+    .green_din  (green_data_i),
+    .red_din    (red_data_i),
+    .hsync      (hsync_i),
+    .vsync      (vsync_i),
+    .de         (not_blank),
+    .tmds_data0 (tmds_data0),
+    .tmds_data1 (tmds_data1),
+    .tmds_data2 (tmds_data2));
+
+  wire [2:0] tmdsint;
+
+  wire serdes_rst = RSTBTN | ~bufpll_lock;
+
+  serdes_n_to_1 #(.SF(5)) oserdes0 (
+             .ioclk(pclkx10),
+             .serdesstrobe(serdesstrobe),
+             .reset(serdes_rst),
+             .gclk(pclkx2),
+             .datain(tmds_data0),
+             .iob_data_out(tmdsint[0])) ;
+
+  serdes_n_to_1 #(.SF(5)) oserdes1 (
+             .ioclk(pclkx10),
+             .serdesstrobe(serdesstrobe),
+             .reset(serdes_rst),
+             .gclk(pclkx2),
+             .datain(tmds_data1),
+             .iob_data_out(tmdsint[1])) ;
+
+  serdes_n_to_1 #(.SF(5)) oserdes2 (
+             .ioclk(pclkx10),
+             .serdesstrobe(serdesstrobe),
+             .reset(serdes_rst),
+             .gclk(pclkx2),
+             .datain(tmds_data2),
+             .iob_data_out(tmdsint[2])) ;
+
+  OBUFDS TMDS0 (.I(tmdsint[0]), .O(TMDS[0]), .OB(TMDSB[0])) ;
+  OBUFDS TMDS1 (.I(tmdsint[1]), .O(TMDS[1]), .OB(TMDSB[1])) ;
+  OBUFDS TMDS2 (.I(tmdsint[2]), .O(TMDS[2]), .OB(TMDSB[2])) ;
+
+  reg [4:0] tmdsclkint = 5'b00000;
+  reg toggle = 1'b0;
+
+  always @ (posedge pclkx2 or posedge serdes_rst) begin
+    if (serdes_rst)
+      toggle <= 1'b0;
+    else
+      toggle <= ~toggle;
+  end
+
+  always @ (posedge pclkx2) begin
+    if (toggle)
+      tmdsclkint <= 5'b11111;
+    else
+      tmdsclkint <= 5'b00000;
+  end
+
+  wire tmdsclk;
+
+  serdes_n_to_1 #(
+    .SF           (5))
+  clkout (
+    .iob_data_out (tmdsclk),
+    .ioclk        (pclkx10),
+    .serdesstrobe (serdesstrobe),
+    .gclk         (pclkx2),
+    .reset        (serdes_rst),
+    .datain       (tmdsclkint));
+
+  OBUFDS TMDS3 (.I(tmdsclk), .O(TMDS[3]), .OB(TMDSB[3])) ;// clock
+
+endmodule

--- a/systems/atlys/rtl/verilog/dvi_gen/encode.v
+++ b/systems/atlys/rtl/verilog/dvi_gen/encode.v
@@ -1,0 +1,191 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+//  Xilinx, Inc. 2008                 www.xilinx.com
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//  File name :       encode.v
+//
+//  Description :     TMDS encoder  
+//
+//  Date - revision : Jan. 2008 - v 1.0
+//
+//  Author :          Bob Feng
+//
+//  Disclaimer: LIMITED WARRANTY AND DISCLAMER. These designs are
+//              provided to you "as is". Xilinx and its licensors make and you
+//              receive no warranties or conditions, express, implied,
+//              statutory or otherwise, and Xilinx specifically disclaims any
+//              implied warranties of merchantability, non-infringement,or
+//              fitness for a particular purpose. Xilinx does not warrant that
+//              the functions contained in these designs will meet your
+//              requirements, or that the operation of these designs will be
+//              uninterrupted or error free, or that defects in the Designs
+//              will be corrected. Furthermore, Xilinx does not warrantor
+//              make any representations regarding use or the results of the
+//              use of the designs in terms of correctness, accuracy,
+//              reliability, or otherwise.
+//
+//              LIMITATION OF LIABILITY. In no event will Xilinx or its
+//              licensors be liable for any loss of data, lost profits,cost
+//              or procurement of substitute goods or services, or for any
+//              special, incidental, consequential, or indirect damages
+//              arising from the use or operation of the designs or
+//              accompanying documentation, however caused and on any theory
+//              of liability. This limitation will apply even if Xilinx
+//              has been advised of the possibility of such damage. This
+//              limitation shall apply not-withstanding the failure of the
+//              essential purpose of any limited remedies herein.
+//
+//  Copyright © 2006 Xilinx, Inc.
+//  All rights reserved
+//
+//////////////////////////////////////////////////////////////////////////////  
+`timescale 1 ps / 1ps
+
+module encode (
+  input            clkin,    // pixel clock input
+  input            rstin,    // async. reset input (active high)
+  input      [7:0] din,      // data inputs: expect registered
+  input            c0,       // c0 input
+  input            c1,       // c1 input
+  input            de,       // de input
+  output reg [9:0] dout      // data outputs
+);
+
+  ////////////////////////////////////////////////////////////
+  // Counting number of 1s and 0s for each incoming pixel
+  // component. Pipe line the result.
+  // Register Data Input so it matches the pipe lined adder
+  // output
+  ////////////////////////////////////////////////////////////
+  reg [3:0] n1d; //number of 1s in din
+  reg [7:0] din_q;
+
+  always @ (posedge clkin) begin
+    n1d <=#1 din[0] + din[1] + din[2] + din[3] + din[4] + din[5] + din[6] + din[7];
+
+    din_q <=#1 din;
+  end
+
+  ///////////////////////////////////////////////////////
+  // Stage 1: 8 bit -> 9 bit
+  // Refer to DVI 1.0 Specification, page 29, Figure 3-5
+  ///////////////////////////////////////////////////////
+  wire decision1;
+
+  assign decision1 = (n1d > 4'h4) | ((n1d == 4'h4) & (din_q[0] == 1'b0));
+/*
+  reg [8:0] q_m;
+  always @ (posedge clkin) begin
+    q_m[0] <=#1 din_q[0];
+    q_m[1] <=#1 (decision1) ? (q_m[0] ^~ din_q[1]) : (q_m[0] ^ din_q[1]);
+    q_m[2] <=#1 (decision1) ? (q_m[1] ^~ din_q[2]) : (q_m[1] ^ din_q[2]);
+    q_m[3] <=#1 (decision1) ? (q_m[2] ^~ din_q[3]) : (q_m[2] ^ din_q[3]);
+    q_m[4] <=#1 (decision1) ? (q_m[3] ^~ din_q[4]) : (q_m[3] ^ din_q[4]);
+    q_m[5] <=#1 (decision1) ? (q_m[4] ^~ din_q[5]) : (q_m[4] ^ din_q[5]);
+    q_m[6] <=#1 (decision1) ? (q_m[5] ^~ din_q[6]) : (q_m[5] ^ din_q[6]);
+    q_m[7] <=#1 (decision1) ? (q_m[6] ^~ din_q[7]) : (q_m[6] ^ din_q[7]);
+    q_m[8] <=#1 (decision1) ? 1'b0 : 1'b1;
+  end
+*/
+  wire [8:0] q_m;
+  assign q_m[0] = din_q[0];
+  assign q_m[1] = (decision1) ? (q_m[0] ^~ din_q[1]) : (q_m[0] ^ din_q[1]);
+  assign q_m[2] = (decision1) ? (q_m[1] ^~ din_q[2]) : (q_m[1] ^ din_q[2]);
+  assign q_m[3] = (decision1) ? (q_m[2] ^~ din_q[3]) : (q_m[2] ^ din_q[3]);
+  assign q_m[4] = (decision1) ? (q_m[3] ^~ din_q[4]) : (q_m[3] ^ din_q[4]);
+  assign q_m[5] = (decision1) ? (q_m[4] ^~ din_q[5]) : (q_m[4] ^ din_q[5]);
+  assign q_m[6] = (decision1) ? (q_m[5] ^~ din_q[6]) : (q_m[5] ^ din_q[6]);
+  assign q_m[7] = (decision1) ? (q_m[6] ^~ din_q[7]) : (q_m[6] ^ din_q[7]);
+  assign q_m[8] = (decision1) ? 1'b0 : 1'b1;
+
+  /////////////////////////////////////////////////////////
+  // Stage 2: 9 bit -> 10 bit
+  // Refer to DVI 1.0 Specification, page 29, Figure 3-5
+  /////////////////////////////////////////////////////////
+  reg [3:0] n1q_m, n0q_m; // number of 1s and 0s for q_m
+  always @ (posedge clkin) begin
+    n1q_m  <=#1 q_m[0] + q_m[1] + q_m[2] + q_m[3] + q_m[4] + q_m[5] + q_m[6] + q_m[7];
+    n0q_m  <=#1 4'h8 - (q_m[0] + q_m[1] + q_m[2] + q_m[3] + q_m[4] + q_m[5] + q_m[6] + q_m[7]);
+  end
+
+  parameter CTRLTOKEN0 = 10'b1101010100;
+  parameter CTRLTOKEN1 = 10'b0010101011;
+  parameter CTRLTOKEN2 = 10'b0101010100;
+  parameter CTRLTOKEN3 = 10'b1010101011;
+
+  reg [4:0] cnt; //disparity counter, MSB is the sign bit
+  wire decision2, decision3;
+
+  assign decision2 = (cnt == 5'h0) | (n1q_m == n0q_m);
+  /////////////////////////////////////////////////////////////////////////
+  // [(cnt > 0) and (N1q_m > N0q_m)] or [(cnt < 0) and (N0q_m > N1q_m)]
+  /////////////////////////////////////////////////////////////////////////
+  assign decision3 = (~cnt[4] & (n1q_m > n0q_m)) | (cnt[4] & (n0q_m > n1q_m));
+
+  ////////////////////////////////////
+  // pipe line alignment
+  ////////////////////////////////////
+  reg       de_q, de_reg;
+  reg       c0_q, c1_q;
+  reg       c0_reg, c1_reg;
+  reg [8:0] q_m_reg;
+
+  always @ (posedge clkin) begin
+    de_q    <=#1 de;
+    de_reg  <=#1 de_q;
+    
+    c0_q    <=#1 c0;
+    c0_reg  <=#1 c0_q;
+    c1_q    <=#1 c1;
+    c1_reg  <=#1 c1_q;
+
+    q_m_reg <=#1 q_m;
+  end
+
+  ///////////////////////////////
+  // 10-bit out
+  // disparity counter
+  ///////////////////////////////
+  always @ (posedge clkin or posedge rstin) begin
+    if(rstin) begin
+      dout <= 10'h0;
+      cnt <= 5'h0;
+    end else begin
+      if (de_reg) begin
+        if(decision2) begin
+          dout[9]   <=#1 ~q_m_reg[8]; 
+          dout[8]   <=#1 q_m_reg[8]; 
+          dout[7:0] <=#1 (q_m_reg[8]) ? q_m_reg[7:0] : ~q_m_reg[7:0];
+
+          cnt <=#1 (~q_m_reg[8]) ? (cnt + n0q_m - n1q_m) : (cnt + n1q_m - n0q_m);
+        end else begin
+          if(decision3) begin
+            dout[9]   <=#1 1'b1;
+            dout[8]   <=#1 q_m_reg[8];
+            dout[7:0] <=#1 ~q_m_reg[7:0];
+
+            cnt <=#1 cnt + {q_m_reg[8], 1'b0} + (n0q_m - n1q_m);
+          end else begin
+            dout[9]   <=#1 1'b0;
+            dout[8]   <=#1 q_m_reg[8];
+            dout[7:0] <=#1 q_m_reg[7:0];
+
+            cnt <=#1 cnt - {~q_m_reg[8], 1'b0} + (n1q_m - n0q_m);
+          end
+        end
+      end else begin
+        case ({c1_reg, c0_reg})
+          2'b00:   dout <=#1 CTRLTOKEN0;
+          2'b01:   dout <=#1 CTRLTOKEN1;
+          2'b10:   dout <=#1 CTRLTOKEN2;
+          default: dout <=#1 CTRLTOKEN3;
+        endcase
+
+        cnt <=#1 5'h0;
+      end
+    end
+  end
+  
+endmodule

--- a/systems/atlys/rtl/verilog/dvi_gen/serdes_n_to_1.v
+++ b/systems/atlys/rtl/verilog/dvi_gen/serdes_n_to_1.v
@@ -1,0 +1,150 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+//  Xilinx, Inc. 2008                 www.xilinx.com
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//  File name :       	serdes_n_to_1.v
+//
+//  Description :     	1-bit generic n:1 transmitter module
+// 			Takes in n bits of data and serialises this to 1 bit
+// 			data is transmitted LSB first
+// 			0, 1, 2 ......
+//
+//  Date - revision : 	August 1st 2008 - v 1.0
+//
+//  Author :          	NJS
+//
+//  Disclaimer: LIMITED WARRANTY AND DISCLAMER. These designs are
+//              provided to you "as is". Xilinx and its licensors make and you
+//              receive no warranties or conditions, express, implied,
+//              statutory or otherwise, and Xilinx specifically disclaims any
+//              implied warranties of merchantability, non-infringement,or
+//              fitness for a particular purpose. Xilinx does not warrant that
+//              the functions contained in these designs will meet your
+//              requirements, or that the operation of these designs will be
+//              uninterrupted or error free, or that defects in the Designs
+//              will be corrected. Furthermore, Xilinx does not warrantor
+//              make any representations regarding use or the results of the
+//              use of the designs in terms of correctness, accuracy,
+//              reliability, or otherwise.
+//
+//              LIMITATION OF LIABILITY. In no event will Xilinx or its
+//              licensors be liable for any loss of data, lost profits,cost
+//              or procurement of substitute goods or services, or for any
+//              special, incidental, consequential, or indirect damages
+//              arising from the use or operation of the designs or
+//              accompanying documentation, however caused and on any theory
+//              of liability. This limitation will apply even if Xilinx
+//              has been advised of the possibility of such damage. This
+//              limitation shall apply not-withstanding the failure of the
+//              essential purpose of any limited remedies herein.
+//
+//  Copyright © 2008 Xilinx, Inc.
+//  All rights reserved
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+
+`timescale 1ps/1ps
+
+module serdes_n_to_1 (ioclk, serdesstrobe, reset, gclk, datain, iob_data_out) ;
+
+parameter integer SF = 8 ;   		// Parameter to set the serdes factor 1..8
+
+input 			ioclk ;		// IO Clock network
+input 			serdesstrobe ;	// Parallel data capture strobe
+input 			reset ;		// Reset
+input 			gclk ;		// Global clock
+input 	[SF-1 : 0]	datain ;  	// Data for output
+output 			iob_data_out ;	// output data
+
+wire		cascade_di ;		//
+wire		cascade_do ;		//
+wire		cascade_ti ;		//
+wire		cascade_to ;		//
+wire	[8:0]	mdatain ;		//
+
+genvar i ;				// Pad out the input data bus with 0's to 8 bits to avoid errors
+generate
+for (i = 0 ; i <= (SF - 1) ; i = i + 1)
+begin : loop0
+assign mdatain[i] = datain[i] ;
+end
+endgenerate
+generate
+for (i = (SF) ; i <= 8 ; i = i + 1)
+begin : loop1
+assign mdatain[i] = 1'b0 ;
+end
+endgenerate
+
+OSERDES2 #(
+	.DATA_WIDTH     	(SF), 			// SERDES word width.  This should match the setting is BUFPLL
+	.DATA_RATE_OQ      	("SDR"), 		// <SDR>, DDR
+	.DATA_RATE_OT      	("SDR"), 		// <SDR>, DDR
+	.SERDES_MODE    	("MASTER"), 		// <DEFAULT>, MASTER, SLAVE
+	.OUTPUT_MODE 		("DIFFERENTIAL"))
+oserdes_m (
+	.OQ       		(iob_data_out),
+	.OCE     		(1'b1),
+	.CLK0    		(ioclk),
+	.CLK1    		(1'b0),
+	.IOCE    		(serdesstrobe),
+	.RST     		(reset),
+	.CLKDIV  		(gclk),
+	.D4  			(mdatain[7]),
+	.D3  			(mdatain[6]),
+	.D2  			(mdatain[5]),
+	.D1  			(mdatain[4]),
+	.TQ  			(),
+	.T1 			(1'b0),
+	.T2 			(1'b0),
+	.T3 			(1'b0),
+	.T4 			(1'b0),
+	.TRAIN    		(1'b0),
+	.TCE	   		(1'b1),
+	.SHIFTIN1 		(1'b1),			// Dummy input in Master
+	.SHIFTIN2 		(1'b1),			// Dummy input in Master
+	.SHIFTIN3 		(cascade_do),		// Cascade output D data from slave
+	.SHIFTIN4 		(cascade_to),		// Cascade output T data from slave
+	.SHIFTOUT1 		(cascade_di),		// Cascade input D data to slave
+	.SHIFTOUT2 		(cascade_ti),		// Cascade input T data to slave
+	.SHIFTOUT3 		(),			// Dummy output in Master
+	.SHIFTOUT4 		()) ;			// Dummy output in Master
+
+OSERDES2 #(
+	.DATA_WIDTH     	(SF), 			// SERDES word width.  This should match the setting is BUFPLL
+	.DATA_RATE_OQ      	("SDR"), 		// <SDR>, DDR
+	.DATA_RATE_OT      	("SDR"), 		// <SDR>, DDR
+	.SERDES_MODE    	("SLAVE"), 		// <DEFAULT>, MASTER, SLAVE
+	.OUTPUT_MODE 		("DIFFERENTIAL"))
+oserdes_s (
+	.OQ       		(),
+	.OCE     		(1'b1),
+	.CLK0    		(ioclk),
+	.CLK1    		(1'b0),
+	.IOCE    		(serdesstrobe),
+	.RST     		(reset),
+	.CLKDIV  		(gclk),
+	.D4  			(mdatain[3]),
+	.D3  			(mdatain[2]),
+	.D2  			(mdatain[1]),
+	.D1  			(mdatain[0]),
+	.TQ  			(),
+	.T1 			(1'b0),
+	.T2 			(1'b0),
+	.T3  			(1'b0),
+	.T4  			(1'b0),
+	.TRAIN 			(1'b0),
+	.TCE	 		(1'b1),
+	.SHIFTIN1 		(cascade_di),		// Cascade input D from Master
+	.SHIFTIN2 		(cascade_ti),		// Cascade input T from Master
+	.SHIFTIN3 		(1'b1),			// Dummy input in Slave
+	.SHIFTIN4 		(1'b1),			// Dummy input in Slave
+	.SHIFTOUT1 		(),			// Dummy output in Slave
+	.SHIFTOUT2 		(),			// Dummy output in Slave
+	.SHIFTOUT3 		(cascade_do),   	// Cascade output D data to Master
+	.SHIFTOUT4 		(cascade_to)) ; 	// Cascade output T data to Master
+
+endmodule

--- a/systems/atlys/rtl/verilog/dvi_gen/synchro.v
+++ b/systems/atlys/rtl/verilog/dvi_gen/synchro.v
@@ -1,0 +1,93 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2006 Xilinx, Inc.
+// This design is confidential and proprietary of Xilinx, All Rights Reserved.
+//////////////////////////////////////////////////////////////////////////////
+//   ____  ____
+//  /   /\/   /
+// /___/  \  /   Vendor:        Xilinx
+// \   \   \/    Version:       1.0.0
+//  \   \        Filename:      synchro.v
+//  /   /        Date Created:  December 25, 2006
+// /___/   /\    Last Modified: December 25, 2006
+// \   \  /  \
+//  \___\/\___\
+//
+// Devices:   Spartan-3 Generation FPGA
+// Purpose:   Signal synchronizer, for async inputs
+// Contact:   crabill@xilinx.com
+// Reference: None
+//
+// Revision History:
+//   Rev 1.0.0 - (crabill) First created December 25, 2006.
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+// LIMITED WARRANTY AND DISCLAIMER. These designs are provided to you "as is".
+// Xilinx and its licensors make and you receive no warranties or conditions,
+// express, implied, statutory or otherwise, and Xilinx specifically disclaims
+// any implied warranties of merchantability, non-infringement, or fitness for
+// a particular purpose. Xilinx does not warrant that the functions contained
+// in these designs will meet your requirements, or that the operation of
+// these designs will be uninterrupted or error free, or that defects in the
+// designs will be corrected. Furthermore, Xilinx does not warrant or make any
+// representations regarding use or the results of the use of the designs in
+// terms of correctness, accuracy, reliability, or otherwise.
+//
+// LIMITATION OF LIABILITY. In no event will Xilinx or its licensors be liable
+// for any loss of data, lost profits, cost or procurement of substitute goods
+// or services, or for any special, incidental, consequential, or indirect
+// damages arising from the use or operation of the designs or accompanying
+// documentation, however caused and on any theory of liability. This
+// limitation will apply even if Xilinx has been advised of the possibility
+// of such damage. This limitation shall apply not-withstanding the failure
+// of the essential purpose of any limited remedies herein.
+//
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2006 Xilinx, Inc.
+// This design is confidential and proprietary of Xilinx, All Rights Reserved.
+//////////////////////////////////////////////////////////////////////////////
+
+`timescale 1 ns / 1 ps
+
+module synchro
+  #(
+  parameter          INITIALIZE = "LOGIC0"
+  )
+
+  (
+  input  wire        async,
+  input  wire        clk,
+  output wire        sync
+  );
+
+  //******************************************************************//
+  // Synchronizer.                                                    //
+  //******************************************************************//
+
+  wire        temp;
+
+  generate
+    if (INITIALIZE == "LOGIC1")
+    begin : use_fdp
+      FDP fda (.Q(temp),.D(async),.C(clk),.PRE(1'b0));
+      FDP fdb (.Q(sync),.D(temp),.C(clk),.PRE(1'b0));
+    end
+    else
+    begin : use_fdc
+      FDC fda (.Q(temp),.D(async),.C(clk),.CLR(1'b0));
+      FDC fdb (.Q(sync),.D(temp),.C(clk),.CLR(1'b0));
+    end
+  endgenerate
+
+  // synthesis attribute ASYNC_REG of fda is "TRUE";
+  // synthesis attribute ASYNC_REG of fdb is "TRUE";
+  // synthesis attribute HU_SET of fda is "SYNC";
+  // synthesis attribute HU_SET of fdb is "SYNC";
+  // synthesis attribute RLOC of fda is "X0Y0";
+  // synthesis attribute RLOC of fdb is "X0Y0";
+
+  //******************************************************************//
+  //                                                                  //
+  //******************************************************************//
+
+endmodule

--- a/systems/atlys/rtl/verilog/include/orpsoc-defines.v
+++ b/systems/atlys/rtl/verilog/include/orpsoc-defines.v
@@ -1,0 +1,19 @@
+//
+// orpsoc-defines
+//
+`define MOR1KX
+`ifndef MOR1KX
+`define OR1200
+`endif
+`define UART0
+`define SPI0
+`define VGA0
+`define ETH0
+`define AC97
+`define PS2_0
+`define PS2_1
+`define PS2_2
+`define JTAG_DEBUG
+`define RAM_WB
+`define BOOTROM
+// end of included module defines - keep this comment line here

--- a/systems/atlys/rtl/verilog/include/timescale.v
+++ b/systems/atlys/rtl/verilog/include/timescale.v
@@ -1,0 +1,1 @@
+`timescale 1ps/1ps

--- a/systems/atlys/rtl/verilog/include/uart_defines.v
+++ b/systems/atlys/rtl/verilog/include/uart_defines.v
@@ -1,0 +1,250 @@
+//////////////////////////////////////////////////////////////////////
+////                                                              ////
+////  uart_defines.v                                              ////
+////                                                              ////
+////                                                              ////
+////  This file is part of the "UART 16550 compatible" project    ////
+////  http://www.opencores.org/cores/uart16550/                   ////
+////                                                              ////
+////  Documentation related to this project:                      ////
+////  - http://www.opencores.org/cores/uart16550/                 ////
+////                                                              ////
+////  Projects compatibility:                                     ////
+////  - WISHBONE                                                  ////
+////  RS232 Protocol                                              ////
+////  16550D uart (mostly supported)                              ////
+////                                                              ////
+////  Overview (main Features):                                   ////
+////  Defines of the Core                                         ////
+////                                                              ////
+////  Known problems (limits):                                    ////
+////  None                                                        ////
+////                                                              ////
+////  To Do:                                                      ////
+////  Nothing.                                                    ////
+////                                                              ////
+////  Author(s):                                                  ////
+////      - gorban@opencores.org                                  ////
+////      - Jacob Gorban                                          ////
+////      - Igor Mohor (igorm@opencores.org)                      ////
+////                                                              ////
+////  Created:        2001/05/12                                  ////
+////  Last Updated:   2001/05/17                                  ////
+////                  (See log for the revision history)          ////
+////                                                              ////
+////                                                              ////
+//////////////////////////////////////////////////////////////////////
+////                                                              ////
+//// Copyright (C) 2000, 2001 Authors                             ////
+////                                                              ////
+//// This source file may be used and distributed without         ////
+//// restriction provided that this copyright statement is not    ////
+//// removed from the file and that any derivative work contains  ////
+//// the original copyright notice and the associated disclaimer. ////
+////                                                              ////
+//// This source file is free software; you can redistribute it   ////
+//// and/or modify it under the terms of the GNU Lesser General   ////
+//// Public License as published by the Free Software Foundation; ////
+//// either version 2.1 of the License, or (at your option) any   ////
+//// later version.                                               ////
+////                                                              ////
+//// This source is distributed in the hope that it will be       ////
+//// useful, but WITHOUT ANY WARRANTY; without even the implied   ////
+//// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR      ////
+//// PURPOSE.  See the GNU Lesser General Public License for more ////
+//// details.                                                     ////
+////                                                              ////
+//// You should have received a copy of the GNU Lesser General    ////
+//// Public License along with this source; if not, download it   ////
+//// from http://www.opencores.org/lgpl.shtml                     ////
+////                                                              ////
+//////////////////////////////////////////////////////////////////////
+//
+// CVS Revision History
+//
+// $Log: not supported by cvs2svn $
+// Revision 1.13  2003/06/11 16:37:47  gorban
+// This fixes errors in some cases when data is being read and put to the FIFO at the same time. Patch is submitted by Scott Furman. Update is very recommended.
+//
+// Revision 1.12  2002/07/22 23:02:23  gorban
+// Bug Fixes:
+//  * Possible loss of sync and bad reception of stop bit on slow baud rates fixed.
+//   Problem reported by Kenny.Tung.
+//  * Bad (or lack of ) loopback handling fixed. Reported by Cherry Withers.
+//
+// Improvements:
+//  * Made FIFO's as general inferrable memory where possible.
+//  So on FPGA they should be inferred as RAM (Distributed RAM on Xilinx).
+//  This saves about 1/3 of the Slice count and reduces P&R and synthesis times.
+//
+//  * Added optional baudrate output (baud_o).
+//  This is identical to BAUDOUT* signal on 16550 chip.
+//  It outputs 16xbit_clock_rate - the divided clock.
+//  It's disabled by default. Define UART_HAS_BAUDRATE_OUTPUT to use.
+//
+// Revision 1.10  2001/12/11 08:55:40  mohor
+// Scratch register define added.
+//
+// Revision 1.9  2001/12/03 21:44:29  gorban
+// Updated specification documentation.
+// Added full 32-bit data bus interface, now as default.
+// Address is 5-bit wide in 32-bit data bus mode.
+// Added wb_sel_i input to the core. It's used in the 32-bit mode.
+// Added debug interface with two 32-bit read-only registers in 32-bit mode.
+// Bits 5 and 6 of LSR are now only cleared on TX FIFO write.
+// My small test bench is modified to work with 32-bit mode.
+//
+// Revision 1.8  2001/11/26 21:38:54  gorban
+// Lots of fixes:
+// Break condition wasn't handled correctly at all.
+// LSR bits could lose their values.
+// LSR value after reset was wrong.
+// Timing of THRE interrupt signal corrected.
+// LSR bit 0 timing corrected.
+//
+// Revision 1.7  2001/08/24 21:01:12  mohor
+// Things connected to parity changed.
+// Clock devider changed.
+//
+// Revision 1.6  2001/08/23 16:05:05  mohor
+// Stop bit bug fixed.
+// Parity bug fixed.
+// WISHBONE read cycle bug fixed,
+// OE indicator (Overrun Error) bug fixed.
+// PE indicator (Parity Error) bug fixed.
+// Register read bug fixed.
+//
+// Revision 1.5  2001/05/31 20:08:01  gorban
+// FIFO changes and other corrections.
+//
+// Revision 1.4  2001/05/21 19:12:02  gorban
+// Corrected some Linter messages.
+//
+// Revision 1.3  2001/05/17 18:34:18  gorban
+// First 'stable' release. Should be sythesizable now. Also added new header.
+//
+// Revision 1.0  2001-05-17 21:27:11+02  jacob
+// Initial revision
+//
+//
+
+// remove comments to restore to use the new version with 8 data bit interface
+// in 32bit-bus mode, the wb_sel_i signal is used to put data in correct place
+// also, in 8-bit version there'll be no debugging features included
+// CAUTION: doesn't work with current version of OR1200
+`define DATA_BUS_WIDTH_8
+
+`ifdef DATA_BUS_WIDTH_8
+ `define UART_ADDR_WIDTH 3
+ `define UART_DATA_WIDTH 8
+`else
+ `define UART_ADDR_WIDTH 5
+ `define UART_DATA_WIDTH 32
+`endif
+
+// Uncomment this if you want your UART to have
+// 16xBaudrate output port.
+// If defined, the enable signal will be used to drive baudrate_o signal
+// It's frequency is 16xbaudrate
+
+// `define UART_HAS_BAUDRATE_OUTPUT
+
+// Register addresses
+`define UART_REG_RB	`UART_ADDR_WIDTH'd0	// receiver buffer
+`define UART_REG_TR  `UART_ADDR_WIDTH'd0	// transmitter
+`define UART_REG_IE	`UART_ADDR_WIDTH'd1	// Interrupt enable
+`define UART_REG_II  `UART_ADDR_WIDTH'd2	// Interrupt identification
+`define UART_REG_FC  `UART_ADDR_WIDTH'd2	// FIFO control
+`define UART_REG_LC	`UART_ADDR_WIDTH'd3	// Line Control
+`define UART_REG_MC	`UART_ADDR_WIDTH'd4	// Modem control
+`define UART_REG_LS  `UART_ADDR_WIDTH'd5	// Line status
+`define UART_REG_MS  `UART_ADDR_WIDTH'd6	// Modem status
+`define UART_REG_SR  `UART_ADDR_WIDTH'd7	// Scratch register
+`define UART_REG_DL1	`UART_ADDR_WIDTH'd0	// Divisor latch bytes (1-2)
+`define UART_REG_DL2	`UART_ADDR_WIDTH'd1
+
+// Interrupt Enable register bits
+`define UART_IE_RDA	0	// Received Data available interrupt
+`define UART_IE_THRE	1	// Transmitter Holding Register empty interrupt
+`define UART_IE_RLS	2	// Receiver Line Status Interrupt
+`define UART_IE_MS	3	// Modem Status Interrupt
+
+// Interrupt Identification register bits
+`define UART_II_IP	0	// Interrupt pending when 0
+`define UART_II_II	3:1	// Interrupt identification
+
+// Interrupt identification values for bits 3:1
+`define UART_II_RLS	3'b011	// Receiver Line Status
+`define UART_II_RDA	3'b010	// Receiver Data available
+`define UART_II_TI	3'b110	// Timeout Indication
+`define UART_II_THRE	3'b001	// Transmitter Holding Register empty
+`define UART_II_MS	3'b000	// Modem Status
+
+// FIFO Control Register bits
+`define UART_FC_TL	1:0	// Trigger level
+
+// FIFO trigger level values
+`define UART_FC_1		2'b00
+`define UART_FC_4		2'b01
+`define UART_FC_8		2'b10
+`define UART_FC_14	2'b11
+
+// Line Control register bits
+`define UART_LC_BITS	1:0	// bits in character
+`define UART_LC_SB	2	// stop bits
+`define UART_LC_PE	3	// parity enable
+`define UART_LC_EP	4	// even parity
+`define UART_LC_SP	5	// stick parity
+`define UART_LC_BC	6	// Break control
+`define UART_LC_DL	7	// Divisor Latch access bit
+
+// Modem Control register bits
+`define UART_MC_DTR	0
+`define UART_MC_RTS	1
+`define UART_MC_OUT1	2
+`define UART_MC_OUT2	3
+`define UART_MC_LB	4	// Loopback mode
+
+// Line Status Register bits
+`define UART_LS_DR	0	// Data ready
+`define UART_LS_OE	1	// Overrun Error
+`define UART_LS_PE	2	// Parity Error
+`define UART_LS_FE	3	// Framing Error
+`define UART_LS_BI	4	// Break interrupt
+`define UART_LS_TFE	5	// Transmit FIFO is empty
+`define UART_LS_TE	6	// Transmitter Empty indicator
+`define UART_LS_EI	7	// Error indicator
+
+// Modem Status Register bits
+`define UART_MS_DCTS	0	// Delta signals
+`define UART_MS_DDSR	1
+`define UART_MS_TERI	2
+`define UART_MS_DDCD	3
+`define UART_MS_CCTS	4	// Complement signals
+`define UART_MS_CDSR	5
+`define UART_MS_CRI	6
+`define UART_MS_CDCD	7
+
+// FIFO parameter defines
+
+`define UART_FIFO_WIDTH	8
+`define UART_FIFO_DEPTH	16
+`define UART_FIFO_POINTER_W	4
+`define UART_FIFO_COUNTER_W	5
+// receiver fifo has width 11 because it has break, parity and framing error bits
+`define UART_FIFO_REC_WIDTH  11
+
+
+`define VERBOSE_WB  0           // All activity on the WISHBONE is recorded
+`define VERBOSE_LINE_STATUS 0   // Details about the lsr (line status register)
+`define FAST_TEST   1           // 64/1024 packets are sent
+
+// Defines hard baud prescaler register - uncomment to enable
+//`define PRESCALER_PRESET_HARD
+// 115200 baud preset values
+// 20MHz: prescaler 10.8 (11, rounded up)
+//`define PRESCALER_HIGH_PRESET 8'd0
+//`define PRESCALER_LOW_PRESET 8'd11
+// 50MHz: prescaler 27.1
+//`define PRESCALER_HIGH_PRESET 8'd0
+//`define PRESCALER_LOW_PRESET 8'd27

--- a/systems/atlys/rtl/verilog/include/xilinx_ddr2_params.v
+++ b/systems/atlys/rtl/verilog/include/xilinx_ddr2_params.v
@@ -1,0 +1,26 @@
+   parameter C3_P0_MASK_SIZE         = 4;
+   parameter C3_P0_DATA_PORT_SIZE    = 32;
+   parameter C3_P1_MASK_SIZE         = 4;
+   parameter C3_P1_DATA_PORT_SIZE    = 32;
+   parameter DEBUG_EN                = 0;
+   parameter C3_MEMCLK_PERIOD        = 3750;       
+   parameter C3_CALIB_SOFT_IP        = "TRUE";       
+   parameter C3_SIMULATION           = "FALSE";       
+   parameter C3_RST_ACT_LOW          = 0;
+   parameter C3_INPUT_CLK_TYPE       = "SINGLE_ENDED";       
+   parameter C3_MEM_ADDR_ORDER       = "BANK_ROW_COLUMN";       
+   parameter C3_NUM_DQ_PINS          = 16;       
+   parameter C3_MEM_ADDR_WIDTH       = 13;       
+   parameter C3_MEM_BANKADDR_WIDTH   = 3;
+   
+   // Simulation parameter defines
+   parameter DQ_WIDTH                = 16;
+   parameter DQS_WIDTH               = 1;
+   parameter DM_WIDTH                = 1;
+   parameter CLK_WIDTH               = 1;
+   parameter ROW_WIDTH               = 13;
+   parameter BANK_WIDTH              = 3;
+   parameter CKE_WIDTH               = 1;
+   parameter ODT_WIDTH               = 1;
+
+     

--- a/systems/atlys/rtl/verilog/orpsoc_top.v
+++ b/systems/atlys/rtl/verilog/orpsoc_top.v
@@ -1,0 +1,1114 @@
+//////////////////////////////////////////////////////////////////////
+///                                                               ////
+/// ORPSoC top for Atlys board                                    ////
+///                                                               ////
+/// Instantiates modules, depending on ORPSoC defines file        ////
+///                                                               ////
+/// Copyright (C) 2013 Stefan Kristiansson                        ////
+///  <stefan.kristiansson@saunalahti.fi                           ////
+///                                                               ////
+//////////////////////////////////////////////////////////////////////
+//// This source file may be used and distributed without         ////
+//// restriction provided that this copyright statement is not    ////
+//// removed from the file and that any derivative work contains  ////
+//// the original copyright notice and the associated disclaimer. ////
+////                                                              ////
+//// This source file is free software; you can redistribute it   ////
+//// and/or modify it under the terms of the GNU Lesser General   ////
+//// Public License as published by the Free Software Foundation; ////
+//// either version 2.1 of the License, or (at your option) any   ////
+//// later version.                                               ////
+////                                                              ////
+//// This source is distributed in the hope that it will be       ////
+//// useful, but WITHOUT ANY WARRANTY; without even the implied   ////
+//// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR      ////
+//// PURPOSE.  See the GNU Lesser General Public License for more ////
+//// details.                                                     ////
+////                                                              ////
+//// You should have received a copy of the GNU Lesser General    ////
+//// Public License along with this source; if not, download it   ////
+//// from http://www.opencores.org/lgpl.shtml                     ////
+////                                                              ////
+//////////////////////////////////////////////////////////////////////
+
+`include "orpsoc-defines.v"
+
+module orpsoc_top #(
+	parameter	rom0_aw = 6,
+	parameter	uart0_aw = 3
+)(
+	input		sys_clk_pad_i,
+	input		rst_n_pad_i,
+
+	// JTAG
+	output		tdo_pad_o,
+	input		tms_pad_i,
+	input		tck_pad_i,
+	input		tdi_pad_i,
+
+	// Ethernet
+	input		eth0_tx_clk,
+	output [3:0]	eth0_tx_data,
+	output		eth0_tx_en,
+	output		eth0_tx_er,
+	input		eth0_rx_clk,
+	input [3:0]	eth0_rx_data,
+	input		eth0_dv,
+	input		eth0_rx_er,
+	input		eth0_col,
+	input		eth0_crs,
+	output		eth0_mdc_pad_o,
+	inout		eth0_md_pad_io,
+	output		eth0_rst_n_o,
+
+	// DVI
+	output [3:0]	tmds_o,
+	output [3:0]	tmdsb_o,
+
+	// DDR2
+	output [12:0]	ddr2_a,
+	output [2:0]	ddr2_ba,
+	output		ddr2_ras_n,
+	output		ddr2_cas_n,
+	output		ddr2_we_n,
+	output		ddr2_rzq,
+	output		ddr2_zio,
+	output		ddr2_odt,
+	output		ddr2_cke,
+	output		ddr2_dm,
+	output		ddr2_udm,
+	inout [15:0]	ddr2_dq,
+	inout		ddr2_dqs,
+	inout		ddr2_dqs_n,
+	inout		ddr2_udqs,
+	inout		ddr2_udqs_n,
+	output		ddr2_ck,
+	output		ddr2_ck_n,
+
+	// UART
+	input		uart0_srx_pad_i,
+	output		uart0_stx_pad_o,
+
+	// GPIO
+	inout	[7:0]	gpio0_io,
+
+	// SPI
+	output		spi0_sck_o,
+	output		spi0_mosi_o,
+	input		spi0_miso_i,
+	output [0:0]	spi0_ss_o,
+
+	// AC97
+	input		ac97_bit_clk_pad_i,
+	output		ac97_sync_pad_o,
+	output		ac97_sdata_pad_o,
+	input		ac97_sdata_pad_i,
+	output		ac97_reset_pad_o,
+
+	// PS2
+	inout		ps2_0_clk,
+	inout		ps2_0_dat,
+
+	inout		ps2_1_clk,
+	inout		ps2_1_dat,
+
+	inout		ps2_2_clk,
+	inout		ps2_2_dat
+);
+
+parameter	IDCODE_VALUE=32'h14951185;
+
+////////////////////////////////////////////////////////////////////////
+//
+// Clock and reset generation module
+//
+////////////////////////////////////////////////////////////////////////
+
+wire	async_rst;
+wire	wb_clk, wb_rst;
+wire	dbg_tck;
+
+wire	dvi_clk;
+
+wire	ddr2_if_clk;
+wire	ddr2_if_rst;
+wire	clk100;
+
+clkgen clkgen0 (
+	.sys_clk_pad_i	(sys_clk_pad_i),
+	.rst_n_pad_i	(rst_n_pad_i),
+	.async_rst_o	(async_rst),
+	.wb_clk_o	(wb_clk),
+	.wb_rst_o	(wb_rst),
+
+	.tck_pad_i	(tck_pad_i),
+	.dbg_tck_o	(dbg_tck),
+
+	.dvi_clk_o	(dvi_clk),
+
+	.ddr2_if_clk_o	(ddr2_if_clk),
+	.ddr2_if_rst_o	(ddr2_if_rst),
+	.clk100_o	(clk100)
+);
+
+////////////////////////////////////////////////////////////////////////
+//
+// Modules interconnections
+//
+////////////////////////////////////////////////////////////////////////
+`include "wb_intercon.vh"
+
+`ifdef JTAG_DEBUG
+////////////////////////////////////////////////////////////////////////
+//
+// GENERIC JTAG TAP
+//
+////////////////////////////////////////////////////////////////////////
+
+wire	dbg_if_select;
+wire	dbg_if_tdo;
+wire	jtag_tap_tdo;
+wire	jtag_tap_shift_dr;
+wire	jtag_tap_pause_dr;
+wire	jtag_tap_update_dr;
+wire	jtag_tap_capture_dr;
+
+tap_top jtag_tap0 (
+	.tdo_pad_o			(tdo_pad_o),
+	.tms_pad_i			(tms_pad_i),
+	.tck_pad_i			(dbg_tck),
+	.trst_pad_i			(async_rst),
+	.tdi_pad_i			(tdi_pad_i),
+
+	.tdo_padoe_o			(tdo_padoe_o),
+
+	.tdo_o				(jtag_tap_tdo),
+
+	.shift_dr_o			(jtag_tap_shift_dr),
+	.pause_dr_o			(jtag_tap_pause_dr),
+	.update_dr_o			(jtag_tap_update_dr),
+	.capture_dr_o			(jtag_tap_capture_dr),
+
+	.extest_select_o		(),
+	.sample_preload_select_o	(),
+	.mbist_select_o			(),
+	.debug_select_o			(dbg_if_select),
+
+
+	.bs_chain_tdi_i			(1'b0),
+	.mbist_tdi_i			(1'b0),
+	.debug_tdi_i			(dbg_if_tdo)
+);
+
+`endif
+
+////////////////////////////////////////////////////////////////////////
+//
+// OR1K CPU
+//
+////////////////////////////////////////////////////////////////////////
+
+wire	[31:0]	or1k_irq;
+
+wire	[31:0]	or1k_dbg_dat_i;
+wire	[31:0]	or1k_dbg_adr_i;
+wire		or1k_dbg_we_i;
+wire		or1k_dbg_stb_i;
+wire		or1k_dbg_ack_o;
+wire	[31:0]	or1k_dbg_dat_o;
+
+wire		or1k_dbg_stall_i;
+wire		or1k_dbg_ewt_i;
+wire	[3:0]	or1k_dbg_lss_o;
+wire	[1:0]	or1k_dbg_is_o;
+wire	[10:0]	or1k_dbg_wp_o;
+wire		or1k_dbg_bp_o;
+wire		or1k_dbg_rst;
+
+wire		sig_tick;
+
+wire		or1k_rst;
+
+assign or1k_rst = wb_rst | or1k_dbg_rst;
+
+`ifdef OR1200
+
+or1200_top #(.boot_adr(32'hf0000100))
+or1200_top0 (
+	// Instruction bus, clocks, reset
+	.iwb_clk_i			(wb_clk),
+	.iwb_rst_i			(wb_rst),
+	.iwb_ack_i			(wb_s2m_or1k_i_ack),
+	.iwb_err_i			(wb_s2m_or1k_i_err),
+	.iwb_rty_i			(wb_s2m_or1k_i_rty),
+	.iwb_dat_i			(wb_s2m_or1k_i_dat),
+
+	.iwb_cyc_o			(wb_m2s_or1k_i_cyc),
+	.iwb_adr_o			(wb_m2s_or1k_i_adr),
+	.iwb_stb_o			(wb_m2s_or1k_i_stb),
+	.iwb_we_o			(wb_m2s_or1k_i_we),
+	.iwb_sel_o			(wb_m2s_or1k_i_sel),
+	.iwb_dat_o			(wb_m2s_or1k_i_dat),
+	.iwb_cti_o			(wb_m2s_or1k_i_cti),
+	.iwb_bte_o			(wb_m2s_or1k_i_bte),
+
+	// Data bus, clocks, reset
+	.dwb_clk_i			(wb_clk),
+	.dwb_rst_i			(wb_rst),
+	.dwb_ack_i			(wb_s2m_or1k_d_ack),
+	.dwb_err_i			(wb_s2m_or1k_d_err),
+	.dwb_rty_i			(wb_s2m_or1k_d_rty),
+	.dwb_dat_i			(wb_s2m_or1k_d_dat),
+
+	.dwb_cyc_o			(wb_m2s_or1k_d_cyc),
+	.dwb_adr_o			(wb_m2s_or1k_d_adr),
+	.dwb_stb_o			(wb_m2s_or1k_d_stb),
+	.dwb_we_o			(wb_m2s_or1k_d_we),
+	.dwb_sel_o			(wb_m2s_or1k_d_sel),
+	.dwb_dat_o			(wb_m2s_or1k_d_dat),
+	.dwb_cti_o			(wb_m2s_or1k_d_cti),
+	.dwb_bte_o			(wb_m2s_or1k_d_bte),
+
+	// Debug interface ports
+	.dbg_stall_i			(or1k_dbg_stall_i),
+	.dbg_ewt_i			(1'b0),
+	.dbg_lss_o			(or1k_dbg_lss_o),
+	.dbg_is_o			(or1k_dbg_is_o),
+	.dbg_wp_o			(or1k_dbg_wp_o),
+	.dbg_bp_o			(or1k_dbg_bp_o),
+
+	.dbg_adr_i			(or1k_dbg_adr_i),
+	.dbg_we_i			(or1k_dbg_we_i),
+	.dbg_stb_i			(or1k_dbg_stb_i),
+	.dbg_dat_i			(or1k_dbg_dat_i),
+	.dbg_dat_o			(or1k_dbg_dat_o),
+	.dbg_ack_o			(or1k_dbg_ack_o),
+
+	.pm_clksd_o			(),
+	.pm_dc_gate_o			(),
+	.pm_ic_gate_o			(),
+	.pm_dmmu_gate_o			(),
+	.pm_immu_gate_o			(),
+	.pm_tt_gate_o			(),
+	.pm_cpu_gate_o			(),
+	.pm_wakeup_o			(),
+	.pm_lvolt_o			(),
+
+	// Core clocks, resets
+	.clk_i				(wb_clk),
+	.rst_i				(or1k_rst),
+
+	.clmode_i			(2'b00),
+
+	// Interrupts
+	.pic_ints_i			(or1k_irq),
+	.sig_tick			(sig_tick),
+
+	.pm_cpustall_i			(1'b0)
+);
+`endif
+
+`ifdef MOR1KX
+mor1kx #(
+	.FEATURE_DEBUGUNIT("ENABLED"),
+	.FEATURE_CMOV("ENABLED"),
+	.FEATURE_INSTRUCTIONCACHE("ENABLED"),
+	.OPTION_ICACHE_BLOCK_WIDTH(5),
+	.OPTION_ICACHE_SET_WIDTH(8),
+	.OPTION_ICACHE_WAYS(4),
+	.OPTION_ICACHE_LIMIT_WIDTH(32),
+	.FEATURE_IMMU("ENABLED"),
+	.FEATURE_DATACACHE("ENABLED"),
+	.OPTION_DCACHE_BLOCK_WIDTH(5),
+	.OPTION_DCACHE_SET_WIDTH(8),
+	.OPTION_DCACHE_WAYS(4),
+	.OPTION_DCACHE_LIMIT_WIDTH(31),
+	.FEATURE_DMMU("ENABLED"),
+	.OPTION_PIC_TRIGGER("LATCHED_LEVEL"),
+
+	.IBUS_WB_TYPE("B3_REGISTERED_FEEDBACK"),
+	.DBUS_WB_TYPE("B3_REGISTERED_FEEDBACK"),
+	.OPTION_CPU0("CAPPUCCINO"),
+	.OPTION_RESET_PC(32'hf0000100)
+) mor1kx0 (
+	.iwbm_adr_o(wb_m2s_or1k_i_adr),
+	.iwbm_stb_o(wb_m2s_or1k_i_stb),
+	.iwbm_cyc_o(wb_m2s_or1k_i_cyc),
+	.iwbm_sel_o(wb_m2s_or1k_i_sel),
+	.iwbm_we_o (wb_m2s_or1k_i_we),
+	.iwbm_cti_o(wb_m2s_or1k_i_cti),
+	.iwbm_bte_o(wb_m2s_or1k_i_bte),
+	.iwbm_dat_o(wb_m2s_or1k_i_dat),
+
+	.dwbm_adr_o(wb_m2s_or1k_d_adr),
+	.dwbm_stb_o(wb_m2s_or1k_d_stb),
+	.dwbm_cyc_o(wb_m2s_or1k_d_cyc),
+	.dwbm_sel_o(wb_m2s_or1k_d_sel),
+	.dwbm_we_o (wb_m2s_or1k_d_we ),
+	.dwbm_cti_o(wb_m2s_or1k_d_cti),
+	.dwbm_bte_o(wb_m2s_or1k_d_bte),
+	.dwbm_dat_o(wb_m2s_or1k_d_dat),
+
+	.clk(wb_clk),
+	.rst(or1k_rst),
+
+	.iwbm_err_i(wb_s2m_or1k_i_err),
+	.iwbm_ack_i(wb_s2m_or1k_i_ack),
+	.iwbm_dat_i(wb_s2m_or1k_i_dat),
+	.iwbm_rty_i(wb_s2m_or1k_i_rty),
+
+	.dwbm_err_i(wb_s2m_or1k_d_err),
+	.dwbm_ack_i(wb_s2m_or1k_d_ack),
+	.dwbm_dat_i(wb_s2m_or1k_d_dat),
+	.dwbm_rty_i(wb_s2m_or1k_d_rty),
+
+	.irq_i(or1k_irq),
+
+	.du_addr_i(or1k_dbg_adr_i[15:0]),
+	.du_stb_i(or1k_dbg_stb_i),
+	.du_dat_i(or1k_dbg_dat_i),
+	.du_we_i(or1k_dbg_we_i),
+	.du_dat_o(or1k_dbg_dat_o),
+	.du_ack_o(or1k_dbg_ack_o),
+	.du_stall_i(or1k_dbg_stall_i),
+	.du_stall_o(or1k_dbg_bp_o)
+);
+
+`endif
+////////////////////////////////////////////////////////////////////////
+//
+// Debug Interface
+//
+////////////////////////////////////////////////////////////////////////
+
+adbg_top dbg_if0 (
+	// OR1K interface
+	.cpu0_clk_i	(wb_clk),
+	.cpu0_rst_o	(or1k_dbg_rst),
+	.cpu0_addr_o	(or1k_dbg_adr_i),
+	.cpu0_data_o	(or1k_dbg_dat_i),
+	.cpu0_stb_o	(or1k_dbg_stb_i),
+	.cpu0_we_o	(or1k_dbg_we_i),
+	.cpu0_data_i	(or1k_dbg_dat_o),
+	.cpu0_ack_i	(or1k_dbg_ack_o),
+	.cpu0_stall_o	(or1k_dbg_stall_i),
+	.cpu0_bp_i	(or1k_dbg_bp_o),
+
+	// TAP interface
+	.tck_i		(dbg_tck),
+	.tdi_i		(jtag_tap_tdo),
+	.tdo_o		(dbg_if_tdo),
+	.rst_i		(wb_rst),
+	.capture_dr_i	(jtag_tap_capture_dr),
+	.shift_dr_i	(jtag_tap_shift_dr),
+	.pause_dr_i	(jtag_tap_pause_dr),
+	.update_dr_i	(jtag_tap_update_dr),
+	.debug_select_i	(dbg_if_select),
+
+	// Wishbone debug master
+	.wb_rst_i	(wb_rst),
+	.wb_clk_i	(wb_clk),
+	.wb_dat_i	(wb_s2m_dbg_dat),
+	.wb_ack_i	(wb_s2m_dbg_ack),
+	.wb_err_i	(wb_s2m_dbg_err),
+
+	.wb_adr_o	(wb_m2s_dbg_adr),
+	.wb_dat_o	(wb_m2s_dbg_dat),
+	.wb_cyc_o	(wb_m2s_dbg_cyc),
+	.wb_stb_o	(wb_m2s_dbg_stb),
+	.wb_sel_o	(wb_m2s_dbg_sel),
+	.wb_we_o	(wb_m2s_dbg_we),
+	.wb_cti_o	(wb_m2s_dbg_cti),
+	.wb_bte_o	(wb_m2s_dbg_bte)
+);
+
+////////////////////////////////////////////////////////////////////////
+//
+// ROM
+//
+////////////////////////////////////////////////////////////////////////
+
+assign	wb_s2m_rom0_err = 1'b0;
+assign	wb_s2m_rom0_rty = 1'b0;
+
+`ifdef BOOTROM
+rom #(.addr_width(rom0_aw))
+rom0 (
+	.wb_clk		(wb_clk),
+	.wb_rst		(wb_rst),
+	.wb_adr_i	(wb_m2s_rom0_adr[(rom0_aw + 2) - 1 : 2]),
+	.wb_cyc_i	(wb_m2s_rom0_cyc),
+	.wb_stb_i	(wb_m2s_rom0_stb),
+	.wb_cti_i	(wb_m2s_rom0_cti),
+	.wb_bte_i	(wb_m2s_rom0_bte),
+	.wb_dat_o	(wb_s2m_rom0_dat),
+	.wb_ack_o	(wb_s2m_rom0_ack)
+);
+`else
+assign	wb_s2m_rom0_dat_o = 0;
+assign	wb_s2m_rom0_ack_o = 0;
+`endif
+
+////////////////////////////////////////////////////////////////////////
+//
+// DDR2 SDRAM Memory Controller
+//
+////////////////////////////////////////////////////////////////////////
+
+xilinx_ddr2 xilinx_ddr2_0 (
+	.wbm0_adr_i	(wb_m2s_ddr2_eth0_adr),
+	.wbm0_bte_i	(wb_m2s_ddr2_eth0_bte),
+	.wbm0_cti_i	(wb_m2s_ddr2_eth0_cti),
+	.wbm0_cyc_i	(wb_m2s_ddr2_eth0_cyc),
+	.wbm0_dat_i	(wb_m2s_ddr2_eth0_dat),
+	.wbm0_sel_i	(wb_m2s_ddr2_eth0_sel),
+	.wbm0_stb_i	(wb_m2s_ddr2_eth0_stb),
+	.wbm0_we_i	(wb_m2s_ddr2_eth0_we),
+	.wbm0_ack_o	(wb_s2m_ddr2_eth0_ack),
+	.wbm0_err_o	(wb_s2m_ddr2_eth0_err),
+	.wbm0_rty_o	(wb_s2m_ddr2_eth0_rty),
+	.wbm0_dat_o	(wb_s2m_ddr2_eth0_dat),
+
+	.wbm1_adr_i	(wb_m2s_ddr2_dbus_adr),
+	.wbm1_bte_i	(wb_m2s_ddr2_dbus_bte),
+	.wbm1_cti_i	(wb_m2s_ddr2_dbus_cti),
+	.wbm1_cyc_i	(wb_m2s_ddr2_dbus_cyc),
+	.wbm1_dat_i	(wb_m2s_ddr2_dbus_dat),
+	.wbm1_sel_i	(wb_m2s_ddr2_dbus_sel),
+	.wbm1_stb_i	(wb_m2s_ddr2_dbus_stb),
+	.wbm1_we_i	(wb_m2s_ddr2_dbus_we),
+	.wbm1_ack_o	(wb_s2m_ddr2_dbus_ack),
+	.wbm1_err_o	(wb_s2m_ddr2_dbus_err),
+	.wbm1_rty_o	(wb_s2m_ddr2_dbus_rty),
+	.wbm1_dat_o	(wb_s2m_ddr2_dbus_dat),
+
+	.wbm2_adr_i	(wb_m2s_ddr2_ibus_adr),
+	.wbm2_bte_i	(wb_m2s_ddr2_ibus_bte),
+	.wbm2_cti_i	(wb_m2s_ddr2_ibus_cti),
+	.wbm2_cyc_i	(wb_m2s_ddr2_ibus_cyc),
+	.wbm2_dat_i	(wb_m2s_ddr2_ibus_dat),
+	.wbm2_sel_i	(wb_m2s_ddr2_ibus_sel),
+	.wbm2_stb_i	(wb_m2s_ddr2_ibus_stb),
+	.wbm2_we_i	(wb_m2s_ddr2_ibus_we),
+	.wbm2_ack_o	(wb_s2m_ddr2_ibus_ack),
+	.wbm2_err_o	(wb_s2m_ddr2_ibus_err),
+	.wbm2_rty_o	(wb_s2m_ddr2_ibus_rty),
+	.wbm2_dat_o	(wb_s2m_ddr2_ibus_dat),
+
+	.wbm3_adr_i	(wb_m2s_ddr2_vga0_adr),
+	.wbm3_bte_i	(wb_m2s_ddr2_vga0_bte),
+	.wbm3_cti_i	(wb_m2s_ddr2_vga0_cti),
+	.wbm3_cyc_i	(wb_m2s_ddr2_vga0_cyc),
+	.wbm3_dat_i	(wb_m2s_ddr2_vga0_dat),
+	.wbm3_sel_i	(wb_m2s_ddr2_vga0_sel),
+	.wbm3_stb_i	(wb_m2s_ddr2_vga0_stb),
+	.wbm3_we_i	(wb_m2s_ddr2_vga0_we),
+	.wbm3_ack_o	(wb_s2m_ddr2_vga0_ack),
+	.wbm3_err_o	(wb_s2m_ddr2_vga0_err),
+	.wbm3_rty_o	(wb_s2m_ddr2_vga0_rty),
+	.wbm3_dat_o	(wb_s2m_ddr2_vga0_dat),
+
+	.wbm4_adr_i	(0),
+	.wbm4_bte_i	(0),
+	.wbm4_cti_i	(0),
+	.wbm4_cyc_i	(0),
+	.wbm4_dat_i	(0),
+	.wbm4_sel_i	(0),
+	.wbm4_stb_i	(0),
+	.wbm4_we_i	(0),
+	.wbm4_ack_o	(),
+	.wbm4_err_o	(),
+	.wbm4_rty_o	(),
+	.wbm4_dat_o	(),
+
+	.wb_clk		(wb_clk),
+	.wb_rst		(wb_rst),
+
+	.ddr2_a		(ddr2_a[12:0]),
+	.ddr2_ba	(ddr2_ba),
+	.ddr2_ras_n	(ddr2_ras_n),
+	.ddr2_cas_n	(ddr2_cas_n),
+	.ddr2_we_n	(ddr2_we_n),
+	.ddr2_rzq	(ddr2_rzq),
+	.ddr2_zio	(ddr2_zio),
+	.ddr2_odt	(ddr2_odt),
+	.ddr2_cke	(ddr2_cke),
+	.ddr2_dm	(ddr2_dm),
+	.ddr2_udm	(ddr2_udm),
+	.ddr2_ck	(ddr2_ck),
+	.ddr2_ck_n	(ddr2_ck_n),
+	.ddr2_dq	(ddr2_dq),
+	.ddr2_dqs	(ddr2_dqs),
+	.ddr2_dqs_n	(ddr2_dqs_n),
+	.ddr2_udqs	(ddr2_udqs),
+	.ddr2_udqs_n	(ddr2_udqs_n),
+	.ddr2_if_clk	(ddr2_if_clk),
+	.ddr2_if_rst	(ddr2_if_rst)
+);
+
+////////////////////////////////////////////////////////////////////////
+//
+// UART0
+//
+////////////////////////////////////////////////////////////////////////
+
+wire	uart0_irq;
+
+uart_top uart16550_0 (
+	// Wishbone slave interface
+	.wb_clk_i	(wb_clk),
+	.wb_rst_i	(wb_rst),
+	.wb_adr_i	(wb_m2s_uart0_adr[uart0_aw-1:0]),
+	.wb_dat_i	(wb_m2s_uart0_dat),
+	.wb_we_i	(wb_m2s_uart0_we),
+	.wb_stb_i	(wb_m2s_uart0_stb),
+	.wb_cyc_i	(wb_m2s_uart0_cyc),
+	.wb_sel_i	(4'b0), // Not used in 8-bit mode
+	.wb_dat_o	(wb_s2m_uart0_dat),
+	.wb_ack_o	(wb_s2m_uart0_ack),
+
+	// Outputs
+	.int_o		(uart0_irq),
+	.stx_pad_o	(uart0_stx_pad_o),
+	.rts_pad_o	(),
+	.dtr_pad_o	(),
+
+	// Inputs
+	.srx_pad_i	(uart0_srx_pad_i),
+	.cts_pad_i	(1'b0),
+	.dsr_pad_i	(1'b0),
+	.ri_pad_i	(1'b0),
+	.dcd_pad_i	(1'b0)
+);
+
+`ifdef SPI0
+////////////////////////////////////////////////////////////////////////
+//
+// SPI0 controller
+//
+////////////////////////////////////////////////////////////////////////
+
+//
+// Wires
+//
+wire            spi0_irq;
+
+//
+// Assigns
+//
+assign  wb_s2m_spi0_err = 0;
+assign  wb_s2m_spi0_rty = 0;
+assign  spi0_hold_n_o = 1;
+assign  spi0_w_n_o = 1;
+
+simple_spi spi0(
+	// Wishbone slave interface
+	.clk_i	(wb_clk),
+	.rst_i	(wb_rst),
+	.adr_i	(wb_m2s_spi0_adr[2:0]),
+	.dat_i	(wb_m2s_spi0_dat),
+	.we_i	(wb_m2s_spi0_we),
+	.stb_i	(wb_m2s_spi0_stb),
+	.cyc_i	(wb_m2s_spi0_cyc),
+	.dat_o	(wb_s2m_spi0_dat),
+	.ack_o	(wb_s2m_spi0_ack),
+
+	// Outputs
+	.inta_o		(spi0_irq),
+	.sck_o		(spi0_sck_o),
+	.ss_o		(spi0_ss_o[0]),
+	.mosi_o		(spi0_mosi_o),
+
+	// Inputs
+	.miso_i		(spi0_miso_i)
+);
+
+`endif
+
+////////////////////////////////////////////////////////////////////////
+//
+// GPIO 0
+//
+////////////////////////////////////////////////////////////////////////
+
+wire [7:0]	gpio0_in;
+wire [7:0]	gpio0_out;
+wire [7:0]	gpio0_dir;
+
+// Tristate logic for IO
+// 0 = input, 1 = output
+genvar                    i;
+generate
+	for (i = 0; i < 8; i = i+1) begin: gpio0_tris
+		assign gpio0_io[i] = gpio0_dir[i] ? gpio0_out[i] : 1'bz;
+		assign gpio0_in[i] = gpio0_dir[i] ? gpio0_out[i] : gpio0_io[i];
+	end
+endgenerate
+
+gpio gpio0 (
+	// GPIO bus
+	.gpio_i		(gpio0_in),
+	.gpio_o		(gpio0_out),
+	.gpio_dir_o	(gpio0_dir),
+	// Wishbone slave interface
+	.wb_adr_i	(wb_m2s_gpio0_adr[0]),
+	.wb_dat_i	(wb_m2s_gpio0_dat),
+	.wb_we_i	(wb_m2s_gpio0_we),
+	.wb_cyc_i	(wb_m2s_gpio0_cyc),
+	.wb_stb_i	(wb_m2s_gpio0_stb),
+	.wb_cti_i	(wb_m2s_gpio0_cti),
+	.wb_bte_i	(wb_m2s_gpio0_bte),
+	.wb_dat_o	(wb_s2m_gpio0_dat),
+	.wb_ack_o	(wb_s2m_gpio0_ack),
+	.wb_err_o	(wb_s2m_gpio0_err),
+	.wb_rty_o	(wb_s2m_gpio0_rty),
+
+	.wb_clk		(wb_clk),
+	.wb_rst		(wb_rst)
+);
+
+////////////////////////////////////////////////////////////////////////
+//
+// VGA/LCD
+//
+////////////////////////////////////////////////////////////////////////
+`ifdef VGA0
+wire		vga0_irq;
+wire		pclk;
+wire [7:0]	r;
+wire [7:0]	g;
+wire [7:0]	b;
+wire		hsync;
+wire		vsync;
+wire		blank;
+wire		gate;
+reg [15:0]	hlen;
+reg [15:0]	vlen;
+
+vga_enh_top #(
+	.LINE_FIFO_AWIDTH(10)
+) vga0 (
+	.wb_clk_i	(wb_clk),
+	.wb_rst_i	(wb_rst),
+	.rst_i		(1'b1),
+	.wb_inta_o	(vga0_irq),
+	// Wishbone slave connections
+	.wbs_adr_i	(wb_m2s_vga0_adr),
+	.wbs_dat_i	(wb_m2s_vga0_dat),
+	.wbs_sel_i	(wb_m2s_vga0_sel),
+	.wbs_we_i	(wb_m2s_vga0_we),
+	.wbs_stb_i	(wb_m2s_vga0_stb),
+	.wbs_cyc_i	(wb_m2s_vga0_cyc),
+	.wbs_dat_o	(wb_s2m_vga0_dat),
+	.wbs_ack_o	(wb_s2m_vga0_ack),
+	.wbs_rty_o	(wb_s2m_vga0_rty),
+	.wbs_err_o	(wb_s2m_vga0_err),
+	// Wishbone master connections
+	.wbm_adr_o	(wb_m2s_vga0_master_adr),
+	.wbm_cti_o	(wb_m2s_vga0_master_cti),
+	.wbm_bte_o	(wb_m2s_vga0_master_bte),
+	.wbm_sel_o	(wb_m2s_vga0_master_sel),
+	.wbm_we_o	(wb_m2s_vga0_master_we),
+	.wbm_stb_o	(wb_m2s_vga0_master_stb),
+	.wbm_cyc_o	(wb_m2s_vga0_master_cyc),
+	.wbm_dat_i	(wb_s2m_vga0_master_dat),
+	.wbm_ack_i	(wb_s2m_vga0_master_ack),
+	.wbm_err_i	(wb_s2m_vga0_master_err),
+	.clk_p_i	(pclk),
+	.clk_p_o	(),
+	.hsync_pad_o	(hsync),
+	.vsync_pad_o	(vsync),
+	.csync_pad_o	(),
+	.blank_pad_o	(blank),
+	.r_pad_o	(r),
+	.g_pad_o	(g),
+	.b_pad_o	(b)
+);
+
+// Snoop wishbone bus for accesses to hlen and vlen
+always @(posedge wb_clk)
+	if (wb_rst) begin
+		hlen <= 0;
+		vlen <= 0;
+	end else if ((wb_m2s_vga0_adr[7:0] == 8'h16) &
+		     wb_m2s_vga0_stb & wb_m2s_vga0_cyc) begin
+		hlen <= wb_m2s_vga0_dat[31:16];
+		vlen <= wb_m2s_vga0_dat[15:0];
+	end
+
+dvi_gen_top dvi_gen0 (
+	.rst_n_pad_i	(rst_n_pad_i),
+	.dvi_clk_i	(dvi_clk),
+	.hlen		(hlen),
+	.vlen		(vlen),
+	.TMDS		(tmds_o),
+	.TMDSB		(tmdsb_o),
+	.pclk_o		(pclk),
+	.hsync_i	(hsync),
+	.vsync_i	(vsync),
+	.blank_i	(blank),
+	.red_data_i	(r),
+	.green_data_i	(g),
+	.blue_data_i	(b)
+);
+`else
+wire		vga0_irq = 0;
+`endif
+
+////////////////////////////////////////////////////////////////////////
+//
+// Ethernet
+//
+////////////////////////////////////////////////////////////////////////
+`ifdef ETH0
+wire		eth0_irq;
+wire [3:0]	eth0_mtxd;
+wire		eth0_mtxen;
+wire		eth0_mtxerr;
+wire		eth0_mtx_clk;
+wire		eth0_mrx_clk;
+wire [3:0]	eth0_mrxd;
+wire		eth0_mrxdv;
+wire		eth0_mrxerr;
+wire		eth0_mcoll;
+wire		eth0_mcrs;
+wire		eth0_speed;
+wire		eth0_duplex;
+wire		eth0_link;
+// Management interface wires
+wire		eth0_md_i;
+wire		eth0_md_o;
+wire		eth0_md_oe;
+
+// Hook up MII wires
+assign eth0_mtx_clk   = eth0_tx_clk;
+assign eth0_tx_data   = eth0_mtxd[3:0];
+assign eth0_tx_en     = eth0_mtxen;
+assign eth0_tx_er     = eth0_mtxerr;
+assign eth0_mrxd[3:0] = eth0_rx_data;
+assign eth0_mrxdv     = eth0_dv;
+assign eth0_mrxerr    = eth0_rx_er;
+assign eth0_mrx_clk   = eth0_rx_clk;
+assign eth0_mcoll     = eth0_col;
+assign eth0_mcrs      = eth0_crs;
+
+// Tristate control for management interface
+assign eth0_md_pad_io = eth0_md_oe ? eth0_md_o : 1'bz;
+assign eth0_md_i = eth0_md_pad_io;
+
+assign eth0_rst_n_o = !wb_rst;
+
+ethmac ethmac0 (
+	// Wishbone Slave interface
+	.wb_clk_i	(wb_clk),
+	.wb_rst_i	(wb_rst),
+	.wb_adr_i	(wb_m2s_eth0_adr[11:2]),
+	.wb_dat_i	(wb_m2s_eth0_dat),
+	.wb_sel_i	(wb_m2s_eth0_sel),
+	.wb_we_i 	(wb_m2s_eth0_we),
+	.wb_cyc_i	(wb_m2s_eth0_cyc),
+	.wb_stb_i	(wb_m2s_eth0_stb),
+	.wb_dat_o	(wb_s2m_eth0_dat),
+	.wb_err_o	(wb_s2m_eth0_err),
+	.wb_ack_o	(wb_s2m_eth0_ack),
+	// Wishbone Master Interface
+	.m_wb_adr_o	(wb_m2s_eth0_master_adr),
+	.m_wb_sel_o	(wb_m2s_eth0_master_sel),
+	.m_wb_we_o 	(wb_m2s_eth0_master_we),
+	.m_wb_dat_o	(wb_m2s_eth0_master_dat),
+	.m_wb_cyc_o	(wb_m2s_eth0_master_cyc),
+	.m_wb_stb_o	(wb_m2s_eth0_master_stb),
+	.m_wb_cti_o	(wb_m2s_eth0_master_cti),
+	.m_wb_bte_o	(wb_m2s_eth0_master_bte),
+	.m_wb_dat_i	(wb_s2m_eth0_master_dat),
+	.m_wb_ack_i	(wb_s2m_eth0_master_ack),
+	.m_wb_err_i	(wb_s2m_eth0_master_err),
+
+	// Ethernet MII interface
+	// Transmit
+	.mtxd_pad_o	(eth0_mtxd[3:0]),
+	.mtxen_pad_o	(eth0_mtxen),
+	.mtxerr_pad_o	(eth0_mtxerr),
+	.mtx_clk_pad_i	(eth0_mtx_clk),
+	// Receive
+	.mrx_clk_pad_i	(eth0_mrx_clk),
+	.mrxd_pad_i	(eth0_mrxd[3:0]),
+	.mrxdv_pad_i	(eth0_mrxdv),
+	.mrxerr_pad_i	(eth0_mrxerr),
+	.mcoll_pad_i	(eth0_mcoll),
+	.mcrs_pad_i	(eth0_mcrs),
+	// Management interface
+	.md_pad_i	(eth0_md_i),
+	.mdc_pad_o	(eth0_mdc_pad_o),
+	.md_pad_o	(eth0_md_o),
+	.md_padoe_o	(eth0_md_oe),
+
+	// Processor interrupt
+	.int_o		(eth0_irq)
+      );
+`else
+assign eth0_irq = 0;
+assign eth0_tx_data = 0;
+assign eth0_tx_en = 0;
+assign eth0_tx_er = 0;
+assign eth0_mdc_pad_o = 0;
+assign eth0_md_pad_io = 0;
+assign eth0_rst_n_o = 0;
+
+`endif
+
+////////////////////////////////////////////////////////////////////////
+//
+// AC97
+//
+////////////////////////////////////////////////////////////////////////
+`ifdef AC97
+wire ac97_irq;
+wire ac97_dma_req;
+wire ac97_dma_ack = 0;
+
+ac97_top ac97 (
+	.clk_i			(wb_clk),
+	.rst_i			(!wb_rst),
+	.wb_data_i		(wb_m2s_ac97_dat),
+	.wb_data_o		(wb_s2m_ac97_dat),
+	.wb_addr_i		(wb_m2s_ac97_adr),
+	.wb_sel_i		(wb_m2s_ac97_sel),
+	.wb_we_i		(wb_m2s_ac97_we),
+	.wb_cyc_i		(wb_m2s_ac97_cyc),
+	.wb_stb_i		(wb_m2s_ac97_stb),
+	.wb_ack_o		(wb_s2m_ac97_ack),
+	.wb_err_o		(wb_s2m_ac97_err),
+	.int_o			(ac97_irq),
+	.dma_req_o		(ac97_dma_req),
+	.dma_ack_i		(ac97_dma_ack),
+	.suspended_o		(),
+	.bit_clk_pad_i		(ac97_bit_clk_pad_i),
+	.sync_pad_o		(ac97_sync_pad_o),
+	.sdata_pad_o		(ac97_sdata_pad_o),
+	.sdata_pad_i		(ac97_sdata_pad_i),
+	.ac97_reset_pad_o_	(ac97_reset_pad_o)
+    );
+`else
+wire ac97_irq = 0;
+`endif
+
+////////////////////////////////////////////////////////////////////////
+//
+// PS2_0
+//
+////////////////////////////////////////////////////////////////////////
+wire ps2_0_irq;
+
+assign wb_s2m_ps2_0_err = 0;
+assign wb_s2m_ps2_0_rty = 0;
+
+`ifdef PS2_0
+wire ps2_0_cycstb = wb_m2s_ps2_0_cyc & wb_m2s_ps2_0_stb;
+
+ps2_wb ps2_0 (
+	.wb_clk_i	(wb_clk),
+	.wb_rst_i	(wb_rst),
+	.wb_dat_i	(wb_m2s_ps2_0_dat),
+	.wb_dat_o	(wb_s2m_ps2_0_dat),
+	.wb_adr_i	(wb_m2s_ps2_0_adr),
+	.wb_stb_i	(ps2_0_cycstb),
+	.wb_we_i	(wb_m2s_ps2_0_we),
+	.wb_ack_o	(wb_s2m_ps2_0_ack),
+
+	// IRQ output
+	.irq_o		(ps2_0_irq),
+
+	// PS2 signals
+	.ps2_clk	(ps2_0_clk),
+	.ps2_dat	(ps2_0_dat)
+);
+`else
+assign ps2_0_irq = 0;
+assign wb_s2m_ps2_0_dat = 0;
+assign wb_s2m_ps2_0_ack = 0;
+`endif // PS2_0
+
+////////////////////////////////////////////////////////////////////////
+//
+// PS2_1
+//
+////////////////////////////////////////////////////////////////////////
+wire ps2_1_irq;
+
+assign wb_s2m_ps2_1_err = 0;
+assign wb_s2m_ps2_1_rty = 0;
+
+`ifdef PS2_1
+wire ps2_1_cycstb = wb_m2s_ps2_1_cyc & wb_m2s_ps2_1_stb;
+
+ps2_wb ps2_1 (
+	.wb_clk_i	(wb_clk),
+	.wb_rst_i	(wb_rst),
+	.wb_dat_i	(wb_m2s_ps2_1_dat),
+	.wb_dat_o	(wb_s2m_ps2_1_dat),
+	.wb_adr_i	(wb_m2s_ps2_1_adr),
+	.wb_stb_i	(ps2_1_cycstb),
+	.wb_we_i	(wb_m2s_ps2_1_we),
+	.wb_ack_o	(wb_s2m_ps2_1_ack),
+
+	// IRQoutput
+	.irq_o		(ps2_1_irq),
+
+	// PS2 signals
+	.ps2_clk	(ps2_1_clk),
+	.ps2_dat	(ps2_1_dat)
+);
+`else
+assign ps2_1_irq = 0;
+assign wb_s2m_ps2_1_dat = 0;
+assign wb_s2m_ps2_1_ack = 0;
+`endif // PS2_1
+
+////////////////////////////////////////////////////////////////////////
+//
+// PS2_2
+//
+////////////////////////////////////////////////////////////////////////
+wire ps2_2_irq;
+
+assign wb_s2m_ps2_2_err = 0;
+assign wb_s2m_ps2_2_rty = 0;
+
+`ifdef PS2_2
+wire ps2_2_cycstb = wb_m2s_ps2_2_cyc & wb_m2s_ps2_2_stb;
+
+ps2_wb ps2_2 (
+	.wb_clk_i	(wb_clk),
+	.wb_rst_i	(wb_rst),
+	.wb_dat_i	(wb_m2s_ps2_2_dat),
+	.wb_dat_o	(wb_s2m_ps2_2_dat),
+	.wb_adr_i	(wb_m2s_ps2_2_adr),
+	.wb_stb_i	(ps2_2_cycstb),
+	.wb_we_i	(wb_m2s_ps2_2_we),
+	.wb_ack_o	(wb_s2m_ps2_2_ack),
+
+	// IRQ output
+	.irq_o		(ps2_2_irq),
+
+	// PS2 signals
+	.ps2_clk	(ps2_2_clk),
+	.ps2_dat	(ps2_2_dat)
+);
+`else
+assign ps2_2_irq = 0;
+assign wb_s2m_ps2_2_dat = 0;
+assign wb_s2m_ps2_2_ack = 0;
+`endif // PS2_2
+
+////////////////////////////////////////////////////////////////////////
+//
+// diila - Device Independent Integrated Logic Analyzer
+//
+////////////////////////////////////////////////////////////////////////
+wire [31:0] diila_trig;
+wire [31:0] diila_data [5:0];
+
+assign diila_trig = {
+		     30'h0,
+		     wb_m2s_dbg_stb,
+		     wb_m2s_dbg_cyc
+		     };
+
+assign diila_data[0] = wb_m2s_ddr2_dbus_adr;
+assign diila_data[1] = wb_m2s_ddr2_dbus_dat;
+assign diila_data[2] = wb_s2m_ddr2_dbus_dat;
+assign diila_data[3] = {
+			7'h0,
+			wb_m2s_or1k_d_cyc,	// 1
+			wb_m2s_or1k_d_stb,	// 1
+			wb_m2s_diila_cyc,	// 1
+			wb_m2s_eth0_cyc,	// 1
+			wb_m2s_vga0_cyc,	// 1
+			wb_m2s_spi0_cyc,	// 1
+			wb_m2s_gpio0_cyc,	// 1
+			wb_m2s_uart0_cyc,	// 1
+			wb_s2m_dbg_ack,		// 1
+			wb_m2s_dbg_we,		// 1
+			wb_m2s_ddr2_dbus_stb,	// 1
+			wb_m2s_ddr2_dbus_cyc,	// 1
+			wb_m2s_ddr2_dbus_bte,	// 2
+			wb_m2s_ddr2_dbus_cti,	// 3
+			wb_m2s_ddr2_dbus_sel,	// 4
+			wb_m2s_ddr2_dbus_we,	// 1
+			wb_s2m_ddr2_dbus_ack,	// 1
+			wb_s2m_ddr2_dbus_err,	// 1
+			wb_s2m_ddr2_dbus_rty	// 1
+			};
+assign diila_data[4] = wb_m2s_dbg_adr;
+assign diila_data[5] = 0;
+
+diila
+      #(
+	.DATA_WIDTH(32*6)
+)
+diila (
+	.wb_rst_i             (wb_rst),
+	.wb_clk_i             (wb_clk),
+	.wb_dat_i             (wb_m2s_diila_dat),
+	.wb_adr_i             (wb_m2s_diila_adr[23:2]),
+	.wb_sel_i             (wb_m2s_diila_sel),
+	.wb_we_i              (wb_m2s_diila_we),
+	.wb_cyc_i             (wb_m2s_diila_cyc),
+	.wb_stb_i             (wb_m2s_diila_stb),
+	.wb_dat_o             (wb_s2m_diila_dat),
+	.wb_ack_o             (wb_s2m_diila_ack),
+	.wb_err_o             (wb_s2m_diila_err),
+	.wb_rty_o             (wb_s2m_diila_rty),
+	.storage_en           (1'b1/*diila_storage_en*/),
+	.trig_i               (diila_trig),
+	.data_i               ({
+				diila_data[0],
+				diila_data[1],
+				diila_data[2],
+				diila_data[3],
+				diila_data[4],
+				diila_data[5]
+				})
+);
+
+////////////////////////////////////////////////////////////////////////
+//
+// Interrupt assignment
+//
+////////////////////////////////////////////////////////////////////////
+
+assign or1k_irq[0] = 0; // Non-maskable inside OR1K
+assign or1k_irq[1] = 0; // Non-maskable inside OR1K
+assign or1k_irq[2] = uart0_irq;
+assign or1k_irq[3] = 0;
+assign or1k_irq[4] = eth0_irq;
+assign or1k_irq[5] = ps2_0_irq;
+assign or1k_irq[6] = spi0_irq;
+assign or1k_irq[7] = 0;
+assign or1k_irq[8] = vga0_irq;
+assign or1k_irq[9] = 0;
+assign or1k_irq[10] = 0;
+assign or1k_irq[11] = 0;
+assign or1k_irq[12] = ac97_irq;
+assign or1k_irq[13] = ps2_1_irq;
+assign or1k_irq[14] = ps2_2_irq;
+assign or1k_irq[15] = 0;
+assign or1k_irq[16] = 0;
+assign or1k_irq[17] = 0;
+assign or1k_irq[18] = 0;
+assign or1k_irq[19] = 0;
+assign or1k_irq[20] = 0;
+assign or1k_irq[21] = 0;
+assign or1k_irq[22] = 0;
+assign or1k_irq[23] = 0;
+assign or1k_irq[24] = 0;
+assign or1k_irq[25] = 0;
+assign or1k_irq[26] = 0;
+assign or1k_irq[27] = 0;
+assign or1k_irq[28] = 0;
+assign or1k_irq[29] = 0;
+assign or1k_irq[30] = 0;
+assign or1k_irq[31] = 0;
+
+endmodule // orpsoc_top

--- a/systems/atlys/rtl/verilog/rom.v
+++ b/systems/atlys/rtl/verilog/rom.v
@@ -1,0 +1,133 @@
+//////////////////////////////////////////////////////////////////////
+////                                                              ////
+////  ROM                                                         ////
+////                                                              ////
+////  Author(s):                                                  ////
+////      - Michael Unneback (unneback@opencores.org)             ////
+////      - Julius Baxter    (julius@opencores.org)               ////
+////                                                              ////
+//////////////////////////////////////////////////////////////////////
+////                                                              ////
+//// Copyright (C) 2009 Authors                                   ////
+////                                                              ////
+//// This source file may be used and distributed without         ////
+//// restriction provided that this copyright statement is not    ////
+//// removed from the file and that any derivative work contains  ////
+//// the original copyright notice and the associated disclaimer. ////
+////                                                              ////
+//// This source file is free software; you can redistribute it   ////
+//// and/or modify it under the terms of the GNU Lesser General   ////
+//// Public License as published by the Free Software Foundation; ////
+//// either version 2.1 of the License, or (at your option) any   ////
+//// later version.                                               ////
+////                                                              ////
+//// This source is distributed in the hope that it will be       ////
+//// useful, but WITHOUT ANY WARRANTY; without even the implied   ////
+//// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR      ////
+//// PURPOSE.  See the GNU Lesser General Public License for more ////
+//// details.                                                     ////
+////                                                              ////
+//// You should have received a copy of the GNU Lesser General    ////
+//// Public License along with this source; if not, download it   ////
+//// from http://www.opencores.org/lgpl.shtml                     ////
+////                                                              ////
+//////////////////////////////////////////////////////////////////////
+
+module rom
+  #(parameter addr_width = 5,
+    parameter b3_burst   = 0)
+   (
+    input 		       wb_clk,
+    input 		       wb_rst,
+    input [(addr_width+2)-1:2] wb_adr_i,
+    input 		       wb_stb_i,
+    input 		       wb_cyc_i,
+    input [2:0] 	       wb_cti_i,
+    input [1:0] 	       wb_bte_i,
+    output reg [31:0] 	       wb_dat_o,
+    output reg 		       wb_ack_o);
+   
+   reg [addr_width-1:0] 	    adr;
+
+   always @ (posedge wb_clk or posedge wb_rst)
+     if (wb_rst)
+       wb_dat_o <= 32'h15000000;
+     else
+       case (adr)
+	 // Zero r0 and endless loop
+	 0 : wb_dat_o <= 32'h18000000;
+	 1 : wb_dat_o <= 32'hA8200000;
+	 2 : wb_dat_o <= 32'hA8C00100;
+	 3 : wb_dat_o <= 32'h00000000;
+	 4 : wb_dat_o <= 32'h15000000;
+/*
+	 // Zero r0 and jump to 0x00000100
+	 0 : wb_dat_o <= 32'h18000000;
+	 1 : wb_dat_o <= 32'hA8200000;
+	 2 : wb_dat_o <= 32'hA8C00100;
+	 3 : wb_dat_o <= 32'h44003000;
+	 4 : wb_dat_o <= 32'h15000000;
+ */
+	 default:
+	   wb_dat_o <= 32'h00000000;
+       endcase // case (wb_adr_i)
+
+generate
+if(b3_burst) begin : gen_b3_burst
+   reg 				    wb_stb_i_r;
+   reg 				    new_access_r;   
+   reg 				    burst_r;
+	 
+   wire burst      = wb_cyc_i & (!(wb_cti_i == 3'b000)) & (!(wb_cti_i == 3'b111));
+   wire new_access = (wb_stb_i & !wb_stb_i_r);
+   wire new_burst  = (burst & !burst_r);
+
+   always @(posedge wb_clk) begin
+     new_access_r <= new_access;
+     burst_r      <= burst;
+     wb_stb_i_r   <= wb_stb_i;
+   end
+   
+   
+   always @(posedge wb_clk)
+     if (wb_rst)
+       adr <= 0;
+     else if (new_access)
+       // New access, register address, ack a cycle later
+       adr <= wb_adr_i[(addr_width+2)-1:2];
+     else if (burst) begin
+	if (wb_cti_i == 3'b010)
+	  case (wb_bte_i)
+	    2'b00: adr <= adr + 1;
+	    2'b01: adr[1:0] <= adr[1:0] + 1;
+	    2'b10: adr[2:0] <= adr[2:0] + 1;
+	    2'b11: adr[3:0] <= adr[3:0] + 1;
+	  endcase // case (wb_bte_i)
+	else
+	  adr <= wb_adr_i[(addr_width+2)-1:2];
+     end // if (burst)
+   
+   
+   always @(posedge wb_clk)
+     if (wb_rst)
+       wb_ack_o <= 0;
+     else if (wb_ack_o & (!burst | (wb_cti_i == 3'b111)))
+       wb_ack_o <= 0;
+     else if (wb_stb_i & ((!burst & !new_access & new_access_r) | (burst & burst_r)))
+       wb_ack_o <= 1;
+     else
+       wb_ack_o <= 0;
+
+     end else begin
+	always @(wb_adr_i)
+	  adr <= wb_adr_i;
+	
+	always @ (posedge wb_clk or posedge wb_rst)
+	  if (wb_rst)
+	    wb_ack_o <= 1'b0;
+	  else
+	    wb_ack_o <= wb_stb_i & wb_cyc_i & !wb_ack_o;
+	
+     end
+endgenerate   
+endmodule 

--- a/systems/atlys/rtl/verilog/wb_intercon.v
+++ b/systems/atlys/rtl/verilog/wb_intercon.v
@@ -1,0 +1,1138 @@
+module wb_intercon
+   (input         wb_clk_i,
+    input         wb_rst_i,
+    input  [31:0] wb_or1k_i_adr_i,
+    input  [31:0] wb_or1k_i_dat_i,
+    input   [3:0] wb_or1k_i_sel_i,
+    input         wb_or1k_i_we_i,
+    input         wb_or1k_i_cyc_i,
+    input         wb_or1k_i_stb_i,
+    input   [2:0] wb_or1k_i_cti_i,
+    input   [1:0] wb_or1k_i_bte_i,
+    output [31:0] wb_or1k_i_dat_o,
+    output        wb_or1k_i_ack_o,
+    output        wb_or1k_i_err_o,
+    output        wb_or1k_i_rty_o,
+    input  [31:0] wb_or1k_d_adr_i,
+    input  [31:0] wb_or1k_d_dat_i,
+    input   [3:0] wb_or1k_d_sel_i,
+    input         wb_or1k_d_we_i,
+    input         wb_or1k_d_cyc_i,
+    input         wb_or1k_d_stb_i,
+    input   [2:0] wb_or1k_d_cti_i,
+    input   [1:0] wb_or1k_d_bte_i,
+    output [31:0] wb_or1k_d_dat_o,
+    output        wb_or1k_d_ack_o,
+    output        wb_or1k_d_err_o,
+    output        wb_or1k_d_rty_o,
+    input  [31:0] wb_dbg_adr_i,
+    input  [31:0] wb_dbg_dat_i,
+    input   [3:0] wb_dbg_sel_i,
+    input         wb_dbg_we_i,
+    input         wb_dbg_cyc_i,
+    input         wb_dbg_stb_i,
+    input   [2:0] wb_dbg_cti_i,
+    input   [1:0] wb_dbg_bte_i,
+    output [31:0] wb_dbg_dat_o,
+    output        wb_dbg_ack_o,
+    output        wb_dbg_err_o,
+    output        wb_dbg_rty_o,
+    input  [31:0] wb_vga0_master_adr_i,
+    input  [31:0] wb_vga0_master_dat_i,
+    input   [3:0] wb_vga0_master_sel_i,
+    input         wb_vga0_master_we_i,
+    input         wb_vga0_master_cyc_i,
+    input         wb_vga0_master_stb_i,
+    input   [2:0] wb_vga0_master_cti_i,
+    input   [1:0] wb_vga0_master_bte_i,
+    output [31:0] wb_vga0_master_dat_o,
+    output        wb_vga0_master_ack_o,
+    output        wb_vga0_master_err_o,
+    output        wb_vga0_master_rty_o,
+    input  [31:0] wb_eth0_master_adr_i,
+    input  [31:0] wb_eth0_master_dat_i,
+    input   [3:0] wb_eth0_master_sel_i,
+    input         wb_eth0_master_we_i,
+    input         wb_eth0_master_cyc_i,
+    input         wb_eth0_master_stb_i,
+    input   [2:0] wb_eth0_master_cti_i,
+    input   [1:0] wb_eth0_master_bte_i,
+    output [31:0] wb_eth0_master_dat_o,
+    output        wb_eth0_master_ack_o,
+    output        wb_eth0_master_err_o,
+    output        wb_eth0_master_rty_o,
+    output [31:0] wb_gpio0_adr_o,
+    output [31:0] wb_gpio0_dat_o,
+    output  [3:0] wb_gpio0_sel_o,
+    output        wb_gpio0_we_o,
+    output        wb_gpio0_cyc_o,
+    output        wb_gpio0_stb_o,
+    output  [2:0] wb_gpio0_cti_o,
+    output  [1:0] wb_gpio0_bte_o,
+    input  [31:0] wb_gpio0_dat_i,
+    input         wb_gpio0_ack_i,
+    input         wb_gpio0_err_i,
+    input         wb_gpio0_rty_i,
+    output [31:0] wb_rom0_adr_o,
+    output [31:0] wb_rom0_dat_o,
+    output  [3:0] wb_rom0_sel_o,
+    output        wb_rom0_we_o,
+    output        wb_rom0_cyc_o,
+    output        wb_rom0_stb_o,
+    output  [2:0] wb_rom0_cti_o,
+    output  [1:0] wb_rom0_bte_o,
+    input  [31:0] wb_rom0_dat_i,
+    input         wb_rom0_ack_i,
+    input         wb_rom0_err_i,
+    input         wb_rom0_rty_i,
+    output [31:0] wb_ddr2_dbus_adr_o,
+    output [31:0] wb_ddr2_dbus_dat_o,
+    output  [3:0] wb_ddr2_dbus_sel_o,
+    output        wb_ddr2_dbus_we_o,
+    output        wb_ddr2_dbus_cyc_o,
+    output        wb_ddr2_dbus_stb_o,
+    output  [2:0] wb_ddr2_dbus_cti_o,
+    output  [1:0] wb_ddr2_dbus_bte_o,
+    input  [31:0] wb_ddr2_dbus_dat_i,
+    input         wb_ddr2_dbus_ack_i,
+    input         wb_ddr2_dbus_err_i,
+    input         wb_ddr2_dbus_rty_i,
+    output [31:0] wb_spi0_adr_o,
+    output [31:0] wb_spi0_dat_o,
+    output  [3:0] wb_spi0_sel_o,
+    output        wb_spi0_we_o,
+    output        wb_spi0_cyc_o,
+    output        wb_spi0_stb_o,
+    output  [2:0] wb_spi0_cti_o,
+    output  [1:0] wb_spi0_bte_o,
+    input  [31:0] wb_spi0_dat_i,
+    input         wb_spi0_ack_i,
+    input         wb_spi0_err_i,
+    input         wb_spi0_rty_i,
+    output [31:0] wb_diila_adr_o,
+    output [31:0] wb_diila_dat_o,
+    output  [3:0] wb_diila_sel_o,
+    output        wb_diila_we_o,
+    output        wb_diila_cyc_o,
+    output        wb_diila_stb_o,
+    output  [2:0] wb_diila_cti_o,
+    output  [1:0] wb_diila_bte_o,
+    input  [31:0] wb_diila_dat_i,
+    input         wb_diila_ack_i,
+    input         wb_diila_err_i,
+    input         wb_diila_rty_i,
+    output [31:0] wb_uart0_adr_o,
+    output [31:0] wb_uart0_dat_o,
+    output  [3:0] wb_uart0_sel_o,
+    output        wb_uart0_we_o,
+    output        wb_uart0_cyc_o,
+    output        wb_uart0_stb_o,
+    output  [2:0] wb_uart0_cti_o,
+    output  [1:0] wb_uart0_bte_o,
+    input  [31:0] wb_uart0_dat_i,
+    input         wb_uart0_ack_i,
+    input         wb_uart0_err_i,
+    input         wb_uart0_rty_i,
+    output [31:0] wb_ps2_0_adr_o,
+    output [31:0] wb_ps2_0_dat_o,
+    output  [3:0] wb_ps2_0_sel_o,
+    output        wb_ps2_0_we_o,
+    output        wb_ps2_0_cyc_o,
+    output        wb_ps2_0_stb_o,
+    output  [2:0] wb_ps2_0_cti_o,
+    output  [1:0] wb_ps2_0_bte_o,
+    input  [31:0] wb_ps2_0_dat_i,
+    input         wb_ps2_0_ack_i,
+    input         wb_ps2_0_err_i,
+    input         wb_ps2_0_rty_i,
+    output [31:0] wb_vga0_adr_o,
+    output [31:0] wb_vga0_dat_o,
+    output  [3:0] wb_vga0_sel_o,
+    output        wb_vga0_we_o,
+    output        wb_vga0_cyc_o,
+    output        wb_vga0_stb_o,
+    output  [2:0] wb_vga0_cti_o,
+    output  [1:0] wb_vga0_bte_o,
+    input  [31:0] wb_vga0_dat_i,
+    input         wb_vga0_ack_i,
+    input         wb_vga0_err_i,
+    input         wb_vga0_rty_i,
+    output [31:0] wb_ddr2_eth0_adr_o,
+    output [31:0] wb_ddr2_eth0_dat_o,
+    output  [3:0] wb_ddr2_eth0_sel_o,
+    output        wb_ddr2_eth0_we_o,
+    output        wb_ddr2_eth0_cyc_o,
+    output        wb_ddr2_eth0_stb_o,
+    output  [2:0] wb_ddr2_eth0_cti_o,
+    output  [1:0] wb_ddr2_eth0_bte_o,
+    input  [31:0] wb_ddr2_eth0_dat_i,
+    input         wb_ddr2_eth0_ack_i,
+    input         wb_ddr2_eth0_err_i,
+    input         wb_ddr2_eth0_rty_i,
+    output [31:0] wb_ac97_adr_o,
+    output [31:0] wb_ac97_dat_o,
+    output  [3:0] wb_ac97_sel_o,
+    output        wb_ac97_we_o,
+    output        wb_ac97_cyc_o,
+    output        wb_ac97_stb_o,
+    output  [2:0] wb_ac97_cti_o,
+    output  [1:0] wb_ac97_bte_o,
+    input  [31:0] wb_ac97_dat_i,
+    input         wb_ac97_ack_i,
+    input         wb_ac97_err_i,
+    input         wb_ac97_rty_i,
+    output [31:0] wb_ddr2_ibus_adr_o,
+    output [31:0] wb_ddr2_ibus_dat_o,
+    output  [3:0] wb_ddr2_ibus_sel_o,
+    output        wb_ddr2_ibus_we_o,
+    output        wb_ddr2_ibus_cyc_o,
+    output        wb_ddr2_ibus_stb_o,
+    output  [2:0] wb_ddr2_ibus_cti_o,
+    output  [1:0] wb_ddr2_ibus_bte_o,
+    input  [31:0] wb_ddr2_ibus_dat_i,
+    input         wb_ddr2_ibus_ack_i,
+    input         wb_ddr2_ibus_err_i,
+    input         wb_ddr2_ibus_rty_i,
+    output [31:0] wb_ddr2_vga0_adr_o,
+    output [31:0] wb_ddr2_vga0_dat_o,
+    output  [3:0] wb_ddr2_vga0_sel_o,
+    output        wb_ddr2_vga0_we_o,
+    output        wb_ddr2_vga0_cyc_o,
+    output        wb_ddr2_vga0_stb_o,
+    output  [2:0] wb_ddr2_vga0_cti_o,
+    output  [1:0] wb_ddr2_vga0_bte_o,
+    input  [31:0] wb_ddr2_vga0_dat_i,
+    input         wb_ddr2_vga0_ack_i,
+    input         wb_ddr2_vga0_err_i,
+    input         wb_ddr2_vga0_rty_i,
+    output [31:0] wb_ps2_2_adr_o,
+    output [31:0] wb_ps2_2_dat_o,
+    output  [3:0] wb_ps2_2_sel_o,
+    output        wb_ps2_2_we_o,
+    output        wb_ps2_2_cyc_o,
+    output        wb_ps2_2_stb_o,
+    output  [2:0] wb_ps2_2_cti_o,
+    output  [1:0] wb_ps2_2_bte_o,
+    input  [31:0] wb_ps2_2_dat_i,
+    input         wb_ps2_2_ack_i,
+    input         wb_ps2_2_err_i,
+    input         wb_ps2_2_rty_i,
+    output [31:0] wb_ps2_1_adr_o,
+    output [31:0] wb_ps2_1_dat_o,
+    output  [3:0] wb_ps2_1_sel_o,
+    output        wb_ps2_1_we_o,
+    output        wb_ps2_1_cyc_o,
+    output        wb_ps2_1_stb_o,
+    output  [2:0] wb_ps2_1_cti_o,
+    output  [1:0] wb_ps2_1_bte_o,
+    input  [31:0] wb_ps2_1_dat_i,
+    input         wb_ps2_1_ack_i,
+    input         wb_ps2_1_err_i,
+    input         wb_ps2_1_rty_i,
+    output [31:0] wb_eth0_adr_o,
+    output [31:0] wb_eth0_dat_o,
+    output  [3:0] wb_eth0_sel_o,
+    output        wb_eth0_we_o,
+    output        wb_eth0_cyc_o,
+    output        wb_eth0_stb_o,
+    output  [2:0] wb_eth0_cti_o,
+    output  [1:0] wb_eth0_bte_o,
+    input  [31:0] wb_eth0_dat_i,
+    input         wb_eth0_ack_i,
+    input         wb_eth0_err_i,
+    input         wb_eth0_rty_i);
+
+wire [31:0] wb_m2s_or1k_d_ddr2_dbus_adr;
+wire [31:0] wb_m2s_or1k_d_ddr2_dbus_dat;
+wire  [3:0] wb_m2s_or1k_d_ddr2_dbus_sel;
+wire        wb_m2s_or1k_d_ddr2_dbus_we;
+wire        wb_m2s_or1k_d_ddr2_dbus_cyc;
+wire        wb_m2s_or1k_d_ddr2_dbus_stb;
+wire  [2:0] wb_m2s_or1k_d_ddr2_dbus_cti;
+wire  [1:0] wb_m2s_or1k_d_ddr2_dbus_bte;
+wire [31:0] wb_s2m_or1k_d_ddr2_dbus_dat;
+wire        wb_s2m_or1k_d_ddr2_dbus_ack;
+wire        wb_s2m_or1k_d_ddr2_dbus_err;
+wire        wb_s2m_or1k_d_ddr2_dbus_rty;
+wire [31:0] wb_m2s_or1k_d_uart0_adr;
+wire [31:0] wb_m2s_or1k_d_uart0_dat;
+wire  [3:0] wb_m2s_or1k_d_uart0_sel;
+wire        wb_m2s_or1k_d_uart0_we;
+wire        wb_m2s_or1k_d_uart0_cyc;
+wire        wb_m2s_or1k_d_uart0_stb;
+wire  [2:0] wb_m2s_or1k_d_uart0_cti;
+wire  [1:0] wb_m2s_or1k_d_uart0_bte;
+wire [31:0] wb_s2m_or1k_d_uart0_dat;
+wire        wb_s2m_or1k_d_uart0_ack;
+wire        wb_s2m_or1k_d_uart0_err;
+wire        wb_s2m_or1k_d_uart0_rty;
+wire [31:0] wb_m2s_or1k_d_gpio0_adr;
+wire [31:0] wb_m2s_or1k_d_gpio0_dat;
+wire  [3:0] wb_m2s_or1k_d_gpio0_sel;
+wire        wb_m2s_or1k_d_gpio0_we;
+wire        wb_m2s_or1k_d_gpio0_cyc;
+wire        wb_m2s_or1k_d_gpio0_stb;
+wire  [2:0] wb_m2s_or1k_d_gpio0_cti;
+wire  [1:0] wb_m2s_or1k_d_gpio0_bte;
+wire [31:0] wb_s2m_or1k_d_gpio0_dat;
+wire        wb_s2m_or1k_d_gpio0_ack;
+wire        wb_s2m_or1k_d_gpio0_err;
+wire        wb_s2m_or1k_d_gpio0_rty;
+wire [31:0] wb_m2s_or1k_d_spi0_adr;
+wire [31:0] wb_m2s_or1k_d_spi0_dat;
+wire  [3:0] wb_m2s_or1k_d_spi0_sel;
+wire        wb_m2s_or1k_d_spi0_we;
+wire        wb_m2s_or1k_d_spi0_cyc;
+wire        wb_m2s_or1k_d_spi0_stb;
+wire  [2:0] wb_m2s_or1k_d_spi0_cti;
+wire  [1:0] wb_m2s_or1k_d_spi0_bte;
+wire [31:0] wb_s2m_or1k_d_spi0_dat;
+wire        wb_s2m_or1k_d_spi0_ack;
+wire        wb_s2m_or1k_d_spi0_err;
+wire        wb_s2m_or1k_d_spi0_rty;
+wire [31:0] wb_m2s_or1k_d_vga0_adr;
+wire [31:0] wb_m2s_or1k_d_vga0_dat;
+wire  [3:0] wb_m2s_or1k_d_vga0_sel;
+wire        wb_m2s_or1k_d_vga0_we;
+wire        wb_m2s_or1k_d_vga0_cyc;
+wire        wb_m2s_or1k_d_vga0_stb;
+wire  [2:0] wb_m2s_or1k_d_vga0_cti;
+wire  [1:0] wb_m2s_or1k_d_vga0_bte;
+wire [31:0] wb_s2m_or1k_d_vga0_dat;
+wire        wb_s2m_or1k_d_vga0_ack;
+wire        wb_s2m_or1k_d_vga0_err;
+wire        wb_s2m_or1k_d_vga0_rty;
+wire [31:0] wb_m2s_or1k_d_eth0_adr;
+wire [31:0] wb_m2s_or1k_d_eth0_dat;
+wire  [3:0] wb_m2s_or1k_d_eth0_sel;
+wire        wb_m2s_or1k_d_eth0_we;
+wire        wb_m2s_or1k_d_eth0_cyc;
+wire        wb_m2s_or1k_d_eth0_stb;
+wire  [2:0] wb_m2s_or1k_d_eth0_cti;
+wire  [1:0] wb_m2s_or1k_d_eth0_bte;
+wire [31:0] wb_s2m_or1k_d_eth0_dat;
+wire        wb_s2m_or1k_d_eth0_ack;
+wire        wb_s2m_or1k_d_eth0_err;
+wire        wb_s2m_or1k_d_eth0_rty;
+wire [31:0] wb_m2s_or1k_d_ps2_0_adr;
+wire [31:0] wb_m2s_or1k_d_ps2_0_dat;
+wire  [3:0] wb_m2s_or1k_d_ps2_0_sel;
+wire        wb_m2s_or1k_d_ps2_0_we;
+wire        wb_m2s_or1k_d_ps2_0_cyc;
+wire        wb_m2s_or1k_d_ps2_0_stb;
+wire  [2:0] wb_m2s_or1k_d_ps2_0_cti;
+wire  [1:0] wb_m2s_or1k_d_ps2_0_bte;
+wire [31:0] wb_s2m_or1k_d_ps2_0_dat;
+wire        wb_s2m_or1k_d_ps2_0_ack;
+wire        wb_s2m_or1k_d_ps2_0_err;
+wire        wb_s2m_or1k_d_ps2_0_rty;
+wire [31:0] wb_m2s_or1k_d_ps2_1_adr;
+wire [31:0] wb_m2s_or1k_d_ps2_1_dat;
+wire  [3:0] wb_m2s_or1k_d_ps2_1_sel;
+wire        wb_m2s_or1k_d_ps2_1_we;
+wire        wb_m2s_or1k_d_ps2_1_cyc;
+wire        wb_m2s_or1k_d_ps2_1_stb;
+wire  [2:0] wb_m2s_or1k_d_ps2_1_cti;
+wire  [1:0] wb_m2s_or1k_d_ps2_1_bte;
+wire [31:0] wb_s2m_or1k_d_ps2_1_dat;
+wire        wb_s2m_or1k_d_ps2_1_ack;
+wire        wb_s2m_or1k_d_ps2_1_err;
+wire        wb_s2m_or1k_d_ps2_1_rty;
+wire [31:0] wb_m2s_or1k_d_ps2_2_adr;
+wire [31:0] wb_m2s_or1k_d_ps2_2_dat;
+wire  [3:0] wb_m2s_or1k_d_ps2_2_sel;
+wire        wb_m2s_or1k_d_ps2_2_we;
+wire        wb_m2s_or1k_d_ps2_2_cyc;
+wire        wb_m2s_or1k_d_ps2_2_stb;
+wire  [2:0] wb_m2s_or1k_d_ps2_2_cti;
+wire  [1:0] wb_m2s_or1k_d_ps2_2_bte;
+wire [31:0] wb_s2m_or1k_d_ps2_2_dat;
+wire        wb_s2m_or1k_d_ps2_2_ack;
+wire        wb_s2m_or1k_d_ps2_2_err;
+wire        wb_s2m_or1k_d_ps2_2_rty;
+wire [31:0] wb_m2s_dbg_ddr2_dbus_adr;
+wire [31:0] wb_m2s_dbg_ddr2_dbus_dat;
+wire  [3:0] wb_m2s_dbg_ddr2_dbus_sel;
+wire        wb_m2s_dbg_ddr2_dbus_we;
+wire        wb_m2s_dbg_ddr2_dbus_cyc;
+wire        wb_m2s_dbg_ddr2_dbus_stb;
+wire  [2:0] wb_m2s_dbg_ddr2_dbus_cti;
+wire  [1:0] wb_m2s_dbg_ddr2_dbus_bte;
+wire [31:0] wb_s2m_dbg_ddr2_dbus_dat;
+wire        wb_s2m_dbg_ddr2_dbus_ack;
+wire        wb_s2m_dbg_ddr2_dbus_err;
+wire        wb_s2m_dbg_ddr2_dbus_rty;
+wire [31:0] wb_m2s_dbg_uart0_adr;
+wire [31:0] wb_m2s_dbg_uart0_dat;
+wire  [3:0] wb_m2s_dbg_uart0_sel;
+wire        wb_m2s_dbg_uart0_we;
+wire        wb_m2s_dbg_uart0_cyc;
+wire        wb_m2s_dbg_uart0_stb;
+wire  [2:0] wb_m2s_dbg_uart0_cti;
+wire  [1:0] wb_m2s_dbg_uart0_bte;
+wire [31:0] wb_s2m_dbg_uart0_dat;
+wire        wb_s2m_dbg_uart0_ack;
+wire        wb_s2m_dbg_uart0_err;
+wire        wb_s2m_dbg_uart0_rty;
+wire [31:0] wb_m2s_dbg_gpio0_adr;
+wire [31:0] wb_m2s_dbg_gpio0_dat;
+wire  [3:0] wb_m2s_dbg_gpio0_sel;
+wire        wb_m2s_dbg_gpio0_we;
+wire        wb_m2s_dbg_gpio0_cyc;
+wire        wb_m2s_dbg_gpio0_stb;
+wire  [2:0] wb_m2s_dbg_gpio0_cti;
+wire  [1:0] wb_m2s_dbg_gpio0_bte;
+wire [31:0] wb_s2m_dbg_gpio0_dat;
+wire        wb_s2m_dbg_gpio0_ack;
+wire        wb_s2m_dbg_gpio0_err;
+wire        wb_s2m_dbg_gpio0_rty;
+wire [31:0] wb_m2s_dbg_spi0_adr;
+wire [31:0] wb_m2s_dbg_spi0_dat;
+wire  [3:0] wb_m2s_dbg_spi0_sel;
+wire        wb_m2s_dbg_spi0_we;
+wire        wb_m2s_dbg_spi0_cyc;
+wire        wb_m2s_dbg_spi0_stb;
+wire  [2:0] wb_m2s_dbg_spi0_cti;
+wire  [1:0] wb_m2s_dbg_spi0_bte;
+wire [31:0] wb_s2m_dbg_spi0_dat;
+wire        wb_s2m_dbg_spi0_ack;
+wire        wb_s2m_dbg_spi0_err;
+wire        wb_s2m_dbg_spi0_rty;
+wire [31:0] wb_m2s_dbg_vga0_adr;
+wire [31:0] wb_m2s_dbg_vga0_dat;
+wire  [3:0] wb_m2s_dbg_vga0_sel;
+wire        wb_m2s_dbg_vga0_we;
+wire        wb_m2s_dbg_vga0_cyc;
+wire        wb_m2s_dbg_vga0_stb;
+wire  [2:0] wb_m2s_dbg_vga0_cti;
+wire  [1:0] wb_m2s_dbg_vga0_bte;
+wire [31:0] wb_s2m_dbg_vga0_dat;
+wire        wb_s2m_dbg_vga0_ack;
+wire        wb_s2m_dbg_vga0_err;
+wire        wb_s2m_dbg_vga0_rty;
+wire [31:0] wb_m2s_dbg_eth0_adr;
+wire [31:0] wb_m2s_dbg_eth0_dat;
+wire  [3:0] wb_m2s_dbg_eth0_sel;
+wire        wb_m2s_dbg_eth0_we;
+wire        wb_m2s_dbg_eth0_cyc;
+wire        wb_m2s_dbg_eth0_stb;
+wire  [2:0] wb_m2s_dbg_eth0_cti;
+wire  [1:0] wb_m2s_dbg_eth0_bte;
+wire [31:0] wb_s2m_dbg_eth0_dat;
+wire        wb_s2m_dbg_eth0_ack;
+wire        wb_s2m_dbg_eth0_err;
+wire        wb_s2m_dbg_eth0_rty;
+wire [31:0] wb_m2s_dbg_ps2_0_adr;
+wire [31:0] wb_m2s_dbg_ps2_0_dat;
+wire  [3:0] wb_m2s_dbg_ps2_0_sel;
+wire        wb_m2s_dbg_ps2_0_we;
+wire        wb_m2s_dbg_ps2_0_cyc;
+wire        wb_m2s_dbg_ps2_0_stb;
+wire  [2:0] wb_m2s_dbg_ps2_0_cti;
+wire  [1:0] wb_m2s_dbg_ps2_0_bte;
+wire [31:0] wb_s2m_dbg_ps2_0_dat;
+wire        wb_s2m_dbg_ps2_0_ack;
+wire        wb_s2m_dbg_ps2_0_err;
+wire        wb_s2m_dbg_ps2_0_rty;
+wire [31:0] wb_m2s_dbg_ps2_1_adr;
+wire [31:0] wb_m2s_dbg_ps2_1_dat;
+wire  [3:0] wb_m2s_dbg_ps2_1_sel;
+wire        wb_m2s_dbg_ps2_1_we;
+wire        wb_m2s_dbg_ps2_1_cyc;
+wire        wb_m2s_dbg_ps2_1_stb;
+wire  [2:0] wb_m2s_dbg_ps2_1_cti;
+wire  [1:0] wb_m2s_dbg_ps2_1_bte;
+wire [31:0] wb_s2m_dbg_ps2_1_dat;
+wire        wb_s2m_dbg_ps2_1_ack;
+wire        wb_s2m_dbg_ps2_1_err;
+wire        wb_s2m_dbg_ps2_1_rty;
+wire [31:0] wb_m2s_dbg_ps2_2_adr;
+wire [31:0] wb_m2s_dbg_ps2_2_dat;
+wire  [3:0] wb_m2s_dbg_ps2_2_sel;
+wire        wb_m2s_dbg_ps2_2_we;
+wire        wb_m2s_dbg_ps2_2_cyc;
+wire        wb_m2s_dbg_ps2_2_stb;
+wire  [2:0] wb_m2s_dbg_ps2_2_cti;
+wire  [1:0] wb_m2s_dbg_ps2_2_bte;
+wire [31:0] wb_s2m_dbg_ps2_2_dat;
+wire        wb_s2m_dbg_ps2_2_ack;
+wire        wb_s2m_dbg_ps2_2_err;
+wire        wb_s2m_dbg_ps2_2_rty;
+wire [31:0] wb_m2s_resize_gpio0_adr;
+wire [31:0] wb_m2s_resize_gpio0_dat;
+wire  [3:0] wb_m2s_resize_gpio0_sel;
+wire        wb_m2s_resize_gpio0_we;
+wire        wb_m2s_resize_gpio0_cyc;
+wire        wb_m2s_resize_gpio0_stb;
+wire  [2:0] wb_m2s_resize_gpio0_cti;
+wire  [1:0] wb_m2s_resize_gpio0_bte;
+wire [31:0] wb_s2m_resize_gpio0_dat;
+wire        wb_s2m_resize_gpio0_ack;
+wire        wb_s2m_resize_gpio0_err;
+wire        wb_s2m_resize_gpio0_rty;
+wire [31:0] wb_m2s_resize_spi0_adr;
+wire [31:0] wb_m2s_resize_spi0_dat;
+wire  [3:0] wb_m2s_resize_spi0_sel;
+wire        wb_m2s_resize_spi0_we;
+wire        wb_m2s_resize_spi0_cyc;
+wire        wb_m2s_resize_spi0_stb;
+wire  [2:0] wb_m2s_resize_spi0_cti;
+wire  [1:0] wb_m2s_resize_spi0_bte;
+wire [31:0] wb_s2m_resize_spi0_dat;
+wire        wb_s2m_resize_spi0_ack;
+wire        wb_s2m_resize_spi0_err;
+wire        wb_s2m_resize_spi0_rty;
+wire [31:0] wb_m2s_resize_uart0_adr;
+wire [31:0] wb_m2s_resize_uart0_dat;
+wire  [3:0] wb_m2s_resize_uart0_sel;
+wire        wb_m2s_resize_uart0_we;
+wire        wb_m2s_resize_uart0_cyc;
+wire        wb_m2s_resize_uart0_stb;
+wire  [2:0] wb_m2s_resize_uart0_cti;
+wire  [1:0] wb_m2s_resize_uart0_bte;
+wire [31:0] wb_s2m_resize_uart0_dat;
+wire        wb_s2m_resize_uart0_ack;
+wire        wb_s2m_resize_uart0_err;
+wire        wb_s2m_resize_uart0_rty;
+wire [31:0] wb_m2s_resize_ps2_0_adr;
+wire [31:0] wb_m2s_resize_ps2_0_dat;
+wire  [3:0] wb_m2s_resize_ps2_0_sel;
+wire        wb_m2s_resize_ps2_0_we;
+wire        wb_m2s_resize_ps2_0_cyc;
+wire        wb_m2s_resize_ps2_0_stb;
+wire  [2:0] wb_m2s_resize_ps2_0_cti;
+wire  [1:0] wb_m2s_resize_ps2_0_bte;
+wire [31:0] wb_s2m_resize_ps2_0_dat;
+wire        wb_s2m_resize_ps2_0_ack;
+wire        wb_s2m_resize_ps2_0_err;
+wire        wb_s2m_resize_ps2_0_rty;
+wire [31:0] wb_m2s_resize_ps2_2_adr;
+wire [31:0] wb_m2s_resize_ps2_2_dat;
+wire  [3:0] wb_m2s_resize_ps2_2_sel;
+wire        wb_m2s_resize_ps2_2_we;
+wire        wb_m2s_resize_ps2_2_cyc;
+wire        wb_m2s_resize_ps2_2_stb;
+wire  [2:0] wb_m2s_resize_ps2_2_cti;
+wire  [1:0] wb_m2s_resize_ps2_2_bte;
+wire [31:0] wb_s2m_resize_ps2_2_dat;
+wire        wb_s2m_resize_ps2_2_ack;
+wire        wb_s2m_resize_ps2_2_err;
+wire        wb_s2m_resize_ps2_2_rty;
+wire [31:0] wb_m2s_resize_ps2_1_adr;
+wire [31:0] wb_m2s_resize_ps2_1_dat;
+wire  [3:0] wb_m2s_resize_ps2_1_sel;
+wire        wb_m2s_resize_ps2_1_we;
+wire        wb_m2s_resize_ps2_1_cyc;
+wire        wb_m2s_resize_ps2_1_stb;
+wire  [2:0] wb_m2s_resize_ps2_1_cti;
+wire  [1:0] wb_m2s_resize_ps2_1_bte;
+wire [31:0] wb_s2m_resize_ps2_1_dat;
+wire        wb_s2m_resize_ps2_1_ack;
+wire        wb_s2m_resize_ps2_1_err;
+wire        wb_s2m_resize_ps2_1_rty;
+
+wb_mux
+  #(.num_slaves (2),
+    .MATCH_ADDR ({32'h00000000, 32'hf0000100}),
+    .MATCH_MASK ({32'hf8000000, 32'hffffffc0}))
+ wb_mux_or1k_i
+   (.wb_clk_i  (wb_clk_i),
+    .wb_rst_i  (wb_rst_i),
+    .wbm_adr_i (wb_or1k_i_adr_i),
+    .wbm_dat_i (wb_or1k_i_dat_i),
+    .wbm_sel_i (wb_or1k_i_sel_i),
+    .wbm_we_i  (wb_or1k_i_we_i),
+    .wbm_cyc_i (wb_or1k_i_cyc_i),
+    .wbm_stb_i (wb_or1k_i_stb_i),
+    .wbm_cti_i (wb_or1k_i_cti_i),
+    .wbm_bte_i (wb_or1k_i_bte_i),
+    .wbm_dat_o (wb_or1k_i_dat_o),
+    .wbm_ack_o (wb_or1k_i_ack_o),
+    .wbm_err_o (wb_or1k_i_err_o),
+    .wbm_rty_o (wb_or1k_i_rty_o),
+    .wbs_adr_o ({wb_ddr2_ibus_adr_o, wb_rom0_adr_o}),
+    .wbs_dat_o ({wb_ddr2_ibus_dat_o, wb_rom0_dat_o}),
+    .wbs_sel_o ({wb_ddr2_ibus_sel_o, wb_rom0_sel_o}),
+    .wbs_we_o  ({wb_ddr2_ibus_we_o, wb_rom0_we_o}),
+    .wbs_cyc_o ({wb_ddr2_ibus_cyc_o, wb_rom0_cyc_o}),
+    .wbs_stb_o ({wb_ddr2_ibus_stb_o, wb_rom0_stb_o}),
+    .wbs_cti_o ({wb_ddr2_ibus_cti_o, wb_rom0_cti_o}),
+    .wbs_bte_o ({wb_ddr2_ibus_bte_o, wb_rom0_bte_o}),
+    .wbs_dat_i ({wb_ddr2_ibus_dat_i, wb_rom0_dat_i}),
+    .wbs_ack_i ({wb_ddr2_ibus_ack_i, wb_rom0_ack_i}),
+    .wbs_err_i ({wb_ddr2_ibus_err_i, wb_rom0_err_i}),
+    .wbs_rty_i ({wb_ddr2_ibus_rty_i, wb_rom0_rty_i}));
+
+wb_mux
+  #(.num_slaves (9),
+    .MATCH_ADDR ({32'h00000000, 32'h90000000, 32'h91000000, 32'hb0000000, 32'h97000000, 32'h92000000, 32'h94000000, 32'h95000000, 32'h9a000000}),
+    .MATCH_MASK ({32'hf8000000, 32'hffffffe0, 32'hfffffffe, 32'hfffffff8, 32'hfffff000, 32'hfffff000, 32'hfffffff8, 32'hfffffff8, 32'hfffffff8}))
+ wb_mux_or1k_d
+   (.wb_clk_i  (wb_clk_i),
+    .wb_rst_i  (wb_rst_i),
+    .wbm_adr_i (wb_or1k_d_adr_i),
+    .wbm_dat_i (wb_or1k_d_dat_i),
+    .wbm_sel_i (wb_or1k_d_sel_i),
+    .wbm_we_i  (wb_or1k_d_we_i),
+    .wbm_cyc_i (wb_or1k_d_cyc_i),
+    .wbm_stb_i (wb_or1k_d_stb_i),
+    .wbm_cti_i (wb_or1k_d_cti_i),
+    .wbm_bte_i (wb_or1k_d_bte_i),
+    .wbm_dat_o (wb_or1k_d_dat_o),
+    .wbm_ack_o (wb_or1k_d_ack_o),
+    .wbm_err_o (wb_or1k_d_err_o),
+    .wbm_rty_o (wb_or1k_d_rty_o),
+    .wbs_adr_o ({wb_m2s_or1k_d_ddr2_dbus_adr, wb_m2s_or1k_d_uart0_adr, wb_m2s_or1k_d_gpio0_adr, wb_m2s_or1k_d_spi0_adr, wb_m2s_or1k_d_vga0_adr, wb_m2s_or1k_d_eth0_adr, wb_m2s_or1k_d_ps2_0_adr, wb_m2s_or1k_d_ps2_1_adr, wb_m2s_or1k_d_ps2_2_adr}),
+    .wbs_dat_o ({wb_m2s_or1k_d_ddr2_dbus_dat, wb_m2s_or1k_d_uart0_dat, wb_m2s_or1k_d_gpio0_dat, wb_m2s_or1k_d_spi0_dat, wb_m2s_or1k_d_vga0_dat, wb_m2s_or1k_d_eth0_dat, wb_m2s_or1k_d_ps2_0_dat, wb_m2s_or1k_d_ps2_1_dat, wb_m2s_or1k_d_ps2_2_dat}),
+    .wbs_sel_o ({wb_m2s_or1k_d_ddr2_dbus_sel, wb_m2s_or1k_d_uart0_sel, wb_m2s_or1k_d_gpio0_sel, wb_m2s_or1k_d_spi0_sel, wb_m2s_or1k_d_vga0_sel, wb_m2s_or1k_d_eth0_sel, wb_m2s_or1k_d_ps2_0_sel, wb_m2s_or1k_d_ps2_1_sel, wb_m2s_or1k_d_ps2_2_sel}),
+    .wbs_we_o  ({wb_m2s_or1k_d_ddr2_dbus_we, wb_m2s_or1k_d_uart0_we, wb_m2s_or1k_d_gpio0_we, wb_m2s_or1k_d_spi0_we, wb_m2s_or1k_d_vga0_we, wb_m2s_or1k_d_eth0_we, wb_m2s_or1k_d_ps2_0_we, wb_m2s_or1k_d_ps2_1_we, wb_m2s_or1k_d_ps2_2_we}),
+    .wbs_cyc_o ({wb_m2s_or1k_d_ddr2_dbus_cyc, wb_m2s_or1k_d_uart0_cyc, wb_m2s_or1k_d_gpio0_cyc, wb_m2s_or1k_d_spi0_cyc, wb_m2s_or1k_d_vga0_cyc, wb_m2s_or1k_d_eth0_cyc, wb_m2s_or1k_d_ps2_0_cyc, wb_m2s_or1k_d_ps2_1_cyc, wb_m2s_or1k_d_ps2_2_cyc}),
+    .wbs_stb_o ({wb_m2s_or1k_d_ddr2_dbus_stb, wb_m2s_or1k_d_uart0_stb, wb_m2s_or1k_d_gpio0_stb, wb_m2s_or1k_d_spi0_stb, wb_m2s_or1k_d_vga0_stb, wb_m2s_or1k_d_eth0_stb, wb_m2s_or1k_d_ps2_0_stb, wb_m2s_or1k_d_ps2_1_stb, wb_m2s_or1k_d_ps2_2_stb}),
+    .wbs_cti_o ({wb_m2s_or1k_d_ddr2_dbus_cti, wb_m2s_or1k_d_uart0_cti, wb_m2s_or1k_d_gpio0_cti, wb_m2s_or1k_d_spi0_cti, wb_m2s_or1k_d_vga0_cti, wb_m2s_or1k_d_eth0_cti, wb_m2s_or1k_d_ps2_0_cti, wb_m2s_or1k_d_ps2_1_cti, wb_m2s_or1k_d_ps2_2_cti}),
+    .wbs_bte_o ({wb_m2s_or1k_d_ddr2_dbus_bte, wb_m2s_or1k_d_uart0_bte, wb_m2s_or1k_d_gpio0_bte, wb_m2s_or1k_d_spi0_bte, wb_m2s_or1k_d_vga0_bte, wb_m2s_or1k_d_eth0_bte, wb_m2s_or1k_d_ps2_0_bte, wb_m2s_or1k_d_ps2_1_bte, wb_m2s_or1k_d_ps2_2_bte}),
+    .wbs_dat_i ({wb_s2m_or1k_d_ddr2_dbus_dat, wb_s2m_or1k_d_uart0_dat, wb_s2m_or1k_d_gpio0_dat, wb_s2m_or1k_d_spi0_dat, wb_s2m_or1k_d_vga0_dat, wb_s2m_or1k_d_eth0_dat, wb_s2m_or1k_d_ps2_0_dat, wb_s2m_or1k_d_ps2_1_dat, wb_s2m_or1k_d_ps2_2_dat}),
+    .wbs_ack_i ({wb_s2m_or1k_d_ddr2_dbus_ack, wb_s2m_or1k_d_uart0_ack, wb_s2m_or1k_d_gpio0_ack, wb_s2m_or1k_d_spi0_ack, wb_s2m_or1k_d_vga0_ack, wb_s2m_or1k_d_eth0_ack, wb_s2m_or1k_d_ps2_0_ack, wb_s2m_or1k_d_ps2_1_ack, wb_s2m_or1k_d_ps2_2_ack}),
+    .wbs_err_i ({wb_s2m_or1k_d_ddr2_dbus_err, wb_s2m_or1k_d_uart0_err, wb_s2m_or1k_d_gpio0_err, wb_s2m_or1k_d_spi0_err, wb_s2m_or1k_d_vga0_err, wb_s2m_or1k_d_eth0_err, wb_s2m_or1k_d_ps2_0_err, wb_s2m_or1k_d_ps2_1_err, wb_s2m_or1k_d_ps2_2_err}),
+    .wbs_rty_i ({wb_s2m_or1k_d_ddr2_dbus_rty, wb_s2m_or1k_d_uart0_rty, wb_s2m_or1k_d_gpio0_rty, wb_s2m_or1k_d_spi0_rty, wb_s2m_or1k_d_vga0_rty, wb_s2m_or1k_d_eth0_rty, wb_s2m_or1k_d_ps2_0_rty, wb_s2m_or1k_d_ps2_1_rty, wb_s2m_or1k_d_ps2_2_rty}));
+
+wb_mux
+  #(.num_slaves (10),
+    .MATCH_ADDR ({32'h00000000, 32'h90000000, 32'h91000000, 32'hb0000000, 32'h97000000, 32'h92000000, 32'h94000000, 32'h95000000, 32'h9a000000, 32'h96000000}),
+    .MATCH_MASK ({32'hf8000000, 32'hffffffe0, 32'hfffffffe, 32'hfffffff8, 32'hfffff000, 32'hfffff000, 32'hfffffff8, 32'hfffffff8, 32'hfffffff8, 32'hffb00000}))
+ wb_mux_dbg
+   (.wb_clk_i  (wb_clk_i),
+    .wb_rst_i  (wb_rst_i),
+    .wbm_adr_i (wb_dbg_adr_i),
+    .wbm_dat_i (wb_dbg_dat_i),
+    .wbm_sel_i (wb_dbg_sel_i),
+    .wbm_we_i  (wb_dbg_we_i),
+    .wbm_cyc_i (wb_dbg_cyc_i),
+    .wbm_stb_i (wb_dbg_stb_i),
+    .wbm_cti_i (wb_dbg_cti_i),
+    .wbm_bte_i (wb_dbg_bte_i),
+    .wbm_dat_o (wb_dbg_dat_o),
+    .wbm_ack_o (wb_dbg_ack_o),
+    .wbm_err_o (wb_dbg_err_o),
+    .wbm_rty_o (wb_dbg_rty_o),
+    .wbs_adr_o ({wb_m2s_dbg_ddr2_dbus_adr, wb_m2s_dbg_uart0_adr, wb_m2s_dbg_gpio0_adr, wb_m2s_dbg_spi0_adr, wb_m2s_dbg_vga0_adr, wb_m2s_dbg_eth0_adr, wb_m2s_dbg_ps2_0_adr, wb_m2s_dbg_ps2_1_adr, wb_m2s_dbg_ps2_2_adr, wb_diila_adr_o}),
+    .wbs_dat_o ({wb_m2s_dbg_ddr2_dbus_dat, wb_m2s_dbg_uart0_dat, wb_m2s_dbg_gpio0_dat, wb_m2s_dbg_spi0_dat, wb_m2s_dbg_vga0_dat, wb_m2s_dbg_eth0_dat, wb_m2s_dbg_ps2_0_dat, wb_m2s_dbg_ps2_1_dat, wb_m2s_dbg_ps2_2_dat, wb_diila_dat_o}),
+    .wbs_sel_o ({wb_m2s_dbg_ddr2_dbus_sel, wb_m2s_dbg_uart0_sel, wb_m2s_dbg_gpio0_sel, wb_m2s_dbg_spi0_sel, wb_m2s_dbg_vga0_sel, wb_m2s_dbg_eth0_sel, wb_m2s_dbg_ps2_0_sel, wb_m2s_dbg_ps2_1_sel, wb_m2s_dbg_ps2_2_sel, wb_diila_sel_o}),
+    .wbs_we_o  ({wb_m2s_dbg_ddr2_dbus_we, wb_m2s_dbg_uart0_we, wb_m2s_dbg_gpio0_we, wb_m2s_dbg_spi0_we, wb_m2s_dbg_vga0_we, wb_m2s_dbg_eth0_we, wb_m2s_dbg_ps2_0_we, wb_m2s_dbg_ps2_1_we, wb_m2s_dbg_ps2_2_we, wb_diila_we_o}),
+    .wbs_cyc_o ({wb_m2s_dbg_ddr2_dbus_cyc, wb_m2s_dbg_uart0_cyc, wb_m2s_dbg_gpio0_cyc, wb_m2s_dbg_spi0_cyc, wb_m2s_dbg_vga0_cyc, wb_m2s_dbg_eth0_cyc, wb_m2s_dbg_ps2_0_cyc, wb_m2s_dbg_ps2_1_cyc, wb_m2s_dbg_ps2_2_cyc, wb_diila_cyc_o}),
+    .wbs_stb_o ({wb_m2s_dbg_ddr2_dbus_stb, wb_m2s_dbg_uart0_stb, wb_m2s_dbg_gpio0_stb, wb_m2s_dbg_spi0_stb, wb_m2s_dbg_vga0_stb, wb_m2s_dbg_eth0_stb, wb_m2s_dbg_ps2_0_stb, wb_m2s_dbg_ps2_1_stb, wb_m2s_dbg_ps2_2_stb, wb_diila_stb_o}),
+    .wbs_cti_o ({wb_m2s_dbg_ddr2_dbus_cti, wb_m2s_dbg_uart0_cti, wb_m2s_dbg_gpio0_cti, wb_m2s_dbg_spi0_cti, wb_m2s_dbg_vga0_cti, wb_m2s_dbg_eth0_cti, wb_m2s_dbg_ps2_0_cti, wb_m2s_dbg_ps2_1_cti, wb_m2s_dbg_ps2_2_cti, wb_diila_cti_o}),
+    .wbs_bte_o ({wb_m2s_dbg_ddr2_dbus_bte, wb_m2s_dbg_uart0_bte, wb_m2s_dbg_gpio0_bte, wb_m2s_dbg_spi0_bte, wb_m2s_dbg_vga0_bte, wb_m2s_dbg_eth0_bte, wb_m2s_dbg_ps2_0_bte, wb_m2s_dbg_ps2_1_bte, wb_m2s_dbg_ps2_2_bte, wb_diila_bte_o}),
+    .wbs_dat_i ({wb_s2m_dbg_ddr2_dbus_dat, wb_s2m_dbg_uart0_dat, wb_s2m_dbg_gpio0_dat, wb_s2m_dbg_spi0_dat, wb_s2m_dbg_vga0_dat, wb_s2m_dbg_eth0_dat, wb_s2m_dbg_ps2_0_dat, wb_s2m_dbg_ps2_1_dat, wb_s2m_dbg_ps2_2_dat, wb_diila_dat_i}),
+    .wbs_ack_i ({wb_s2m_dbg_ddr2_dbus_ack, wb_s2m_dbg_uart0_ack, wb_s2m_dbg_gpio0_ack, wb_s2m_dbg_spi0_ack, wb_s2m_dbg_vga0_ack, wb_s2m_dbg_eth0_ack, wb_s2m_dbg_ps2_0_ack, wb_s2m_dbg_ps2_1_ack, wb_s2m_dbg_ps2_2_ack, wb_diila_ack_i}),
+    .wbs_err_i ({wb_s2m_dbg_ddr2_dbus_err, wb_s2m_dbg_uart0_err, wb_s2m_dbg_gpio0_err, wb_s2m_dbg_spi0_err, wb_s2m_dbg_vga0_err, wb_s2m_dbg_eth0_err, wb_s2m_dbg_ps2_0_err, wb_s2m_dbg_ps2_1_err, wb_s2m_dbg_ps2_2_err, wb_diila_err_i}),
+    .wbs_rty_i ({wb_s2m_dbg_ddr2_dbus_rty, wb_s2m_dbg_uart0_rty, wb_s2m_dbg_gpio0_rty, wb_s2m_dbg_spi0_rty, wb_s2m_dbg_vga0_rty, wb_s2m_dbg_eth0_rty, wb_s2m_dbg_ps2_0_rty, wb_s2m_dbg_ps2_1_rty, wb_s2m_dbg_ps2_2_rty, wb_diila_rty_i}));
+
+wb_mux
+  #(.num_slaves (1),
+    .MATCH_ADDR ({32'h00000000}),
+    .MATCH_MASK ({32'hf8000000}))
+ wb_mux_vga0_master
+   (.wb_clk_i  (wb_clk_i),
+    .wb_rst_i  (wb_rst_i),
+    .wbm_adr_i (wb_vga0_master_adr_i),
+    .wbm_dat_i (wb_vga0_master_dat_i),
+    .wbm_sel_i (wb_vga0_master_sel_i),
+    .wbm_we_i  (wb_vga0_master_we_i),
+    .wbm_cyc_i (wb_vga0_master_cyc_i),
+    .wbm_stb_i (wb_vga0_master_stb_i),
+    .wbm_cti_i (wb_vga0_master_cti_i),
+    .wbm_bte_i (wb_vga0_master_bte_i),
+    .wbm_dat_o (wb_vga0_master_dat_o),
+    .wbm_ack_o (wb_vga0_master_ack_o),
+    .wbm_err_o (wb_vga0_master_err_o),
+    .wbm_rty_o (wb_vga0_master_rty_o),
+    .wbs_adr_o ({wb_ddr2_vga0_adr_o}),
+    .wbs_dat_o ({wb_ddr2_vga0_dat_o}),
+    .wbs_sel_o ({wb_ddr2_vga0_sel_o}),
+    .wbs_we_o  ({wb_ddr2_vga0_we_o}),
+    .wbs_cyc_o ({wb_ddr2_vga0_cyc_o}),
+    .wbs_stb_o ({wb_ddr2_vga0_stb_o}),
+    .wbs_cti_o ({wb_ddr2_vga0_cti_o}),
+    .wbs_bte_o ({wb_ddr2_vga0_bte_o}),
+    .wbs_dat_i ({wb_ddr2_vga0_dat_i}),
+    .wbs_ack_i ({wb_ddr2_vga0_ack_i}),
+    .wbs_err_i ({wb_ddr2_vga0_err_i}),
+    .wbs_rty_i ({wb_ddr2_vga0_rty_i}));
+
+wb_mux
+  #(.num_slaves (1),
+    .MATCH_ADDR ({32'h00000000}),
+    .MATCH_MASK ({32'hf8000000}))
+ wb_mux_eth0_master
+   (.wb_clk_i  (wb_clk_i),
+    .wb_rst_i  (wb_rst_i),
+    .wbm_adr_i (wb_eth0_master_adr_i),
+    .wbm_dat_i (wb_eth0_master_dat_i),
+    .wbm_sel_i (wb_eth0_master_sel_i),
+    .wbm_we_i  (wb_eth0_master_we_i),
+    .wbm_cyc_i (wb_eth0_master_cyc_i),
+    .wbm_stb_i (wb_eth0_master_stb_i),
+    .wbm_cti_i (wb_eth0_master_cti_i),
+    .wbm_bte_i (wb_eth0_master_bte_i),
+    .wbm_dat_o (wb_eth0_master_dat_o),
+    .wbm_ack_o (wb_eth0_master_ack_o),
+    .wbm_err_o (wb_eth0_master_err_o),
+    .wbm_rty_o (wb_eth0_master_rty_o),
+    .wbs_adr_o ({wb_ddr2_eth0_adr_o}),
+    .wbs_dat_o ({wb_ddr2_eth0_dat_o}),
+    .wbs_sel_o ({wb_ddr2_eth0_sel_o}),
+    .wbs_we_o  ({wb_ddr2_eth0_we_o}),
+    .wbs_cyc_o ({wb_ddr2_eth0_cyc_o}),
+    .wbs_stb_o ({wb_ddr2_eth0_stb_o}),
+    .wbs_cti_o ({wb_ddr2_eth0_cti_o}),
+    .wbs_bte_o ({wb_ddr2_eth0_bte_o}),
+    .wbs_dat_i ({wb_ddr2_eth0_dat_i}),
+    .wbs_ack_i ({wb_ddr2_eth0_ack_i}),
+    .wbs_err_i ({wb_ddr2_eth0_err_i}),
+    .wbs_rty_i ({wb_ddr2_eth0_rty_i}));
+
+wb_arbiter
+  #(.num_masters (2))
+ wb_arbiter_gpio0
+   (.wb_clk_i  (wb_clk_i),
+    .wb_rst_i  (wb_rst_i),
+    .wbm_adr_i ({wb_m2s_or1k_d_gpio0_adr, wb_m2s_dbg_gpio0_adr}),
+    .wbm_dat_i ({wb_m2s_or1k_d_gpio0_dat, wb_m2s_dbg_gpio0_dat}),
+    .wbm_sel_i ({wb_m2s_or1k_d_gpio0_sel, wb_m2s_dbg_gpio0_sel}),
+    .wbm_we_i  ({wb_m2s_or1k_d_gpio0_we, wb_m2s_dbg_gpio0_we}),
+    .wbm_cyc_i ({wb_m2s_or1k_d_gpio0_cyc, wb_m2s_dbg_gpio0_cyc}),
+    .wbm_stb_i ({wb_m2s_or1k_d_gpio0_stb, wb_m2s_dbg_gpio0_stb}),
+    .wbm_cti_i ({wb_m2s_or1k_d_gpio0_cti, wb_m2s_dbg_gpio0_cti}),
+    .wbm_bte_i ({wb_m2s_or1k_d_gpio0_bte, wb_m2s_dbg_gpio0_bte}),
+    .wbm_dat_o ({wb_s2m_or1k_d_gpio0_dat, wb_s2m_dbg_gpio0_dat}),
+    .wbm_ack_o ({wb_s2m_or1k_d_gpio0_ack, wb_s2m_dbg_gpio0_ack}),
+    .wbm_err_o ({wb_s2m_or1k_d_gpio0_err, wb_s2m_dbg_gpio0_err}),
+    .wbm_rty_o ({wb_s2m_or1k_d_gpio0_rty, wb_s2m_dbg_gpio0_rty}),
+    .wbs_adr_o (wb_m2s_resize_gpio0_adr),
+    .wbs_dat_o (wb_m2s_resize_gpio0_dat),
+    .wbs_sel_o (wb_m2s_resize_gpio0_sel),
+    .wbs_we_o  (wb_m2s_resize_gpio0_we),
+    .wbs_cyc_o (wb_m2s_resize_gpio0_cyc),
+    .wbs_stb_o (wb_m2s_resize_gpio0_stb),
+    .wbs_cti_o (wb_m2s_resize_gpio0_cti),
+    .wbs_bte_o (wb_m2s_resize_gpio0_bte),
+    .wbs_dat_i (wb_s2m_resize_gpio0_dat),
+    .wbs_ack_i (wb_s2m_resize_gpio0_ack),
+    .wbs_err_i (wb_s2m_resize_gpio0_err),
+    .wbs_rty_i (wb_s2m_resize_gpio0_rty));
+
+wb_data_resize
+  #(.aw  (32),
+    .mdw (32),
+    .sdw (8))
+ wb_data_resize_gpio0
+   (.wbm_adr_i (wb_m2s_resize_gpio0_adr),
+    .wbm_dat_i (wb_m2s_resize_gpio0_dat),
+    .wbm_sel_i (wb_m2s_resize_gpio0_sel),
+    .wbm_we_i  (wb_m2s_resize_gpio0_we),
+    .wbm_cyc_i (wb_m2s_resize_gpio0_cyc),
+    .wbm_stb_i (wb_m2s_resize_gpio0_stb),
+    .wbm_cti_i (wb_m2s_resize_gpio0_cti),
+    .wbm_bte_i (wb_m2s_resize_gpio0_bte),
+    .wbm_dat_o (wb_s2m_resize_gpio0_dat),
+    .wbm_ack_o (wb_s2m_resize_gpio0_ack),
+    .wbm_err_o (wb_s2m_resize_gpio0_err),
+    .wbm_rty_o (wb_s2m_resize_gpio0_rty),
+    .wbs_adr_o (wb_gpio0_adr_o),
+    .wbs_dat_o (wb_gpio0_dat_o),
+    .wbs_we_o  (wb_gpio0_we_o),
+    .wbs_cyc_o (wb_gpio0_cyc_o),
+    .wbs_stb_o (wb_gpio0_stb_o),
+    .wbs_cti_o (wb_gpio0_cti_o),
+    .wbs_bte_o (wb_gpio0_bte_o),
+    .wbs_dat_i (wb_gpio0_dat_i),
+    .wbs_ack_i (wb_gpio0_ack_i),
+    .wbs_err_i (wb_gpio0_err_i),
+    .wbs_rty_i (wb_gpio0_rty_i));
+
+wb_arbiter
+  #(.num_masters (2))
+ wb_arbiter_ddr2_dbus
+   (.wb_clk_i  (wb_clk_i),
+    .wb_rst_i  (wb_rst_i),
+    .wbm_adr_i ({wb_m2s_or1k_d_ddr2_dbus_adr, wb_m2s_dbg_ddr2_dbus_adr}),
+    .wbm_dat_i ({wb_m2s_or1k_d_ddr2_dbus_dat, wb_m2s_dbg_ddr2_dbus_dat}),
+    .wbm_sel_i ({wb_m2s_or1k_d_ddr2_dbus_sel, wb_m2s_dbg_ddr2_dbus_sel}),
+    .wbm_we_i  ({wb_m2s_or1k_d_ddr2_dbus_we, wb_m2s_dbg_ddr2_dbus_we}),
+    .wbm_cyc_i ({wb_m2s_or1k_d_ddr2_dbus_cyc, wb_m2s_dbg_ddr2_dbus_cyc}),
+    .wbm_stb_i ({wb_m2s_or1k_d_ddr2_dbus_stb, wb_m2s_dbg_ddr2_dbus_stb}),
+    .wbm_cti_i ({wb_m2s_or1k_d_ddr2_dbus_cti, wb_m2s_dbg_ddr2_dbus_cti}),
+    .wbm_bte_i ({wb_m2s_or1k_d_ddr2_dbus_bte, wb_m2s_dbg_ddr2_dbus_bte}),
+    .wbm_dat_o ({wb_s2m_or1k_d_ddr2_dbus_dat, wb_s2m_dbg_ddr2_dbus_dat}),
+    .wbm_ack_o ({wb_s2m_or1k_d_ddr2_dbus_ack, wb_s2m_dbg_ddr2_dbus_ack}),
+    .wbm_err_o ({wb_s2m_or1k_d_ddr2_dbus_err, wb_s2m_dbg_ddr2_dbus_err}),
+    .wbm_rty_o ({wb_s2m_or1k_d_ddr2_dbus_rty, wb_s2m_dbg_ddr2_dbus_rty}),
+    .wbs_adr_o (wb_ddr2_dbus_adr_o),
+    .wbs_dat_o (wb_ddr2_dbus_dat_o),
+    .wbs_sel_o (wb_ddr2_dbus_sel_o),
+    .wbs_we_o  (wb_ddr2_dbus_we_o),
+    .wbs_cyc_o (wb_ddr2_dbus_cyc_o),
+    .wbs_stb_o (wb_ddr2_dbus_stb_o),
+    .wbs_cti_o (wb_ddr2_dbus_cti_o),
+    .wbs_bte_o (wb_ddr2_dbus_bte_o),
+    .wbs_dat_i (wb_ddr2_dbus_dat_i),
+    .wbs_ack_i (wb_ddr2_dbus_ack_i),
+    .wbs_err_i (wb_ddr2_dbus_err_i),
+    .wbs_rty_i (wb_ddr2_dbus_rty_i));
+
+wb_arbiter
+  #(.num_masters (2))
+ wb_arbiter_spi0
+   (.wb_clk_i  (wb_clk_i),
+    .wb_rst_i  (wb_rst_i),
+    .wbm_adr_i ({wb_m2s_or1k_d_spi0_adr, wb_m2s_dbg_spi0_adr}),
+    .wbm_dat_i ({wb_m2s_or1k_d_spi0_dat, wb_m2s_dbg_spi0_dat}),
+    .wbm_sel_i ({wb_m2s_or1k_d_spi0_sel, wb_m2s_dbg_spi0_sel}),
+    .wbm_we_i  ({wb_m2s_or1k_d_spi0_we, wb_m2s_dbg_spi0_we}),
+    .wbm_cyc_i ({wb_m2s_or1k_d_spi0_cyc, wb_m2s_dbg_spi0_cyc}),
+    .wbm_stb_i ({wb_m2s_or1k_d_spi0_stb, wb_m2s_dbg_spi0_stb}),
+    .wbm_cti_i ({wb_m2s_or1k_d_spi0_cti, wb_m2s_dbg_spi0_cti}),
+    .wbm_bte_i ({wb_m2s_or1k_d_spi0_bte, wb_m2s_dbg_spi0_bte}),
+    .wbm_dat_o ({wb_s2m_or1k_d_spi0_dat, wb_s2m_dbg_spi0_dat}),
+    .wbm_ack_o ({wb_s2m_or1k_d_spi0_ack, wb_s2m_dbg_spi0_ack}),
+    .wbm_err_o ({wb_s2m_or1k_d_spi0_err, wb_s2m_dbg_spi0_err}),
+    .wbm_rty_o ({wb_s2m_or1k_d_spi0_rty, wb_s2m_dbg_spi0_rty}),
+    .wbs_adr_o (wb_m2s_resize_spi0_adr),
+    .wbs_dat_o (wb_m2s_resize_spi0_dat),
+    .wbs_sel_o (wb_m2s_resize_spi0_sel),
+    .wbs_we_o  (wb_m2s_resize_spi0_we),
+    .wbs_cyc_o (wb_m2s_resize_spi0_cyc),
+    .wbs_stb_o (wb_m2s_resize_spi0_stb),
+    .wbs_cti_o (wb_m2s_resize_spi0_cti),
+    .wbs_bte_o (wb_m2s_resize_spi0_bte),
+    .wbs_dat_i (wb_s2m_resize_spi0_dat),
+    .wbs_ack_i (wb_s2m_resize_spi0_ack),
+    .wbs_err_i (wb_s2m_resize_spi0_err),
+    .wbs_rty_i (wb_s2m_resize_spi0_rty));
+
+wb_data_resize
+  #(.aw  (32),
+    .mdw (32),
+    .sdw (8))
+ wb_data_resize_spi0
+   (.wbm_adr_i (wb_m2s_resize_spi0_adr),
+    .wbm_dat_i (wb_m2s_resize_spi0_dat),
+    .wbm_sel_i (wb_m2s_resize_spi0_sel),
+    .wbm_we_i  (wb_m2s_resize_spi0_we),
+    .wbm_cyc_i (wb_m2s_resize_spi0_cyc),
+    .wbm_stb_i (wb_m2s_resize_spi0_stb),
+    .wbm_cti_i (wb_m2s_resize_spi0_cti),
+    .wbm_bte_i (wb_m2s_resize_spi0_bte),
+    .wbm_dat_o (wb_s2m_resize_spi0_dat),
+    .wbm_ack_o (wb_s2m_resize_spi0_ack),
+    .wbm_err_o (wb_s2m_resize_spi0_err),
+    .wbm_rty_o (wb_s2m_resize_spi0_rty),
+    .wbs_adr_o (wb_spi0_adr_o),
+    .wbs_dat_o (wb_spi0_dat_o),
+    .wbs_we_o  (wb_spi0_we_o),
+    .wbs_cyc_o (wb_spi0_cyc_o),
+    .wbs_stb_o (wb_spi0_stb_o),
+    .wbs_cti_o (wb_spi0_cti_o),
+    .wbs_bte_o (wb_spi0_bte_o),
+    .wbs_dat_i (wb_spi0_dat_i),
+    .wbs_ack_i (wb_spi0_ack_i),
+    .wbs_err_i (wb_spi0_err_i),
+    .wbs_rty_i (wb_spi0_rty_i));
+
+wb_arbiter
+  #(.num_masters (2))
+ wb_arbiter_uart0
+   (.wb_clk_i  (wb_clk_i),
+    .wb_rst_i  (wb_rst_i),
+    .wbm_adr_i ({wb_m2s_or1k_d_uart0_adr, wb_m2s_dbg_uart0_adr}),
+    .wbm_dat_i ({wb_m2s_or1k_d_uart0_dat, wb_m2s_dbg_uart0_dat}),
+    .wbm_sel_i ({wb_m2s_or1k_d_uart0_sel, wb_m2s_dbg_uart0_sel}),
+    .wbm_we_i  ({wb_m2s_or1k_d_uart0_we, wb_m2s_dbg_uart0_we}),
+    .wbm_cyc_i ({wb_m2s_or1k_d_uart0_cyc, wb_m2s_dbg_uart0_cyc}),
+    .wbm_stb_i ({wb_m2s_or1k_d_uart0_stb, wb_m2s_dbg_uart0_stb}),
+    .wbm_cti_i ({wb_m2s_or1k_d_uart0_cti, wb_m2s_dbg_uart0_cti}),
+    .wbm_bte_i ({wb_m2s_or1k_d_uart0_bte, wb_m2s_dbg_uart0_bte}),
+    .wbm_dat_o ({wb_s2m_or1k_d_uart0_dat, wb_s2m_dbg_uart0_dat}),
+    .wbm_ack_o ({wb_s2m_or1k_d_uart0_ack, wb_s2m_dbg_uart0_ack}),
+    .wbm_err_o ({wb_s2m_or1k_d_uart0_err, wb_s2m_dbg_uart0_err}),
+    .wbm_rty_o ({wb_s2m_or1k_d_uart0_rty, wb_s2m_dbg_uart0_rty}),
+    .wbs_adr_o (wb_m2s_resize_uart0_adr),
+    .wbs_dat_o (wb_m2s_resize_uart0_dat),
+    .wbs_sel_o (wb_m2s_resize_uart0_sel),
+    .wbs_we_o  (wb_m2s_resize_uart0_we),
+    .wbs_cyc_o (wb_m2s_resize_uart0_cyc),
+    .wbs_stb_o (wb_m2s_resize_uart0_stb),
+    .wbs_cti_o (wb_m2s_resize_uart0_cti),
+    .wbs_bte_o (wb_m2s_resize_uart0_bte),
+    .wbs_dat_i (wb_s2m_resize_uart0_dat),
+    .wbs_ack_i (wb_s2m_resize_uart0_ack),
+    .wbs_err_i (wb_s2m_resize_uart0_err),
+    .wbs_rty_i (wb_s2m_resize_uart0_rty));
+
+wb_data_resize
+  #(.aw  (32),
+    .mdw (32),
+    .sdw (8))
+ wb_data_resize_uart0
+   (.wbm_adr_i (wb_m2s_resize_uart0_adr),
+    .wbm_dat_i (wb_m2s_resize_uart0_dat),
+    .wbm_sel_i (wb_m2s_resize_uart0_sel),
+    .wbm_we_i  (wb_m2s_resize_uart0_we),
+    .wbm_cyc_i (wb_m2s_resize_uart0_cyc),
+    .wbm_stb_i (wb_m2s_resize_uart0_stb),
+    .wbm_cti_i (wb_m2s_resize_uart0_cti),
+    .wbm_bte_i (wb_m2s_resize_uart0_bte),
+    .wbm_dat_o (wb_s2m_resize_uart0_dat),
+    .wbm_ack_o (wb_s2m_resize_uart0_ack),
+    .wbm_err_o (wb_s2m_resize_uart0_err),
+    .wbm_rty_o (wb_s2m_resize_uart0_rty),
+    .wbs_adr_o (wb_uart0_adr_o),
+    .wbs_dat_o (wb_uart0_dat_o),
+    .wbs_we_o  (wb_uart0_we_o),
+    .wbs_cyc_o (wb_uart0_cyc_o),
+    .wbs_stb_o (wb_uart0_stb_o),
+    .wbs_cti_o (wb_uart0_cti_o),
+    .wbs_bte_o (wb_uart0_bte_o),
+    .wbs_dat_i (wb_uart0_dat_i),
+    .wbs_ack_i (wb_uart0_ack_i),
+    .wbs_err_i (wb_uart0_err_i),
+    .wbs_rty_i (wb_uart0_rty_i));
+
+wb_arbiter
+  #(.num_masters (2))
+ wb_arbiter_ps2_0
+   (.wb_clk_i  (wb_clk_i),
+    .wb_rst_i  (wb_rst_i),
+    .wbm_adr_i ({wb_m2s_or1k_d_ps2_0_adr, wb_m2s_dbg_ps2_0_adr}),
+    .wbm_dat_i ({wb_m2s_or1k_d_ps2_0_dat, wb_m2s_dbg_ps2_0_dat}),
+    .wbm_sel_i ({wb_m2s_or1k_d_ps2_0_sel, wb_m2s_dbg_ps2_0_sel}),
+    .wbm_we_i  ({wb_m2s_or1k_d_ps2_0_we, wb_m2s_dbg_ps2_0_we}),
+    .wbm_cyc_i ({wb_m2s_or1k_d_ps2_0_cyc, wb_m2s_dbg_ps2_0_cyc}),
+    .wbm_stb_i ({wb_m2s_or1k_d_ps2_0_stb, wb_m2s_dbg_ps2_0_stb}),
+    .wbm_cti_i ({wb_m2s_or1k_d_ps2_0_cti, wb_m2s_dbg_ps2_0_cti}),
+    .wbm_bte_i ({wb_m2s_or1k_d_ps2_0_bte, wb_m2s_dbg_ps2_0_bte}),
+    .wbm_dat_o ({wb_s2m_or1k_d_ps2_0_dat, wb_s2m_dbg_ps2_0_dat}),
+    .wbm_ack_o ({wb_s2m_or1k_d_ps2_0_ack, wb_s2m_dbg_ps2_0_ack}),
+    .wbm_err_o ({wb_s2m_or1k_d_ps2_0_err, wb_s2m_dbg_ps2_0_err}),
+    .wbm_rty_o ({wb_s2m_or1k_d_ps2_0_rty, wb_s2m_dbg_ps2_0_rty}),
+    .wbs_adr_o (wb_m2s_resize_ps2_0_adr),
+    .wbs_dat_o (wb_m2s_resize_ps2_0_dat),
+    .wbs_sel_o (wb_m2s_resize_ps2_0_sel),
+    .wbs_we_o  (wb_m2s_resize_ps2_0_we),
+    .wbs_cyc_o (wb_m2s_resize_ps2_0_cyc),
+    .wbs_stb_o (wb_m2s_resize_ps2_0_stb),
+    .wbs_cti_o (wb_m2s_resize_ps2_0_cti),
+    .wbs_bte_o (wb_m2s_resize_ps2_0_bte),
+    .wbs_dat_i (wb_s2m_resize_ps2_0_dat),
+    .wbs_ack_i (wb_s2m_resize_ps2_0_ack),
+    .wbs_err_i (wb_s2m_resize_ps2_0_err),
+    .wbs_rty_i (wb_s2m_resize_ps2_0_rty));
+
+wb_data_resize
+  #(.aw  (32),
+    .mdw (32),
+    .sdw (8))
+ wb_data_resize_ps2_0
+   (.wbm_adr_i (wb_m2s_resize_ps2_0_adr),
+    .wbm_dat_i (wb_m2s_resize_ps2_0_dat),
+    .wbm_sel_i (wb_m2s_resize_ps2_0_sel),
+    .wbm_we_i  (wb_m2s_resize_ps2_0_we),
+    .wbm_cyc_i (wb_m2s_resize_ps2_0_cyc),
+    .wbm_stb_i (wb_m2s_resize_ps2_0_stb),
+    .wbm_cti_i (wb_m2s_resize_ps2_0_cti),
+    .wbm_bte_i (wb_m2s_resize_ps2_0_bte),
+    .wbm_dat_o (wb_s2m_resize_ps2_0_dat),
+    .wbm_ack_o (wb_s2m_resize_ps2_0_ack),
+    .wbm_err_o (wb_s2m_resize_ps2_0_err),
+    .wbm_rty_o (wb_s2m_resize_ps2_0_rty),
+    .wbs_adr_o (wb_ps2_0_adr_o),
+    .wbs_dat_o (wb_ps2_0_dat_o),
+    .wbs_we_o  (wb_ps2_0_we_o),
+    .wbs_cyc_o (wb_ps2_0_cyc_o),
+    .wbs_stb_o (wb_ps2_0_stb_o),
+    .wbs_cti_o (wb_ps2_0_cti_o),
+    .wbs_bte_o (wb_ps2_0_bte_o),
+    .wbs_dat_i (wb_ps2_0_dat_i),
+    .wbs_ack_i (wb_ps2_0_ack_i),
+    .wbs_err_i (wb_ps2_0_err_i),
+    .wbs_rty_i (wb_ps2_0_rty_i));
+
+wb_arbiter
+  #(.num_masters (2))
+ wb_arbiter_vga0
+   (.wb_clk_i  (wb_clk_i),
+    .wb_rst_i  (wb_rst_i),
+    .wbm_adr_i ({wb_m2s_or1k_d_vga0_adr, wb_m2s_dbg_vga0_adr}),
+    .wbm_dat_i ({wb_m2s_or1k_d_vga0_dat, wb_m2s_dbg_vga0_dat}),
+    .wbm_sel_i ({wb_m2s_or1k_d_vga0_sel, wb_m2s_dbg_vga0_sel}),
+    .wbm_we_i  ({wb_m2s_or1k_d_vga0_we, wb_m2s_dbg_vga0_we}),
+    .wbm_cyc_i ({wb_m2s_or1k_d_vga0_cyc, wb_m2s_dbg_vga0_cyc}),
+    .wbm_stb_i ({wb_m2s_or1k_d_vga0_stb, wb_m2s_dbg_vga0_stb}),
+    .wbm_cti_i ({wb_m2s_or1k_d_vga0_cti, wb_m2s_dbg_vga0_cti}),
+    .wbm_bte_i ({wb_m2s_or1k_d_vga0_bte, wb_m2s_dbg_vga0_bte}),
+    .wbm_dat_o ({wb_s2m_or1k_d_vga0_dat, wb_s2m_dbg_vga0_dat}),
+    .wbm_ack_o ({wb_s2m_or1k_d_vga0_ack, wb_s2m_dbg_vga0_ack}),
+    .wbm_err_o ({wb_s2m_or1k_d_vga0_err, wb_s2m_dbg_vga0_err}),
+    .wbm_rty_o ({wb_s2m_or1k_d_vga0_rty, wb_s2m_dbg_vga0_rty}),
+    .wbs_adr_o (wb_vga0_adr_o),
+    .wbs_dat_o (wb_vga0_dat_o),
+    .wbs_sel_o (wb_vga0_sel_o),
+    .wbs_we_o  (wb_vga0_we_o),
+    .wbs_cyc_o (wb_vga0_cyc_o),
+    .wbs_stb_o (wb_vga0_stb_o),
+    .wbs_cti_o (wb_vga0_cti_o),
+    .wbs_bte_o (wb_vga0_bte_o),
+    .wbs_dat_i (wb_vga0_dat_i),
+    .wbs_ack_i (wb_vga0_ack_i),
+    .wbs_err_i (wb_vga0_err_i),
+    .wbs_rty_i (wb_vga0_rty_i));
+
+wb_arbiter
+  #(.num_masters (2))
+ wb_arbiter_ps2_2
+   (.wb_clk_i  (wb_clk_i),
+    .wb_rst_i  (wb_rst_i),
+    .wbm_adr_i ({wb_m2s_or1k_d_ps2_2_adr, wb_m2s_dbg_ps2_2_adr}),
+    .wbm_dat_i ({wb_m2s_or1k_d_ps2_2_dat, wb_m2s_dbg_ps2_2_dat}),
+    .wbm_sel_i ({wb_m2s_or1k_d_ps2_2_sel, wb_m2s_dbg_ps2_2_sel}),
+    .wbm_we_i  ({wb_m2s_or1k_d_ps2_2_we, wb_m2s_dbg_ps2_2_we}),
+    .wbm_cyc_i ({wb_m2s_or1k_d_ps2_2_cyc, wb_m2s_dbg_ps2_2_cyc}),
+    .wbm_stb_i ({wb_m2s_or1k_d_ps2_2_stb, wb_m2s_dbg_ps2_2_stb}),
+    .wbm_cti_i ({wb_m2s_or1k_d_ps2_2_cti, wb_m2s_dbg_ps2_2_cti}),
+    .wbm_bte_i ({wb_m2s_or1k_d_ps2_2_bte, wb_m2s_dbg_ps2_2_bte}),
+    .wbm_dat_o ({wb_s2m_or1k_d_ps2_2_dat, wb_s2m_dbg_ps2_2_dat}),
+    .wbm_ack_o ({wb_s2m_or1k_d_ps2_2_ack, wb_s2m_dbg_ps2_2_ack}),
+    .wbm_err_o ({wb_s2m_or1k_d_ps2_2_err, wb_s2m_dbg_ps2_2_err}),
+    .wbm_rty_o ({wb_s2m_or1k_d_ps2_2_rty, wb_s2m_dbg_ps2_2_rty}),
+    .wbs_adr_o (wb_m2s_resize_ps2_2_adr),
+    .wbs_dat_o (wb_m2s_resize_ps2_2_dat),
+    .wbs_sel_o (wb_m2s_resize_ps2_2_sel),
+    .wbs_we_o  (wb_m2s_resize_ps2_2_we),
+    .wbs_cyc_o (wb_m2s_resize_ps2_2_cyc),
+    .wbs_stb_o (wb_m2s_resize_ps2_2_stb),
+    .wbs_cti_o (wb_m2s_resize_ps2_2_cti),
+    .wbs_bte_o (wb_m2s_resize_ps2_2_bte),
+    .wbs_dat_i (wb_s2m_resize_ps2_2_dat),
+    .wbs_ack_i (wb_s2m_resize_ps2_2_ack),
+    .wbs_err_i (wb_s2m_resize_ps2_2_err),
+    .wbs_rty_i (wb_s2m_resize_ps2_2_rty));
+
+wb_data_resize
+  #(.aw  (32),
+    .mdw (32),
+    .sdw (8))
+ wb_data_resize_ps2_2
+   (.wbm_adr_i (wb_m2s_resize_ps2_2_adr),
+    .wbm_dat_i (wb_m2s_resize_ps2_2_dat),
+    .wbm_sel_i (wb_m2s_resize_ps2_2_sel),
+    .wbm_we_i  (wb_m2s_resize_ps2_2_we),
+    .wbm_cyc_i (wb_m2s_resize_ps2_2_cyc),
+    .wbm_stb_i (wb_m2s_resize_ps2_2_stb),
+    .wbm_cti_i (wb_m2s_resize_ps2_2_cti),
+    .wbm_bte_i (wb_m2s_resize_ps2_2_bte),
+    .wbm_dat_o (wb_s2m_resize_ps2_2_dat),
+    .wbm_ack_o (wb_s2m_resize_ps2_2_ack),
+    .wbm_err_o (wb_s2m_resize_ps2_2_err),
+    .wbm_rty_o (wb_s2m_resize_ps2_2_rty),
+    .wbs_adr_o (wb_ps2_2_adr_o),
+    .wbs_dat_o (wb_ps2_2_dat_o),
+    .wbs_we_o  (wb_ps2_2_we_o),
+    .wbs_cyc_o (wb_ps2_2_cyc_o),
+    .wbs_stb_o (wb_ps2_2_stb_o),
+    .wbs_cti_o (wb_ps2_2_cti_o),
+    .wbs_bte_o (wb_ps2_2_bte_o),
+    .wbs_dat_i (wb_ps2_2_dat_i),
+    .wbs_ack_i (wb_ps2_2_ack_i),
+    .wbs_err_i (wb_ps2_2_err_i),
+    .wbs_rty_i (wb_ps2_2_rty_i));
+
+wb_arbiter
+  #(.num_masters (2))
+ wb_arbiter_ps2_1
+   (.wb_clk_i  (wb_clk_i),
+    .wb_rst_i  (wb_rst_i),
+    .wbm_adr_i ({wb_m2s_or1k_d_ps2_1_adr, wb_m2s_dbg_ps2_1_adr}),
+    .wbm_dat_i ({wb_m2s_or1k_d_ps2_1_dat, wb_m2s_dbg_ps2_1_dat}),
+    .wbm_sel_i ({wb_m2s_or1k_d_ps2_1_sel, wb_m2s_dbg_ps2_1_sel}),
+    .wbm_we_i  ({wb_m2s_or1k_d_ps2_1_we, wb_m2s_dbg_ps2_1_we}),
+    .wbm_cyc_i ({wb_m2s_or1k_d_ps2_1_cyc, wb_m2s_dbg_ps2_1_cyc}),
+    .wbm_stb_i ({wb_m2s_or1k_d_ps2_1_stb, wb_m2s_dbg_ps2_1_stb}),
+    .wbm_cti_i ({wb_m2s_or1k_d_ps2_1_cti, wb_m2s_dbg_ps2_1_cti}),
+    .wbm_bte_i ({wb_m2s_or1k_d_ps2_1_bte, wb_m2s_dbg_ps2_1_bte}),
+    .wbm_dat_o ({wb_s2m_or1k_d_ps2_1_dat, wb_s2m_dbg_ps2_1_dat}),
+    .wbm_ack_o ({wb_s2m_or1k_d_ps2_1_ack, wb_s2m_dbg_ps2_1_ack}),
+    .wbm_err_o ({wb_s2m_or1k_d_ps2_1_err, wb_s2m_dbg_ps2_1_err}),
+    .wbm_rty_o ({wb_s2m_or1k_d_ps2_1_rty, wb_s2m_dbg_ps2_1_rty}),
+    .wbs_adr_o (wb_m2s_resize_ps2_1_adr),
+    .wbs_dat_o (wb_m2s_resize_ps2_1_dat),
+    .wbs_sel_o (wb_m2s_resize_ps2_1_sel),
+    .wbs_we_o  (wb_m2s_resize_ps2_1_we),
+    .wbs_cyc_o (wb_m2s_resize_ps2_1_cyc),
+    .wbs_stb_o (wb_m2s_resize_ps2_1_stb),
+    .wbs_cti_o (wb_m2s_resize_ps2_1_cti),
+    .wbs_bte_o (wb_m2s_resize_ps2_1_bte),
+    .wbs_dat_i (wb_s2m_resize_ps2_1_dat),
+    .wbs_ack_i (wb_s2m_resize_ps2_1_ack),
+    .wbs_err_i (wb_s2m_resize_ps2_1_err),
+    .wbs_rty_i (wb_s2m_resize_ps2_1_rty));
+
+wb_data_resize
+  #(.aw  (32),
+    .mdw (32),
+    .sdw (8))
+ wb_data_resize_ps2_1
+   (.wbm_adr_i (wb_m2s_resize_ps2_1_adr),
+    .wbm_dat_i (wb_m2s_resize_ps2_1_dat),
+    .wbm_sel_i (wb_m2s_resize_ps2_1_sel),
+    .wbm_we_i  (wb_m2s_resize_ps2_1_we),
+    .wbm_cyc_i (wb_m2s_resize_ps2_1_cyc),
+    .wbm_stb_i (wb_m2s_resize_ps2_1_stb),
+    .wbm_cti_i (wb_m2s_resize_ps2_1_cti),
+    .wbm_bte_i (wb_m2s_resize_ps2_1_bte),
+    .wbm_dat_o (wb_s2m_resize_ps2_1_dat),
+    .wbm_ack_o (wb_s2m_resize_ps2_1_ack),
+    .wbm_err_o (wb_s2m_resize_ps2_1_err),
+    .wbm_rty_o (wb_s2m_resize_ps2_1_rty),
+    .wbs_adr_o (wb_ps2_1_adr_o),
+    .wbs_dat_o (wb_ps2_1_dat_o),
+    .wbs_we_o  (wb_ps2_1_we_o),
+    .wbs_cyc_o (wb_ps2_1_cyc_o),
+    .wbs_stb_o (wb_ps2_1_stb_o),
+    .wbs_cti_o (wb_ps2_1_cti_o),
+    .wbs_bte_o (wb_ps2_1_bte_o),
+    .wbs_dat_i (wb_ps2_1_dat_i),
+    .wbs_ack_i (wb_ps2_1_ack_i),
+    .wbs_err_i (wb_ps2_1_err_i),
+    .wbs_rty_i (wb_ps2_1_rty_i));
+
+wb_arbiter
+  #(.num_masters (2))
+ wb_arbiter_eth0
+   (.wb_clk_i  (wb_clk_i),
+    .wb_rst_i  (wb_rst_i),
+    .wbm_adr_i ({wb_m2s_or1k_d_eth0_adr, wb_m2s_dbg_eth0_adr}),
+    .wbm_dat_i ({wb_m2s_or1k_d_eth0_dat, wb_m2s_dbg_eth0_dat}),
+    .wbm_sel_i ({wb_m2s_or1k_d_eth0_sel, wb_m2s_dbg_eth0_sel}),
+    .wbm_we_i  ({wb_m2s_or1k_d_eth0_we, wb_m2s_dbg_eth0_we}),
+    .wbm_cyc_i ({wb_m2s_or1k_d_eth0_cyc, wb_m2s_dbg_eth0_cyc}),
+    .wbm_stb_i ({wb_m2s_or1k_d_eth0_stb, wb_m2s_dbg_eth0_stb}),
+    .wbm_cti_i ({wb_m2s_or1k_d_eth0_cti, wb_m2s_dbg_eth0_cti}),
+    .wbm_bte_i ({wb_m2s_or1k_d_eth0_bte, wb_m2s_dbg_eth0_bte}),
+    .wbm_dat_o ({wb_s2m_or1k_d_eth0_dat, wb_s2m_dbg_eth0_dat}),
+    .wbm_ack_o ({wb_s2m_or1k_d_eth0_ack, wb_s2m_dbg_eth0_ack}),
+    .wbm_err_o ({wb_s2m_or1k_d_eth0_err, wb_s2m_dbg_eth0_err}),
+    .wbm_rty_o ({wb_s2m_or1k_d_eth0_rty, wb_s2m_dbg_eth0_rty}),
+    .wbs_adr_o (wb_eth0_adr_o),
+    .wbs_dat_o (wb_eth0_dat_o),
+    .wbs_sel_o (wb_eth0_sel_o),
+    .wbs_we_o  (wb_eth0_we_o),
+    .wbs_cyc_o (wb_eth0_cyc_o),
+    .wbs_stb_o (wb_eth0_stb_o),
+    .wbs_cti_o (wb_eth0_cti_o),
+    .wbs_bte_o (wb_eth0_bte_o),
+    .wbs_dat_i (wb_eth0_dat_i),
+    .wbs_ack_i (wb_eth0_ack_i),
+    .wbs_err_i (wb_eth0_err_i),
+    .wbs_rty_i (wb_eth0_rty_i));
+
+endmodule

--- a/systems/atlys/rtl/verilog/wb_intercon.vh
+++ b/systems/atlys/rtl/verilog/wb_intercon.vh
@@ -1,0 +1,485 @@
+wire [31:0] wb_m2s_or1k_i_adr;
+wire [31:0] wb_m2s_or1k_i_dat;
+wire  [3:0] wb_m2s_or1k_i_sel;
+wire        wb_m2s_or1k_i_we;
+wire        wb_m2s_or1k_i_cyc;
+wire        wb_m2s_or1k_i_stb;
+wire  [2:0] wb_m2s_or1k_i_cti;
+wire  [1:0] wb_m2s_or1k_i_bte;
+wire [31:0] wb_s2m_or1k_i_dat;
+wire        wb_s2m_or1k_i_ack;
+wire        wb_s2m_or1k_i_err;
+wire        wb_s2m_or1k_i_rty;
+wire [31:0] wb_m2s_or1k_d_adr;
+wire [31:0] wb_m2s_or1k_d_dat;
+wire  [3:0] wb_m2s_or1k_d_sel;
+wire        wb_m2s_or1k_d_we;
+wire        wb_m2s_or1k_d_cyc;
+wire        wb_m2s_or1k_d_stb;
+wire  [2:0] wb_m2s_or1k_d_cti;
+wire  [1:0] wb_m2s_or1k_d_bte;
+wire [31:0] wb_s2m_or1k_d_dat;
+wire        wb_s2m_or1k_d_ack;
+wire        wb_s2m_or1k_d_err;
+wire        wb_s2m_or1k_d_rty;
+wire [31:0] wb_m2s_dbg_adr;
+wire [31:0] wb_m2s_dbg_dat;
+wire  [3:0] wb_m2s_dbg_sel;
+wire        wb_m2s_dbg_we;
+wire        wb_m2s_dbg_cyc;
+wire        wb_m2s_dbg_stb;
+wire  [2:0] wb_m2s_dbg_cti;
+wire  [1:0] wb_m2s_dbg_bte;
+wire [31:0] wb_s2m_dbg_dat;
+wire        wb_s2m_dbg_ack;
+wire        wb_s2m_dbg_err;
+wire        wb_s2m_dbg_rty;
+wire [31:0] wb_m2s_vga0_master_adr;
+wire [31:0] wb_m2s_vga0_master_dat;
+wire  [3:0] wb_m2s_vga0_master_sel;
+wire        wb_m2s_vga0_master_we;
+wire        wb_m2s_vga0_master_cyc;
+wire        wb_m2s_vga0_master_stb;
+wire  [2:0] wb_m2s_vga0_master_cti;
+wire  [1:0] wb_m2s_vga0_master_bte;
+wire [31:0] wb_s2m_vga0_master_dat;
+wire        wb_s2m_vga0_master_ack;
+wire        wb_s2m_vga0_master_err;
+wire        wb_s2m_vga0_master_rty;
+wire [31:0] wb_m2s_eth0_master_adr;
+wire [31:0] wb_m2s_eth0_master_dat;
+wire  [3:0] wb_m2s_eth0_master_sel;
+wire        wb_m2s_eth0_master_we;
+wire        wb_m2s_eth0_master_cyc;
+wire        wb_m2s_eth0_master_stb;
+wire  [2:0] wb_m2s_eth0_master_cti;
+wire  [1:0] wb_m2s_eth0_master_bte;
+wire [31:0] wb_s2m_eth0_master_dat;
+wire        wb_s2m_eth0_master_ack;
+wire        wb_s2m_eth0_master_err;
+wire        wb_s2m_eth0_master_rty;
+wire [31:0] wb_m2s_gpio0_adr;
+wire [31:0] wb_m2s_gpio0_dat;
+wire  [3:0] wb_m2s_gpio0_sel;
+wire        wb_m2s_gpio0_we;
+wire        wb_m2s_gpio0_cyc;
+wire        wb_m2s_gpio0_stb;
+wire  [2:0] wb_m2s_gpio0_cti;
+wire  [1:0] wb_m2s_gpio0_bte;
+wire [31:0] wb_s2m_gpio0_dat;
+wire        wb_s2m_gpio0_ack;
+wire        wb_s2m_gpio0_err;
+wire        wb_s2m_gpio0_rty;
+wire [31:0] wb_m2s_rom0_adr;
+wire [31:0] wb_m2s_rom0_dat;
+wire  [3:0] wb_m2s_rom0_sel;
+wire        wb_m2s_rom0_we;
+wire        wb_m2s_rom0_cyc;
+wire        wb_m2s_rom0_stb;
+wire  [2:0] wb_m2s_rom0_cti;
+wire  [1:0] wb_m2s_rom0_bte;
+wire [31:0] wb_s2m_rom0_dat;
+wire        wb_s2m_rom0_ack;
+wire        wb_s2m_rom0_err;
+wire        wb_s2m_rom0_rty;
+wire [31:0] wb_m2s_ddr2_dbus_adr;
+wire [31:0] wb_m2s_ddr2_dbus_dat;
+wire  [3:0] wb_m2s_ddr2_dbus_sel;
+wire        wb_m2s_ddr2_dbus_we;
+wire        wb_m2s_ddr2_dbus_cyc;
+wire        wb_m2s_ddr2_dbus_stb;
+wire  [2:0] wb_m2s_ddr2_dbus_cti;
+wire  [1:0] wb_m2s_ddr2_dbus_bte;
+wire [31:0] wb_s2m_ddr2_dbus_dat;
+wire        wb_s2m_ddr2_dbus_ack;
+wire        wb_s2m_ddr2_dbus_err;
+wire        wb_s2m_ddr2_dbus_rty;
+wire [31:0] wb_m2s_spi0_adr;
+wire [31:0] wb_m2s_spi0_dat;
+wire  [3:0] wb_m2s_spi0_sel;
+wire        wb_m2s_spi0_we;
+wire        wb_m2s_spi0_cyc;
+wire        wb_m2s_spi0_stb;
+wire  [2:0] wb_m2s_spi0_cti;
+wire  [1:0] wb_m2s_spi0_bte;
+wire [31:0] wb_s2m_spi0_dat;
+wire        wb_s2m_spi0_ack;
+wire        wb_s2m_spi0_err;
+wire        wb_s2m_spi0_rty;
+wire [31:0] wb_m2s_diila_adr;
+wire [31:0] wb_m2s_diila_dat;
+wire  [3:0] wb_m2s_diila_sel;
+wire        wb_m2s_diila_we;
+wire        wb_m2s_diila_cyc;
+wire        wb_m2s_diila_stb;
+wire  [2:0] wb_m2s_diila_cti;
+wire  [1:0] wb_m2s_diila_bte;
+wire [31:0] wb_s2m_diila_dat;
+wire        wb_s2m_diila_ack;
+wire        wb_s2m_diila_err;
+wire        wb_s2m_diila_rty;
+wire [31:0] wb_m2s_uart0_adr;
+wire [31:0] wb_m2s_uart0_dat;
+wire  [3:0] wb_m2s_uart0_sel;
+wire        wb_m2s_uart0_we;
+wire        wb_m2s_uart0_cyc;
+wire        wb_m2s_uart0_stb;
+wire  [2:0] wb_m2s_uart0_cti;
+wire  [1:0] wb_m2s_uart0_bte;
+wire [31:0] wb_s2m_uart0_dat;
+wire        wb_s2m_uart0_ack;
+wire        wb_s2m_uart0_err;
+wire        wb_s2m_uart0_rty;
+wire [31:0] wb_m2s_ps2_0_adr;
+wire [31:0] wb_m2s_ps2_0_dat;
+wire  [3:0] wb_m2s_ps2_0_sel;
+wire        wb_m2s_ps2_0_we;
+wire        wb_m2s_ps2_0_cyc;
+wire        wb_m2s_ps2_0_stb;
+wire  [2:0] wb_m2s_ps2_0_cti;
+wire  [1:0] wb_m2s_ps2_0_bte;
+wire [31:0] wb_s2m_ps2_0_dat;
+wire        wb_s2m_ps2_0_ack;
+wire        wb_s2m_ps2_0_err;
+wire        wb_s2m_ps2_0_rty;
+wire [31:0] wb_m2s_vga0_adr;
+wire [31:0] wb_m2s_vga0_dat;
+wire  [3:0] wb_m2s_vga0_sel;
+wire        wb_m2s_vga0_we;
+wire        wb_m2s_vga0_cyc;
+wire        wb_m2s_vga0_stb;
+wire  [2:0] wb_m2s_vga0_cti;
+wire  [1:0] wb_m2s_vga0_bte;
+wire [31:0] wb_s2m_vga0_dat;
+wire        wb_s2m_vga0_ack;
+wire        wb_s2m_vga0_err;
+wire        wb_s2m_vga0_rty;
+wire [31:0] wb_m2s_ddr2_eth0_adr;
+wire [31:0] wb_m2s_ddr2_eth0_dat;
+wire  [3:0] wb_m2s_ddr2_eth0_sel;
+wire        wb_m2s_ddr2_eth0_we;
+wire        wb_m2s_ddr2_eth0_cyc;
+wire        wb_m2s_ddr2_eth0_stb;
+wire  [2:0] wb_m2s_ddr2_eth0_cti;
+wire  [1:0] wb_m2s_ddr2_eth0_bte;
+wire [31:0] wb_s2m_ddr2_eth0_dat;
+wire        wb_s2m_ddr2_eth0_ack;
+wire        wb_s2m_ddr2_eth0_err;
+wire        wb_s2m_ddr2_eth0_rty;
+wire [31:0] wb_m2s_ac97_adr;
+wire [31:0] wb_m2s_ac97_dat;
+wire  [3:0] wb_m2s_ac97_sel;
+wire        wb_m2s_ac97_we;
+wire        wb_m2s_ac97_cyc;
+wire        wb_m2s_ac97_stb;
+wire  [2:0] wb_m2s_ac97_cti;
+wire  [1:0] wb_m2s_ac97_bte;
+wire [31:0] wb_s2m_ac97_dat;
+wire        wb_s2m_ac97_ack;
+wire        wb_s2m_ac97_err;
+wire        wb_s2m_ac97_rty;
+wire [31:0] wb_m2s_ddr2_ibus_adr;
+wire [31:0] wb_m2s_ddr2_ibus_dat;
+wire  [3:0] wb_m2s_ddr2_ibus_sel;
+wire        wb_m2s_ddr2_ibus_we;
+wire        wb_m2s_ddr2_ibus_cyc;
+wire        wb_m2s_ddr2_ibus_stb;
+wire  [2:0] wb_m2s_ddr2_ibus_cti;
+wire  [1:0] wb_m2s_ddr2_ibus_bte;
+wire [31:0] wb_s2m_ddr2_ibus_dat;
+wire        wb_s2m_ddr2_ibus_ack;
+wire        wb_s2m_ddr2_ibus_err;
+wire        wb_s2m_ddr2_ibus_rty;
+wire [31:0] wb_m2s_ddr2_vga0_adr;
+wire [31:0] wb_m2s_ddr2_vga0_dat;
+wire  [3:0] wb_m2s_ddr2_vga0_sel;
+wire        wb_m2s_ddr2_vga0_we;
+wire        wb_m2s_ddr2_vga0_cyc;
+wire        wb_m2s_ddr2_vga0_stb;
+wire  [2:0] wb_m2s_ddr2_vga0_cti;
+wire  [1:0] wb_m2s_ddr2_vga0_bte;
+wire [31:0] wb_s2m_ddr2_vga0_dat;
+wire        wb_s2m_ddr2_vga0_ack;
+wire        wb_s2m_ddr2_vga0_err;
+wire        wb_s2m_ddr2_vga0_rty;
+wire [31:0] wb_m2s_ps2_2_adr;
+wire [31:0] wb_m2s_ps2_2_dat;
+wire  [3:0] wb_m2s_ps2_2_sel;
+wire        wb_m2s_ps2_2_we;
+wire        wb_m2s_ps2_2_cyc;
+wire        wb_m2s_ps2_2_stb;
+wire  [2:0] wb_m2s_ps2_2_cti;
+wire  [1:0] wb_m2s_ps2_2_bte;
+wire [31:0] wb_s2m_ps2_2_dat;
+wire        wb_s2m_ps2_2_ack;
+wire        wb_s2m_ps2_2_err;
+wire        wb_s2m_ps2_2_rty;
+wire [31:0] wb_m2s_ps2_1_adr;
+wire [31:0] wb_m2s_ps2_1_dat;
+wire  [3:0] wb_m2s_ps2_1_sel;
+wire        wb_m2s_ps2_1_we;
+wire        wb_m2s_ps2_1_cyc;
+wire        wb_m2s_ps2_1_stb;
+wire  [2:0] wb_m2s_ps2_1_cti;
+wire  [1:0] wb_m2s_ps2_1_bte;
+wire [31:0] wb_s2m_ps2_1_dat;
+wire        wb_s2m_ps2_1_ack;
+wire        wb_s2m_ps2_1_err;
+wire        wb_s2m_ps2_1_rty;
+wire [31:0] wb_m2s_eth0_adr;
+wire [31:0] wb_m2s_eth0_dat;
+wire  [3:0] wb_m2s_eth0_sel;
+wire        wb_m2s_eth0_we;
+wire        wb_m2s_eth0_cyc;
+wire        wb_m2s_eth0_stb;
+wire  [2:0] wb_m2s_eth0_cti;
+wire  [1:0] wb_m2s_eth0_bte;
+wire [31:0] wb_s2m_eth0_dat;
+wire        wb_s2m_eth0_ack;
+wire        wb_s2m_eth0_err;
+wire        wb_s2m_eth0_rty;
+
+wb_intercon wb_intercon0
+   (.wb_clk_i             (wb_clk),
+    .wb_rst_i             (wb_rst),
+    .wb_or1k_i_adr_i      (wb_m2s_or1k_i_adr),
+    .wb_or1k_i_dat_i      (wb_m2s_or1k_i_dat),
+    .wb_or1k_i_sel_i      (wb_m2s_or1k_i_sel),
+    .wb_or1k_i_we_i       (wb_m2s_or1k_i_we),
+    .wb_or1k_i_cyc_i      (wb_m2s_or1k_i_cyc),
+    .wb_or1k_i_stb_i      (wb_m2s_or1k_i_stb),
+    .wb_or1k_i_cti_i      (wb_m2s_or1k_i_cti),
+    .wb_or1k_i_bte_i      (wb_m2s_or1k_i_bte),
+    .wb_or1k_i_dat_o      (wb_s2m_or1k_i_dat),
+    .wb_or1k_i_ack_o      (wb_s2m_or1k_i_ack),
+    .wb_or1k_i_err_o      (wb_s2m_or1k_i_err),
+    .wb_or1k_i_rty_o      (wb_s2m_or1k_i_rty),
+    .wb_or1k_d_adr_i      (wb_m2s_or1k_d_adr),
+    .wb_or1k_d_dat_i      (wb_m2s_or1k_d_dat),
+    .wb_or1k_d_sel_i      (wb_m2s_or1k_d_sel),
+    .wb_or1k_d_we_i       (wb_m2s_or1k_d_we),
+    .wb_or1k_d_cyc_i      (wb_m2s_or1k_d_cyc),
+    .wb_or1k_d_stb_i      (wb_m2s_or1k_d_stb),
+    .wb_or1k_d_cti_i      (wb_m2s_or1k_d_cti),
+    .wb_or1k_d_bte_i      (wb_m2s_or1k_d_bte),
+    .wb_or1k_d_dat_o      (wb_s2m_or1k_d_dat),
+    .wb_or1k_d_ack_o      (wb_s2m_or1k_d_ack),
+    .wb_or1k_d_err_o      (wb_s2m_or1k_d_err),
+    .wb_or1k_d_rty_o      (wb_s2m_or1k_d_rty),
+    .wb_dbg_adr_i         (wb_m2s_dbg_adr),
+    .wb_dbg_dat_i         (wb_m2s_dbg_dat),
+    .wb_dbg_sel_i         (wb_m2s_dbg_sel),
+    .wb_dbg_we_i          (wb_m2s_dbg_we),
+    .wb_dbg_cyc_i         (wb_m2s_dbg_cyc),
+    .wb_dbg_stb_i         (wb_m2s_dbg_stb),
+    .wb_dbg_cti_i         (wb_m2s_dbg_cti),
+    .wb_dbg_bte_i         (wb_m2s_dbg_bte),
+    .wb_dbg_dat_o         (wb_s2m_dbg_dat),
+    .wb_dbg_ack_o         (wb_s2m_dbg_ack),
+    .wb_dbg_err_o         (wb_s2m_dbg_err),
+    .wb_dbg_rty_o         (wb_s2m_dbg_rty),
+    .wb_vga0_master_adr_i (wb_m2s_vga0_master_adr),
+    .wb_vga0_master_dat_i (wb_m2s_vga0_master_dat),
+    .wb_vga0_master_sel_i (wb_m2s_vga0_master_sel),
+    .wb_vga0_master_we_i  (wb_m2s_vga0_master_we),
+    .wb_vga0_master_cyc_i (wb_m2s_vga0_master_cyc),
+    .wb_vga0_master_stb_i (wb_m2s_vga0_master_stb),
+    .wb_vga0_master_cti_i (wb_m2s_vga0_master_cti),
+    .wb_vga0_master_bte_i (wb_m2s_vga0_master_bte),
+    .wb_vga0_master_dat_o (wb_s2m_vga0_master_dat),
+    .wb_vga0_master_ack_o (wb_s2m_vga0_master_ack),
+    .wb_vga0_master_err_o (wb_s2m_vga0_master_err),
+    .wb_vga0_master_rty_o (wb_s2m_vga0_master_rty),
+    .wb_eth0_master_adr_i (wb_m2s_eth0_master_adr),
+    .wb_eth0_master_dat_i (wb_m2s_eth0_master_dat),
+    .wb_eth0_master_sel_i (wb_m2s_eth0_master_sel),
+    .wb_eth0_master_we_i  (wb_m2s_eth0_master_we),
+    .wb_eth0_master_cyc_i (wb_m2s_eth0_master_cyc),
+    .wb_eth0_master_stb_i (wb_m2s_eth0_master_stb),
+    .wb_eth0_master_cti_i (wb_m2s_eth0_master_cti),
+    .wb_eth0_master_bte_i (wb_m2s_eth0_master_bte),
+    .wb_eth0_master_dat_o (wb_s2m_eth0_master_dat),
+    .wb_eth0_master_ack_o (wb_s2m_eth0_master_ack),
+    .wb_eth0_master_err_o (wb_s2m_eth0_master_err),
+    .wb_eth0_master_rty_o (wb_s2m_eth0_master_rty),
+    .wb_gpio0_adr_o       (wb_m2s_gpio0_adr),
+    .wb_gpio0_dat_o       (wb_m2s_gpio0_dat),
+    .wb_gpio0_sel_o       (wb_m2s_gpio0_sel),
+    .wb_gpio0_we_o        (wb_m2s_gpio0_we),
+    .wb_gpio0_cyc_o       (wb_m2s_gpio0_cyc),
+    .wb_gpio0_stb_o       (wb_m2s_gpio0_stb),
+    .wb_gpio0_cti_o       (wb_m2s_gpio0_cti),
+    .wb_gpio0_bte_o       (wb_m2s_gpio0_bte),
+    .wb_gpio0_dat_i       (wb_s2m_gpio0_dat),
+    .wb_gpio0_ack_i       (wb_s2m_gpio0_ack),
+    .wb_gpio0_err_i       (wb_s2m_gpio0_err),
+    .wb_gpio0_rty_i       (wb_s2m_gpio0_rty),
+    .wb_rom0_adr_o        (wb_m2s_rom0_adr),
+    .wb_rom0_dat_o        (wb_m2s_rom0_dat),
+    .wb_rom0_sel_o        (wb_m2s_rom0_sel),
+    .wb_rom0_we_o         (wb_m2s_rom0_we),
+    .wb_rom0_cyc_o        (wb_m2s_rom0_cyc),
+    .wb_rom0_stb_o        (wb_m2s_rom0_stb),
+    .wb_rom0_cti_o        (wb_m2s_rom0_cti),
+    .wb_rom0_bte_o        (wb_m2s_rom0_bte),
+    .wb_rom0_dat_i        (wb_s2m_rom0_dat),
+    .wb_rom0_ack_i        (wb_s2m_rom0_ack),
+    .wb_rom0_err_i        (wb_s2m_rom0_err),
+    .wb_rom0_rty_i        (wb_s2m_rom0_rty),
+    .wb_ddr2_dbus_adr_o   (wb_m2s_ddr2_dbus_adr),
+    .wb_ddr2_dbus_dat_o   (wb_m2s_ddr2_dbus_dat),
+    .wb_ddr2_dbus_sel_o   (wb_m2s_ddr2_dbus_sel),
+    .wb_ddr2_dbus_we_o    (wb_m2s_ddr2_dbus_we),
+    .wb_ddr2_dbus_cyc_o   (wb_m2s_ddr2_dbus_cyc),
+    .wb_ddr2_dbus_stb_o   (wb_m2s_ddr2_dbus_stb),
+    .wb_ddr2_dbus_cti_o   (wb_m2s_ddr2_dbus_cti),
+    .wb_ddr2_dbus_bte_o   (wb_m2s_ddr2_dbus_bte),
+    .wb_ddr2_dbus_dat_i   (wb_s2m_ddr2_dbus_dat),
+    .wb_ddr2_dbus_ack_i   (wb_s2m_ddr2_dbus_ack),
+    .wb_ddr2_dbus_err_i   (wb_s2m_ddr2_dbus_err),
+    .wb_ddr2_dbus_rty_i   (wb_s2m_ddr2_dbus_rty),
+    .wb_spi0_adr_o        (wb_m2s_spi0_adr),
+    .wb_spi0_dat_o        (wb_m2s_spi0_dat),
+    .wb_spi0_sel_o        (wb_m2s_spi0_sel),
+    .wb_spi0_we_o         (wb_m2s_spi0_we),
+    .wb_spi0_cyc_o        (wb_m2s_spi0_cyc),
+    .wb_spi0_stb_o        (wb_m2s_spi0_stb),
+    .wb_spi0_cti_o        (wb_m2s_spi0_cti),
+    .wb_spi0_bte_o        (wb_m2s_spi0_bte),
+    .wb_spi0_dat_i        (wb_s2m_spi0_dat),
+    .wb_spi0_ack_i        (wb_s2m_spi0_ack),
+    .wb_spi0_err_i        (wb_s2m_spi0_err),
+    .wb_spi0_rty_i        (wb_s2m_spi0_rty),
+    .wb_diila_adr_o       (wb_m2s_diila_adr),
+    .wb_diila_dat_o       (wb_m2s_diila_dat),
+    .wb_diila_sel_o       (wb_m2s_diila_sel),
+    .wb_diila_we_o        (wb_m2s_diila_we),
+    .wb_diila_cyc_o       (wb_m2s_diila_cyc),
+    .wb_diila_stb_o       (wb_m2s_diila_stb),
+    .wb_diila_cti_o       (wb_m2s_diila_cti),
+    .wb_diila_bte_o       (wb_m2s_diila_bte),
+    .wb_diila_dat_i       (wb_s2m_diila_dat),
+    .wb_diila_ack_i       (wb_s2m_diila_ack),
+    .wb_diila_err_i       (wb_s2m_diila_err),
+    .wb_diila_rty_i       (wb_s2m_diila_rty),
+    .wb_uart0_adr_o       (wb_m2s_uart0_adr),
+    .wb_uart0_dat_o       (wb_m2s_uart0_dat),
+    .wb_uart0_sel_o       (wb_m2s_uart0_sel),
+    .wb_uart0_we_o        (wb_m2s_uart0_we),
+    .wb_uart0_cyc_o       (wb_m2s_uart0_cyc),
+    .wb_uart0_stb_o       (wb_m2s_uart0_stb),
+    .wb_uart0_cti_o       (wb_m2s_uart0_cti),
+    .wb_uart0_bte_o       (wb_m2s_uart0_bte),
+    .wb_uart0_dat_i       (wb_s2m_uart0_dat),
+    .wb_uart0_ack_i       (wb_s2m_uart0_ack),
+    .wb_uart0_err_i       (wb_s2m_uart0_err),
+    .wb_uart0_rty_i       (wb_s2m_uart0_rty),
+    .wb_ps2_0_adr_o       (wb_m2s_ps2_0_adr),
+    .wb_ps2_0_dat_o       (wb_m2s_ps2_0_dat),
+    .wb_ps2_0_sel_o       (wb_m2s_ps2_0_sel),
+    .wb_ps2_0_we_o        (wb_m2s_ps2_0_we),
+    .wb_ps2_0_cyc_o       (wb_m2s_ps2_0_cyc),
+    .wb_ps2_0_stb_o       (wb_m2s_ps2_0_stb),
+    .wb_ps2_0_cti_o       (wb_m2s_ps2_0_cti),
+    .wb_ps2_0_bte_o       (wb_m2s_ps2_0_bte),
+    .wb_ps2_0_dat_i       (wb_s2m_ps2_0_dat),
+    .wb_ps2_0_ack_i       (wb_s2m_ps2_0_ack),
+    .wb_ps2_0_err_i       (wb_s2m_ps2_0_err),
+    .wb_ps2_0_rty_i       (wb_s2m_ps2_0_rty),
+    .wb_vga0_adr_o        (wb_m2s_vga0_adr),
+    .wb_vga0_dat_o        (wb_m2s_vga0_dat),
+    .wb_vga0_sel_o        (wb_m2s_vga0_sel),
+    .wb_vga0_we_o         (wb_m2s_vga0_we),
+    .wb_vga0_cyc_o        (wb_m2s_vga0_cyc),
+    .wb_vga0_stb_o        (wb_m2s_vga0_stb),
+    .wb_vga0_cti_o        (wb_m2s_vga0_cti),
+    .wb_vga0_bte_o        (wb_m2s_vga0_bte),
+    .wb_vga0_dat_i        (wb_s2m_vga0_dat),
+    .wb_vga0_ack_i        (wb_s2m_vga0_ack),
+    .wb_vga0_err_i        (wb_s2m_vga0_err),
+    .wb_vga0_rty_i        (wb_s2m_vga0_rty),
+    .wb_ddr2_eth0_adr_o   (wb_m2s_ddr2_eth0_adr),
+    .wb_ddr2_eth0_dat_o   (wb_m2s_ddr2_eth0_dat),
+    .wb_ddr2_eth0_sel_o   (wb_m2s_ddr2_eth0_sel),
+    .wb_ddr2_eth0_we_o    (wb_m2s_ddr2_eth0_we),
+    .wb_ddr2_eth0_cyc_o   (wb_m2s_ddr2_eth0_cyc),
+    .wb_ddr2_eth0_stb_o   (wb_m2s_ddr2_eth0_stb),
+    .wb_ddr2_eth0_cti_o   (wb_m2s_ddr2_eth0_cti),
+    .wb_ddr2_eth0_bte_o   (wb_m2s_ddr2_eth0_bte),
+    .wb_ddr2_eth0_dat_i   (wb_s2m_ddr2_eth0_dat),
+    .wb_ddr2_eth0_ack_i   (wb_s2m_ddr2_eth0_ack),
+    .wb_ddr2_eth0_err_i   (wb_s2m_ddr2_eth0_err),
+    .wb_ddr2_eth0_rty_i   (wb_s2m_ddr2_eth0_rty),
+    .wb_ac97_adr_o        (wb_m2s_ac97_adr),
+    .wb_ac97_dat_o        (wb_m2s_ac97_dat),
+    .wb_ac97_sel_o        (wb_m2s_ac97_sel),
+    .wb_ac97_we_o         (wb_m2s_ac97_we),
+    .wb_ac97_cyc_o        (wb_m2s_ac97_cyc),
+    .wb_ac97_stb_o        (wb_m2s_ac97_stb),
+    .wb_ac97_cti_o        (wb_m2s_ac97_cti),
+    .wb_ac97_bte_o        (wb_m2s_ac97_bte),
+    .wb_ac97_dat_i        (wb_s2m_ac97_dat),
+    .wb_ac97_ack_i        (wb_s2m_ac97_ack),
+    .wb_ac97_err_i        (wb_s2m_ac97_err),
+    .wb_ac97_rty_i        (wb_s2m_ac97_rty),
+    .wb_ddr2_ibus_adr_o   (wb_m2s_ddr2_ibus_adr),
+    .wb_ddr2_ibus_dat_o   (wb_m2s_ddr2_ibus_dat),
+    .wb_ddr2_ibus_sel_o   (wb_m2s_ddr2_ibus_sel),
+    .wb_ddr2_ibus_we_o    (wb_m2s_ddr2_ibus_we),
+    .wb_ddr2_ibus_cyc_o   (wb_m2s_ddr2_ibus_cyc),
+    .wb_ddr2_ibus_stb_o   (wb_m2s_ddr2_ibus_stb),
+    .wb_ddr2_ibus_cti_o   (wb_m2s_ddr2_ibus_cti),
+    .wb_ddr2_ibus_bte_o   (wb_m2s_ddr2_ibus_bte),
+    .wb_ddr2_ibus_dat_i   (wb_s2m_ddr2_ibus_dat),
+    .wb_ddr2_ibus_ack_i   (wb_s2m_ddr2_ibus_ack),
+    .wb_ddr2_ibus_err_i   (wb_s2m_ddr2_ibus_err),
+    .wb_ddr2_ibus_rty_i   (wb_s2m_ddr2_ibus_rty),
+    .wb_ddr2_vga0_adr_o   (wb_m2s_ddr2_vga0_adr),
+    .wb_ddr2_vga0_dat_o   (wb_m2s_ddr2_vga0_dat),
+    .wb_ddr2_vga0_sel_o   (wb_m2s_ddr2_vga0_sel),
+    .wb_ddr2_vga0_we_o    (wb_m2s_ddr2_vga0_we),
+    .wb_ddr2_vga0_cyc_o   (wb_m2s_ddr2_vga0_cyc),
+    .wb_ddr2_vga0_stb_o   (wb_m2s_ddr2_vga0_stb),
+    .wb_ddr2_vga0_cti_o   (wb_m2s_ddr2_vga0_cti),
+    .wb_ddr2_vga0_bte_o   (wb_m2s_ddr2_vga0_bte),
+    .wb_ddr2_vga0_dat_i   (wb_s2m_ddr2_vga0_dat),
+    .wb_ddr2_vga0_ack_i   (wb_s2m_ddr2_vga0_ack),
+    .wb_ddr2_vga0_err_i   (wb_s2m_ddr2_vga0_err),
+    .wb_ddr2_vga0_rty_i   (wb_s2m_ddr2_vga0_rty),
+    .wb_ps2_2_adr_o       (wb_m2s_ps2_2_adr),
+    .wb_ps2_2_dat_o       (wb_m2s_ps2_2_dat),
+    .wb_ps2_2_sel_o       (wb_m2s_ps2_2_sel),
+    .wb_ps2_2_we_o        (wb_m2s_ps2_2_we),
+    .wb_ps2_2_cyc_o       (wb_m2s_ps2_2_cyc),
+    .wb_ps2_2_stb_o       (wb_m2s_ps2_2_stb),
+    .wb_ps2_2_cti_o       (wb_m2s_ps2_2_cti),
+    .wb_ps2_2_bte_o       (wb_m2s_ps2_2_bte),
+    .wb_ps2_2_dat_i       (wb_s2m_ps2_2_dat),
+    .wb_ps2_2_ack_i       (wb_s2m_ps2_2_ack),
+    .wb_ps2_2_err_i       (wb_s2m_ps2_2_err),
+    .wb_ps2_2_rty_i       (wb_s2m_ps2_2_rty),
+    .wb_ps2_1_adr_o       (wb_m2s_ps2_1_adr),
+    .wb_ps2_1_dat_o       (wb_m2s_ps2_1_dat),
+    .wb_ps2_1_sel_o       (wb_m2s_ps2_1_sel),
+    .wb_ps2_1_we_o        (wb_m2s_ps2_1_we),
+    .wb_ps2_1_cyc_o       (wb_m2s_ps2_1_cyc),
+    .wb_ps2_1_stb_o       (wb_m2s_ps2_1_stb),
+    .wb_ps2_1_cti_o       (wb_m2s_ps2_1_cti),
+    .wb_ps2_1_bte_o       (wb_m2s_ps2_1_bte),
+    .wb_ps2_1_dat_i       (wb_s2m_ps2_1_dat),
+    .wb_ps2_1_ack_i       (wb_s2m_ps2_1_ack),
+    .wb_ps2_1_err_i       (wb_s2m_ps2_1_err),
+    .wb_ps2_1_rty_i       (wb_s2m_ps2_1_rty),
+    .wb_eth0_adr_o        (wb_m2s_eth0_adr),
+    .wb_eth0_dat_o        (wb_m2s_eth0_dat),
+    .wb_eth0_sel_o        (wb_m2s_eth0_sel),
+    .wb_eth0_we_o         (wb_m2s_eth0_we),
+    .wb_eth0_cyc_o        (wb_m2s_eth0_cyc),
+    .wb_eth0_stb_o        (wb_m2s_eth0_stb),
+    .wb_eth0_cti_o        (wb_m2s_eth0_cti),
+    .wb_eth0_bte_o        (wb_m2s_eth0_bte),
+    .wb_eth0_dat_i        (wb_s2m_eth0_dat),
+    .wb_eth0_ack_i        (wb_s2m_eth0_ack),
+    .wb_eth0_err_i        (wb_s2m_eth0_err),
+    .wb_eth0_rty_i        (wb_s2m_eth0_rty));
+

--- a/systems/atlys/rtl/verilog/xilinx_ddr2/README
+++ b/systems/atlys/rtl/verilog/xilinx_ddr2/README
@@ -1,0 +1,7 @@
+Xilinx DDR2 controller with Wishbone interface
+
+This is a Xilinx technology-dependent DDR2 memory controller, based on a 
+controller from Xilinx's memory interface generator (MIG)
+
+It performes conversion from the wishbone interface to the native userport
+interface of the MIG and vice versa.

--- a/systems/atlys/rtl/verilog/xilinx_ddr2/ddr2_mig.v
+++ b/systems/atlys/rtl/verilog/xilinx_ddr2/ddr2_mig.v
@@ -1,0 +1,731 @@
+//*****************************************************************************
+// (c) Copyright 2009 Xilinx, Inc. All rights reserved.
+//
+// This file contains confidential and proprietary information
+// of Xilinx, Inc. and is protected under U.S. and
+// international copyright and other intellectual property
+// laws.
+//
+// DISCLAIMER
+// This disclaimer is not a license and does not grant any
+// rights to the materials distributed herewith. Except as
+// otherwise provided in a valid license issued to you by
+// Xilinx, and to the maximum extent permitted by applicable
+// law: (1) THESE MATERIALS ARE MADE AVAILABLE "AS IS" AND
+// WITH ALL FAULTS, AND XILINX HEREBY DISCLAIMS ALL WARRANTIES
+// AND CONDITIONS, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING
+// BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, NON-
+// INFRINGEMENT, OR FITNESS FOR ANY PARTICULAR PURPOSE; and
+// (2) Xilinx shall not be liable (whether in contract or tort,
+// including negligence, or under any other theory of
+// liability) for any loss or damage of any kind or nature
+// related to, arising under or in connection with these
+// materials, including for any direct, or any indirect,
+// special, incidental, or consequential loss or damage
+// (including loss of data, profits, goodwill, or any type of
+// loss or damage suffered as a result of any action brought
+// by a third party) even if such damage or loss was
+// reasonably foreseeable or Xilinx had been advised of the
+// possibility of the same.
+//
+// CRITICAL APPLICATIONS
+// Xilinx products are not designed or intended to be fail-
+// safe, or for use in any application requiring fail-safe
+// performance, such as life-support or safety devices or
+// systems, Class III medical devices, nuclear facilities,
+// applications related to the deployment of airbags, or any
+// other applications that could lead to death, personal
+// injury, or severe property or environmental damage
+// (individually and collectively, "Critical
+// Applications"). Customer assumes the sole risk and
+// liability of any use of Xilinx products in Critical
+// Applications, subject only to applicable laws and
+// regulations governing limitations on product liability.
+//
+// THIS COPYRIGHT NOTICE AND DISCLAIMER MUST BE RETAINED AS
+// PART OF THIS FILE AT ALL TIMES.
+//
+//*****************************************************************************
+//   ____  ____
+//  /   /\/   /
+// /___/  \  /    Vendor             : Xilinx
+// \   \   \/     Version            : 3.6.1
+//  \   \         Application        : MIG
+//  /   /         Filename           : ddr2_mig #.v
+// /___/   /\     Date Last Modified : $Date: 2010/10/27 17:40:11 $
+// \   \  /  \    Date Created       : Tue Feb 23 2010
+//  \___\/\___\
+//
+//Device           : Spartan-6
+//Design Name      : DDR/DDR2/DDR3/LPDDR 
+//Purpose          : This is a template file for the design top module. This module contains 
+//                   all the four memory controllers and the two infrastructures. However,
+//                   only the enabled modules will be active and others inactive.
+//Reference        :
+//Revision History :
+//*****************************************************************************
+`timescale 1ns/1ps
+
+(* X_CORE_INFO = "mig_v3_61_ddr2_ddr2_s6, Coregen 12.4" , CORE_GENERATION_INFO = "ddr2_ddr2_s6,mig_v3_61,{component_name=ddr2_mig, C3_MEM_INTERFACE_TYPE=DDR2_SDRAM, C3_CLK_PERIOD=3750, C3_MEMORY_PART=mt47h64m16xx-25e, C3_OUTPUT_DRV=FULL, C3_RTT_NOM=50OHMS, C3_DQS#_ENABLE=YES, C3_HIGH_TEMP_SR=NORMAL, C3_PORT_CONFIG=Two 32-bit bi-directional and four 32-bit unidirectional ports, C3_MEM_ADDR_ORDER=BANK_ROW_COLUMN, C3_PORT_ENABLE=Port0_Port1_Port2_Port3_Port4_Port5, C3_CLASS_ADDR=II, C3_CLASS_DATA=II, C3_INPUT_PIN_TERMINATION=CALIB_TERM, C3_DATA_TERMINATION=25 Ohms, C3_CLKFBOUT_MULT_F=2, C3_CLKOUT_DIVIDE=1, C3_DEBUG_PORT=0, INPUT_CLK_TYPE=Single-Ended, LANGUAGE=Verilog, SYNTHESIS_TOOL=ISE, NO_OF_CONTROLLERS=1}" *)
+module ddr2_mig #
+(
+   parameter C3_P0_MASK_SIZE           = 4,
+   parameter C3_P0_DATA_PORT_SIZE      = 32,
+   parameter C3_P1_MASK_SIZE           = 4,
+   parameter C3_P1_DATA_PORT_SIZE      = 32,
+   parameter DEBUG_EN                = 0,       
+   parameter C3_MEMCLK_PERIOD        = 3750,       
+   parameter C3_CALIB_SOFT_IP        = "TRUE",       
+   parameter C3_SIMULATION           = "FALSE",       
+   parameter C3_RST_ACT_LOW          = 0,       
+   parameter C3_INPUT_CLK_TYPE       = "SINGLE_ENDED",       
+   parameter C3_MEM_ADDR_ORDER       = "BANK_ROW_COLUMN",       
+   parameter C3_NUM_DQ_PINS          = 16,       
+   parameter C3_MEM_ADDR_WIDTH       = 13,       
+   parameter C3_MEM_BANKADDR_WIDTH   = 3        
+)	
+
+(
+
+   inout  [C3_NUM_DQ_PINS-1:0]                      mcb3_dram_dq,
+   output [C3_MEM_ADDR_WIDTH-1:0]                   mcb3_dram_a,
+   output [C3_MEM_BANKADDR_WIDTH-1:0]               mcb3_dram_ba,
+   output                                           mcb3_dram_ras_n,
+   output                                           mcb3_dram_cas_n,
+   output                                           mcb3_dram_we_n,
+   output                                           mcb3_dram_odt,
+   output                                           mcb3_dram_cke,
+   output                                           mcb3_dram_dm,
+   inout                                            mcb3_dram_udqs,
+   inout                                            mcb3_dram_udqs_n,
+   inout                                            mcb3_rzq,
+   inout                                            mcb3_zio,
+   output                                           mcb3_dram_udm,
+   input                                            c3_sys_clk,
+   input                                            c3_sys_rst_n,
+   output                                           c3_calib_done,
+   output                                           c3_clk0,
+   output                                           c3_rst0,
+   inout                                            mcb3_dram_dqs,
+   inout                                            mcb3_dram_dqs_n,
+   output                                           mcb3_dram_ck,
+   output                                           mcb3_dram_ck_n,
+      input		c3_p0_cmd_clk,
+      input		c3_p0_cmd_en,
+      input [2:0]	c3_p0_cmd_instr,
+      input [5:0]	c3_p0_cmd_bl,
+      input [29:0]	c3_p0_cmd_byte_addr,
+      output		c3_p0_cmd_empty,
+      output		c3_p0_cmd_full,
+      input		c3_p0_wr_clk,
+      input		c3_p0_wr_en,
+      input [C3_P0_MASK_SIZE - 1:0]	c3_p0_wr_mask,
+      input [C3_P0_DATA_PORT_SIZE - 1:0]	c3_p0_wr_data,
+      output		c3_p0_wr_full,
+      output		c3_p0_wr_empty,
+      output [6:0]	c3_p0_wr_count,
+      output		c3_p0_wr_underrun,
+      output		c3_p0_wr_error,
+      input		c3_p0_rd_clk,
+      input		c3_p0_rd_en,
+      output [C3_P0_DATA_PORT_SIZE - 1:0]	c3_p0_rd_data,
+      output		c3_p0_rd_full,
+      output		c3_p0_rd_empty,
+      output [6:0]	c3_p0_rd_count,
+      output		c3_p0_rd_overflow,
+      output		c3_p0_rd_error,
+      input		c3_p1_cmd_clk,
+      input		c3_p1_cmd_en,
+      input [2:0]	c3_p1_cmd_instr,
+      input [5:0]	c3_p1_cmd_bl,
+      input [29:0]	c3_p1_cmd_byte_addr,
+      output		c3_p1_cmd_empty,
+      output		c3_p1_cmd_full,
+      input		c3_p1_wr_clk,
+      input		c3_p1_wr_en,
+      input [C3_P1_MASK_SIZE - 1:0]	c3_p1_wr_mask,
+      input [C3_P1_DATA_PORT_SIZE - 1:0]	c3_p1_wr_data,
+      output		c3_p1_wr_full,
+      output		c3_p1_wr_empty,
+      output [6:0]	c3_p1_wr_count,
+      output		c3_p1_wr_underrun,
+      output		c3_p1_wr_error,
+      input		c3_p1_rd_clk,
+      input		c3_p1_rd_en,
+      output [C3_P1_DATA_PORT_SIZE - 1:0]	c3_p1_rd_data,
+      output		c3_p1_rd_full,
+      output		c3_p1_rd_empty,
+      output [6:0]	c3_p1_rd_count,
+      output		c3_p1_rd_overflow,
+      output		c3_p1_rd_error,
+      input		c3_p2_cmd_clk,
+      input		c3_p2_cmd_en,
+      input [2:0]	c3_p2_cmd_instr,
+      input [5:0]	c3_p2_cmd_bl,
+      input [29:0]	c3_p2_cmd_byte_addr,
+      output		c3_p2_cmd_empty,
+      output		c3_p2_cmd_full,
+      input		c3_p2_rd_clk,
+      input		c3_p2_rd_en,
+      output [31:0]	c3_p2_rd_data,
+      output		c3_p2_rd_full,
+      output		c3_p2_rd_empty,
+      output [6:0]	c3_p2_rd_count,
+      output		c3_p2_rd_overflow,
+      output		c3_p2_rd_error,
+      input		c3_p3_cmd_clk,
+      input		c3_p3_cmd_en,
+      input [2:0]	c3_p3_cmd_instr,
+      input [5:0]	c3_p3_cmd_bl,
+      input [29:0]	c3_p3_cmd_byte_addr,
+      output		c3_p3_cmd_empty,
+      output		c3_p3_cmd_full,
+      input		c3_p3_wr_clk,
+      input		c3_p3_wr_en,
+      input [3:0]	c3_p3_wr_mask,
+      input [31:0]	c3_p3_wr_data,
+      output		c3_p3_wr_full,
+      output		c3_p3_wr_empty,
+      output [6:0]	c3_p3_wr_count,
+      output		c3_p3_wr_underrun,
+      output		c3_p3_wr_error,
+      input		c3_p4_cmd_clk,
+      input		c3_p4_cmd_en,
+      input [2:0]	c3_p4_cmd_instr,
+      input [5:0]	c3_p4_cmd_bl,
+      input [29:0]	c3_p4_cmd_byte_addr,
+      output		c3_p4_cmd_empty,
+      output		c3_p4_cmd_full,
+      input		c3_p4_rd_clk,
+      input		c3_p4_rd_en,
+      output [31:0]	c3_p4_rd_data,
+      output		c3_p4_rd_full,
+      output		c3_p4_rd_empty,
+      output [6:0]	c3_p4_rd_count,
+      output		c3_p4_rd_overflow,
+      output		c3_p4_rd_error,
+      input		c3_p5_cmd_clk,
+      input		c3_p5_cmd_en,
+      input [2:0]	c3_p5_cmd_instr,
+      input [5:0]	c3_p5_cmd_bl,
+      input [29:0]	c3_p5_cmd_byte_addr,
+      output		c3_p5_cmd_empty,
+      output		c3_p5_cmd_full,
+      input		c3_p5_rd_clk,
+      input		c3_p5_rd_en,
+      output [31:0]	c3_p5_rd_data,
+      output		c3_p5_rd_full,
+      output		c3_p5_rd_empty,
+      output [6:0]	c3_p5_rd_count,
+      output		c3_p5_rd_overflow,
+      output		c3_p5_rd_error
+);
+// The parameter CX_PORT_ENABLE shows all the active user ports in the design.
+// For example, the value 6'b111100 tells that only port-2, port-3, port-4
+// and port-5 are enabled. The other two ports are inactive. An inactive port
+// can be a disabled port or an invisible logical port. Few examples to the 
+// invisible logical port are port-4 and port-5 in the user port configuration,
+// Config-2: Four 32-bit bi-directional ports and the ports port-2 through
+// port-5 in Config-4: Two 64-bit bi-directional ports. Please look into the 
+// Chapter-2 of ug388.pdf in the /docs directory for further details.
+   localparam C3_PORT_ENABLE              = 6'b111111;
+   localparam C3_PORT_CONFIG             =  "B32_B32_R32_W32_R32_R32";
+   localparam C3_CLKOUT0_DIVIDE       = 1;       
+   localparam C3_CLKOUT1_DIVIDE       = 1;       
+   localparam C3_CLKOUT2_DIVIDE       = 16;       
+   localparam C3_CLKOUT3_DIVIDE       = 8;       
+   localparam C3_CLKFBOUT_MULT        = 2;       
+   localparam C3_DIVCLK_DIVIDE        = 1;       
+   localparam C3_ARB_ALGORITHM        = 0;       
+   localparam C3_ARB_NUM_TIME_SLOTS   = 12;       
+   localparam C3_ARB_TIME_SLOT_0      = 18'o012345;       
+   localparam C3_ARB_TIME_SLOT_1      = 18'o123450;       
+   localparam C3_ARB_TIME_SLOT_2      = 18'o234501;       
+   localparam C3_ARB_TIME_SLOT_3      = 18'o345012;       
+   localparam C3_ARB_TIME_SLOT_4      = 18'o450123;       
+   localparam C3_ARB_TIME_SLOT_5      = 18'o501234;       
+   localparam C3_ARB_TIME_SLOT_6      = 18'o012345;       
+   localparam C3_ARB_TIME_SLOT_7      = 18'o123450;       
+   localparam C3_ARB_TIME_SLOT_8      = 18'o234501;       
+   localparam C3_ARB_TIME_SLOT_9      = 18'o345012;       
+   localparam C3_ARB_TIME_SLOT_10     = 18'o450123;       
+   localparam C3_ARB_TIME_SLOT_11     = 18'o501234;       
+   localparam C3_MEM_TRAS             = 42500;       
+   localparam C3_MEM_TRCD             = 12500;       
+   localparam C3_MEM_TREFI            = 7800000;       
+   localparam C3_MEM_TRFC             = 127500;       
+   localparam C3_MEM_TRP              = 12500;       
+   localparam C3_MEM_TWR              = 15000;       
+   localparam C3_MEM_TRTP             = 7500;       
+   localparam C3_MEM_TWTR             = 7500;       
+   localparam C3_MEM_TYPE             = "DDR2";       
+   localparam C3_MEM_DENSITY          = "1Gb";       
+   localparam C3_MEM_BURST_LEN        = 4;       
+   localparam C3_MEM_CAS_LATENCY      = 4;       
+   localparam C3_MEM_NUM_COL_BITS     = 10;       
+   localparam C3_MEM_DDR1_2_ODS       = "FULL";       
+   localparam C3_MEM_DDR2_RTT         = "50OHMS";       
+   localparam C3_MEM_DDR2_DIFF_DQS_EN  = "YES";       
+   localparam C3_MEM_DDR2_3_PA_SR     = "FULL";       
+   localparam C3_MEM_DDR2_3_HIGH_TEMP_SR  = "NORMAL";       
+   localparam C3_MEM_DDR3_CAS_LATENCY  = 6;       
+   localparam C3_MEM_DDR3_ODS         = "DIV6";       
+   localparam C3_MEM_DDR3_RTT         = "DIV2";       
+   localparam C3_MEM_DDR3_CAS_WR_LATENCY  = 5;       
+   localparam C3_MEM_DDR3_AUTO_SR     = "ENABLED";       
+   localparam C3_MEM_MOBILE_PA_SR     = "FULL";       
+   localparam C3_MEM_MDDR_ODS         = "FULL";       
+   localparam C3_MC_CALIB_BYPASS      = "NO";       
+   localparam C3_MC_CALIBRATION_MODE  = "CALIBRATION";       
+   localparam C3_MC_CALIBRATION_DELAY  = "HALF";       
+   localparam C3_SKIP_IN_TERM_CAL     = 0;       
+   localparam C3_SKIP_DYNAMIC_CAL     = 0;       
+   localparam C3_LDQSP_TAP_DELAY_VAL  = 0;       
+   localparam C3_LDQSN_TAP_DELAY_VAL  = 0;       
+   localparam C3_UDQSP_TAP_DELAY_VAL  = 0;       
+   localparam C3_UDQSN_TAP_DELAY_VAL  = 0;       
+   localparam C3_DQ0_TAP_DELAY_VAL    = 0;       
+   localparam C3_DQ1_TAP_DELAY_VAL    = 0;       
+   localparam C3_DQ2_TAP_DELAY_VAL    = 0;       
+   localparam C3_DQ3_TAP_DELAY_VAL    = 0;       
+   localparam C3_DQ4_TAP_DELAY_VAL    = 0;       
+   localparam C3_DQ5_TAP_DELAY_VAL    = 0;       
+   localparam C3_DQ6_TAP_DELAY_VAL    = 0;       
+   localparam C3_DQ7_TAP_DELAY_VAL    = 0;       
+   localparam C3_DQ8_TAP_DELAY_VAL    = 0;       
+   localparam C3_DQ9_TAP_DELAY_VAL    = 0;       
+   localparam C3_DQ10_TAP_DELAY_VAL   = 0;       
+   localparam C3_DQ11_TAP_DELAY_VAL   = 0;       
+   localparam C3_DQ12_TAP_DELAY_VAL   = 0;       
+   localparam C3_DQ13_TAP_DELAY_VAL   = 0;       
+   localparam C3_DQ14_TAP_DELAY_VAL   = 0;       
+   localparam C3_DQ15_TAP_DELAY_VAL   = 0;       
+   localparam C3_MCB_USE_EXTERNAL_BUFPLL  = 1;       
+   localparam C3_INCLK_PERIOD         = ((C3_MEMCLK_PERIOD * C3_CLKFBOUT_MULT) / (C3_DIVCLK_DIVIDE * C3_CLKOUT0_DIVIDE * 2));       
+   localparam C3_ARB_TIME0_SLOT  = {C3_ARB_TIME_SLOT_0[2:0], C3_ARB_TIME_SLOT_0[5:3], C3_ARB_TIME_SLOT_0[8:6], C3_ARB_TIME_SLOT_0[11:9], C3_ARB_TIME_SLOT_0[14:12], C3_ARB_TIME_SLOT_0[17:15]};
+   localparam C3_ARB_TIME1_SLOT  = {C3_ARB_TIME_SLOT_1[2:0], C3_ARB_TIME_SLOT_1[5:3], C3_ARB_TIME_SLOT_1[8:6], C3_ARB_TIME_SLOT_1[11:9], C3_ARB_TIME_SLOT_1[14:12], C3_ARB_TIME_SLOT_1[17:15]};
+   localparam C3_ARB_TIME2_SLOT  = {C3_ARB_TIME_SLOT_2[2:0], C3_ARB_TIME_SLOT_2[5:3], C3_ARB_TIME_SLOT_2[8:6], C3_ARB_TIME_SLOT_2[11:9], C3_ARB_TIME_SLOT_2[14:12], C3_ARB_TIME_SLOT_2[17:15]};
+   localparam C3_ARB_TIME3_SLOT  = {C3_ARB_TIME_SLOT_3[2:0], C3_ARB_TIME_SLOT_3[5:3], C3_ARB_TIME_SLOT_3[8:6], C3_ARB_TIME_SLOT_3[11:9], C3_ARB_TIME_SLOT_3[14:12], C3_ARB_TIME_SLOT_3[17:15]};
+   localparam C3_ARB_TIME4_SLOT  = {C3_ARB_TIME_SLOT_4[2:0], C3_ARB_TIME_SLOT_4[5:3], C3_ARB_TIME_SLOT_4[8:6], C3_ARB_TIME_SLOT_4[11:9], C3_ARB_TIME_SLOT_4[14:12], C3_ARB_TIME_SLOT_4[17:15]};
+   localparam C3_ARB_TIME5_SLOT  = {C3_ARB_TIME_SLOT_5[2:0], C3_ARB_TIME_SLOT_5[5:3], C3_ARB_TIME_SLOT_5[8:6], C3_ARB_TIME_SLOT_5[11:9], C3_ARB_TIME_SLOT_5[14:12], C3_ARB_TIME_SLOT_5[17:15]};
+   localparam C3_ARB_TIME6_SLOT  = {C3_ARB_TIME_SLOT_6[2:0], C3_ARB_TIME_SLOT_6[5:3], C3_ARB_TIME_SLOT_6[8:6], C3_ARB_TIME_SLOT_6[11:9], C3_ARB_TIME_SLOT_6[14:12], C3_ARB_TIME_SLOT_6[17:15]};
+   localparam C3_ARB_TIME7_SLOT  = {C3_ARB_TIME_SLOT_7[2:0], C3_ARB_TIME_SLOT_7[5:3], C3_ARB_TIME_SLOT_7[8:6], C3_ARB_TIME_SLOT_7[11:9], C3_ARB_TIME_SLOT_7[14:12], C3_ARB_TIME_SLOT_7[17:15]};
+   localparam C3_ARB_TIME8_SLOT  = {C3_ARB_TIME_SLOT_8[2:0], C3_ARB_TIME_SLOT_8[5:3], C3_ARB_TIME_SLOT_8[8:6], C3_ARB_TIME_SLOT_8[11:9], C3_ARB_TIME_SLOT_8[14:12], C3_ARB_TIME_SLOT_8[17:15]};
+   localparam C3_ARB_TIME9_SLOT  = {C3_ARB_TIME_SLOT_9[2:0], C3_ARB_TIME_SLOT_9[5:3], C3_ARB_TIME_SLOT_9[8:6], C3_ARB_TIME_SLOT_9[11:9], C3_ARB_TIME_SLOT_9[14:12], C3_ARB_TIME_SLOT_9[17:15]};
+   localparam C3_ARB_TIME10_SLOT  = {C3_ARB_TIME_SLOT_10[2:0], C3_ARB_TIME_SLOT_10[5:3], C3_ARB_TIME_SLOT_10[8:6], C3_ARB_TIME_SLOT_10[11:9], C3_ARB_TIME_SLOT_10[14:12], C3_ARB_TIME_SLOT_10[17:15]};
+   localparam C3_ARB_TIME11_SLOT  = {C3_ARB_TIME_SLOT_11[2:0], C3_ARB_TIME_SLOT_11[5:3], C3_ARB_TIME_SLOT_11[8:6], C3_ARB_TIME_SLOT_11[11:9], C3_ARB_TIME_SLOT_11[14:12], C3_ARB_TIME_SLOT_11[17:15]};
+
+  wire                              c3_sys_clk_p;
+  wire                              c3_sys_clk_n;
+  wire                              c3_async_rst;
+  wire                              c3_sysclk_2x;
+  wire                              c3_sysclk_2x_180;
+  wire                              c3_pll_ce_0;
+  wire                              c3_pll_ce_90;
+  wire                              c3_pll_lock;
+  wire                              c3_mcb_drp_clk;
+  wire                              c3_cmp_error;
+  wire                              c3_cmp_data_valid;
+  wire                              c3_vio_modify_enable;
+  wire  [2:0]                      c3_vio_data_mode_value;
+  wire  [2:0]                      c3_vio_addr_mode_value;
+  wire  [31:0]                      c3_cmp_data;
+wire				c3_p2_wr_clk;
+wire				c3_p2_wr_en;
+wire[3:0]			c3_p2_wr_mask;
+wire[31:0]			c3_p2_wr_data;
+wire				c3_p2_wr_full;
+wire				c3_p2_wr_empty;
+wire[6:0]			c3_p2_wr_count;
+wire				c3_p2_wr_underrun;
+wire				c3_p2_wr_error;
+wire				c3_p3_rd_clk;
+wire				c3_p3_rd_en;
+wire[31:0]			c3_p3_rd_data;
+wire				c3_p3_rd_full;
+wire				c3_p3_rd_empty;
+wire[6:0]			c3_p3_rd_count;
+wire				c3_p3_rd_overflow;
+wire				c3_p3_rd_error;
+wire				c3_p4_wr_clk;
+wire				c3_p4_wr_en;
+wire[3:0]			c3_p4_wr_mask;
+wire[31:0]			c3_p4_wr_data;
+wire				c3_p4_wr_full;
+wire				c3_p4_wr_empty;
+wire[6:0]			c3_p4_wr_count;
+wire				c3_p4_wr_underrun;
+wire				c3_p4_wr_error;
+wire				c3_p5_wr_clk;
+wire				c3_p5_wr_en;
+wire[3:0]			c3_p5_wr_mask;
+wire[31:0]			c3_p5_wr_data;
+wire				c3_p5_wr_full;
+wire				c3_p5_wr_empty;
+wire[6:0]			c3_p5_wr_count;
+wire				c3_p5_wr_underrun;
+wire				c3_p5_wr_error;
+
+
+
+
+assign  c3_sys_clk_p = 1'b0;
+assign  c3_sys_clk_n = 1'b0;
+
+
+
+// Infrastructure-3 instantiation
+      infrastructure #
+      (
+         .C_INCLK_PERIOD                 (C3_INCLK_PERIOD),
+         .C_RST_ACT_LOW                  (C3_RST_ACT_LOW),
+         .C_INPUT_CLK_TYPE               (C3_INPUT_CLK_TYPE),
+         .C_CLKOUT0_DIVIDE               (C3_CLKOUT0_DIVIDE),
+         .C_CLKOUT1_DIVIDE               (C3_CLKOUT1_DIVIDE),
+         .C_CLKOUT2_DIVIDE               (C3_CLKOUT2_DIVIDE),
+         .C_CLKOUT3_DIVIDE               (C3_CLKOUT3_DIVIDE),
+         .C_CLKFBOUT_MULT                (C3_CLKFBOUT_MULT),
+         .C_DIVCLK_DIVIDE                (C3_DIVCLK_DIVIDE)
+      )
+      memc3_infrastructure_inst
+      (
+         .sys_clk_p                      (c3_sys_clk_p),
+         .sys_clk_n                      (c3_sys_clk_n),
+         .sys_clk                        (c3_sys_clk),
+         .sys_rst_n                      (c3_sys_rst_n),
+         .clk0                           (c3_clk0),
+         .rst0                           (c3_rst0),
+         .async_rst                      (c3_async_rst),
+         .sysclk_2x                      (c3_sysclk_2x),
+         .sysclk_2x_180                  (c3_sysclk_2x_180),
+         .pll_ce_0                       (c3_pll_ce_0),
+         .pll_ce_90                      (c3_pll_ce_90),
+         .pll_lock                       (c3_pll_lock),
+         .mcb_drp_clk                    (c3_mcb_drp_clk)
+      );
+   
+
+
+// Controller-3 instantiation
+      memc_wrapper #
+      (
+         .C_MEMCLK_PERIOD                (C3_MEMCLK_PERIOD),   
+         .C_CALIB_SOFT_IP                (C3_CALIB_SOFT_IP),
+         .C_SIMULATION                   (C3_SIMULATION),
+         .C_ARB_NUM_TIME_SLOTS           (C3_ARB_NUM_TIME_SLOTS),
+         .C_ARB_TIME_SLOT_0              (C3_ARB_TIME0_SLOT),
+         .C_ARB_TIME_SLOT_1              (C3_ARB_TIME1_SLOT),
+         .C_ARB_TIME_SLOT_2              (C3_ARB_TIME2_SLOT),
+         .C_ARB_TIME_SLOT_3              (C3_ARB_TIME3_SLOT),
+         .C_ARB_TIME_SLOT_4              (C3_ARB_TIME4_SLOT),
+         .C_ARB_TIME_SLOT_5              (C3_ARB_TIME5_SLOT),
+         .C_ARB_TIME_SLOT_6              (C3_ARB_TIME6_SLOT),
+         .C_ARB_TIME_SLOT_7              (C3_ARB_TIME7_SLOT),
+         .C_ARB_TIME_SLOT_8              (C3_ARB_TIME8_SLOT),
+         .C_ARB_TIME_SLOT_9              (C3_ARB_TIME9_SLOT),
+         .C_ARB_TIME_SLOT_10             (C3_ARB_TIME10_SLOT),
+         .C_ARB_TIME_SLOT_11             (C3_ARB_TIME11_SLOT),
+         .C_ARB_ALGORITHM                (C3_ARB_ALGORITHM),
+         .C_PORT_ENABLE                  (C3_PORT_ENABLE),
+         .C_PORT_CONFIG                  (C3_PORT_CONFIG),
+         .C_MEM_TRAS                     (C3_MEM_TRAS),
+         .C_MEM_TRCD                     (C3_MEM_TRCD),
+         .C_MEM_TREFI                    (C3_MEM_TREFI),
+         .C_MEM_TRFC                     (C3_MEM_TRFC),
+         .C_MEM_TRP                      (C3_MEM_TRP),
+         .C_MEM_TWR                      (C3_MEM_TWR),
+         .C_MEM_TRTP                     (C3_MEM_TRTP),
+         .C_MEM_TWTR                     (C3_MEM_TWTR),
+         .C_MEM_ADDR_ORDER               (C3_MEM_ADDR_ORDER),
+         .C_NUM_DQ_PINS                  (C3_NUM_DQ_PINS),
+         .C_MEM_TYPE                     (C3_MEM_TYPE),
+         .C_MEM_DENSITY                  (C3_MEM_DENSITY),
+         .C_MEM_BURST_LEN                (C3_MEM_BURST_LEN),
+         .C_MEM_CAS_LATENCY              (C3_MEM_CAS_LATENCY),
+         .C_MEM_ADDR_WIDTH               (C3_MEM_ADDR_WIDTH),
+         .C_MEM_BANKADDR_WIDTH           (C3_MEM_BANKADDR_WIDTH),
+         .C_MEM_NUM_COL_BITS             (C3_MEM_NUM_COL_BITS),
+         .C_MEM_DDR1_2_ODS               (C3_MEM_DDR1_2_ODS),
+         .C_MEM_DDR2_RTT                 (C3_MEM_DDR2_RTT),
+         .C_MEM_DDR2_DIFF_DQS_EN         (C3_MEM_DDR2_DIFF_DQS_EN),
+         .C_MEM_DDR2_3_PA_SR             (C3_MEM_DDR2_3_PA_SR),
+         .C_MEM_DDR2_3_HIGH_TEMP_SR      (C3_MEM_DDR2_3_HIGH_TEMP_SR),
+         .C_MEM_DDR3_CAS_LATENCY         (C3_MEM_DDR3_CAS_LATENCY),
+         .C_MEM_DDR3_ODS                 (C3_MEM_DDR3_ODS),
+         .C_MEM_DDR3_RTT                 (C3_MEM_DDR3_RTT),
+         .C_MEM_DDR3_CAS_WR_LATENCY      (C3_MEM_DDR3_CAS_WR_LATENCY),
+         .C_MEM_DDR3_AUTO_SR             (C3_MEM_DDR3_AUTO_SR),
+         .C_MEM_MOBILE_PA_SR             (C3_MEM_MOBILE_PA_SR),
+         .C_MEM_MDDR_ODS                 (C3_MEM_MDDR_ODS),
+         .C_MC_CALIB_BYPASS              (C3_MC_CALIB_BYPASS),
+         .C_MC_CALIBRATION_MODE          (C3_MC_CALIBRATION_MODE),
+         .C_MC_CALIBRATION_DELAY         (C3_MC_CALIBRATION_DELAY),
+         .C_SKIP_IN_TERM_CAL             (C3_SKIP_IN_TERM_CAL),
+         .C_SKIP_DYNAMIC_CAL             (C3_SKIP_DYNAMIC_CAL),
+         .LDQSP_TAP_DELAY_VAL            (C3_LDQSP_TAP_DELAY_VAL),
+         .UDQSP_TAP_DELAY_VAL            (C3_UDQSP_TAP_DELAY_VAL),
+         .LDQSN_TAP_DELAY_VAL            (C3_LDQSN_TAP_DELAY_VAL),
+         .UDQSN_TAP_DELAY_VAL            (C3_UDQSN_TAP_DELAY_VAL),
+         .DQ0_TAP_DELAY_VAL              (C3_DQ0_TAP_DELAY_VAL),
+         .DQ1_TAP_DELAY_VAL              (C3_DQ1_TAP_DELAY_VAL),
+         .DQ2_TAP_DELAY_VAL              (C3_DQ2_TAP_DELAY_VAL),
+         .DQ3_TAP_DELAY_VAL              (C3_DQ3_TAP_DELAY_VAL),
+         .DQ4_TAP_DELAY_VAL              (C3_DQ4_TAP_DELAY_VAL),
+         .DQ5_TAP_DELAY_VAL              (C3_DQ5_TAP_DELAY_VAL),
+         .DQ6_TAP_DELAY_VAL              (C3_DQ6_TAP_DELAY_VAL),
+         .DQ7_TAP_DELAY_VAL              (C3_DQ7_TAP_DELAY_VAL),
+         .DQ8_TAP_DELAY_VAL              (C3_DQ8_TAP_DELAY_VAL),
+         .DQ9_TAP_DELAY_VAL              (C3_DQ9_TAP_DELAY_VAL),
+         .DQ10_TAP_DELAY_VAL             (C3_DQ10_TAP_DELAY_VAL),
+         .DQ11_TAP_DELAY_VAL             (C3_DQ11_TAP_DELAY_VAL),
+         .DQ12_TAP_DELAY_VAL             (C3_DQ12_TAP_DELAY_VAL),
+         .DQ13_TAP_DELAY_VAL             (C3_DQ13_TAP_DELAY_VAL),
+         .DQ14_TAP_DELAY_VAL             (C3_DQ14_TAP_DELAY_VAL),
+         .DQ15_TAP_DELAY_VAL             (C3_DQ15_TAP_DELAY_VAL),
+         .C_P0_MASK_SIZE                 (C3_P0_MASK_SIZE),
+         .C_P0_DATA_PORT_SIZE            (C3_P0_DATA_PORT_SIZE),
+         .C_P1_MASK_SIZE                 (C3_P1_MASK_SIZE),
+         .C_P1_DATA_PORT_SIZE            (C3_P1_DATA_PORT_SIZE)
+	)
+      
+      memc3_wrapper_inst
+      (
+         .mcbx_dram_addr                 (mcb3_dram_a), 
+         .mcbx_dram_ba                   (mcb3_dram_ba),
+         .mcbx_dram_ras_n                (mcb3_dram_ras_n), 
+         .mcbx_dram_cas_n                (mcb3_dram_cas_n), 
+         .mcbx_dram_we_n                 (mcb3_dram_we_n), 
+         .mcbx_dram_cke                  (mcb3_dram_cke), 
+         .mcbx_dram_clk                  (mcb3_dram_ck), 
+         .mcbx_dram_clk_n                (mcb3_dram_ck_n), 
+         .mcbx_dram_dq                   (mcb3_dram_dq),
+         .mcbx_dram_dqs                  (mcb3_dram_dqs), 
+         .mcbx_dram_dqs_n                (mcb3_dram_dqs_n), 
+         .mcbx_dram_udqs                 (mcb3_dram_udqs), 
+         .mcbx_dram_udqs_n               (mcb3_dram_udqs_n), 
+         .mcbx_dram_udm                  (mcb3_dram_udm), 
+         .mcbx_dram_ldm                  (mcb3_dram_dm), 
+         .mcbx_dram_odt                  (mcb3_dram_odt), 
+         .mcbx_dram_ddr3_rst             ( ), 
+         .mcbx_rzq                       (mcb3_rzq),
+         .mcbx_zio                       (mcb3_zio),
+         .calib_done                     (c3_calib_done),
+         .async_rst                      (c3_async_rst),
+         .sysclk_2x                      (c3_sysclk_2x), 
+         .sysclk_2x_180                  (c3_sysclk_2x_180), 
+         .pll_ce_0                       (c3_pll_ce_0),
+         .pll_ce_90                      (c3_pll_ce_90), 
+         .pll_lock                       (c3_pll_lock),
+         .mcb_drp_clk                    (c3_mcb_drp_clk), 
+     
+         // The following port map shows all the six logical user ports. However, all
+	 // of them may not be active in this design. A port should be enabled to 
+	 // validate its port map. If it is not,the complete port is going to float 
+	 // by getting disconnected from the lower level MCB modules. The port enable
+	 // information of a controller can be obtained from the corresponding local
+	 // parameter CX_PORT_ENABLE. In such a case, we can simply ignore its port map.
+	 // The following comments will explain when a port is going to be active.
+	 // Config-1: Two 32-bit bi-directional and four 32-bit unidirectional ports
+	 // Config-2: Four 32-bit bi-directional ports
+	 // Config-3: One 64-bit bi-directional and two 32-bit bi-directional ports
+	 // Config-4: Two 64-bit bi-directional ports
+	 // Config-5: One 128-bit bi-directional port
+
+         // User Port-0 command interface will be active only when the port is enabled in 
+         // the port configurations Config-1, Config-2, Config-3, Config-4 and Config-5
+         .p0_cmd_clk                     (c3_p0_cmd_clk), 
+         .p0_cmd_en                      (c3_p0_cmd_en), 
+         .p0_cmd_instr                   (c3_p0_cmd_instr),
+         .p0_cmd_bl                      (c3_p0_cmd_bl), 
+         .p0_cmd_byte_addr               (c3_p0_cmd_byte_addr), 
+         .p0_cmd_full                    (c3_p0_cmd_full),
+         .p0_cmd_empty                   (c3_p0_cmd_empty),
+         // User Port-0 data write interface will be active only when the port is enabled in
+         // the port configurations Config-1, Config-2, Config-3, Config-4 and Config-5
+         .p0_wr_clk                      (c3_p0_wr_clk), 
+         .p0_wr_en                       (c3_p0_wr_en),
+         .p0_wr_mask                     (c3_p0_wr_mask),
+         .p0_wr_data                     (c3_p0_wr_data),
+         .p0_wr_full                     (c3_p0_wr_full),
+         .p0_wr_count                    (c3_p0_wr_count),
+         .p0_wr_empty                    (c3_p0_wr_empty),
+         .p0_wr_underrun                 (c3_p0_wr_underrun),
+         .p0_wr_error                    (c3_p0_wr_error),
+         // User Port-0 data read interface will be active only when the port is enabled in
+         // the port configurations Config-1, Config-2, Config-3, Config-4 and Config-5
+         .p0_rd_clk                      (c3_p0_rd_clk), 
+         .p0_rd_en                       (c3_p0_rd_en),
+         .p0_rd_data                     (c3_p0_rd_data),
+         .p0_rd_empty                    (c3_p0_rd_empty),
+         .p0_rd_count                    (c3_p0_rd_count),
+         .p0_rd_full                     (c3_p0_rd_full),
+         .p0_rd_overflow                 (c3_p0_rd_overflow),
+         .p0_rd_error                    (c3_p0_rd_error),
+      
+         // User Port-1 command interface will be active only when the port is enabled in 
+         // the port configurations Config-1, Config-2, Config-3 and Config-4
+         .p1_cmd_clk                     (c3_p1_cmd_clk), 
+         .p1_cmd_en                      (c3_p1_cmd_en), 
+         .p1_cmd_instr                   (c3_p1_cmd_instr),
+         .p1_cmd_bl                      (c3_p1_cmd_bl), 
+         .p1_cmd_byte_addr               (c3_p1_cmd_byte_addr), 
+         .p1_cmd_full                    (c3_p1_cmd_full),
+         .p1_cmd_empty                   (c3_p1_cmd_empty),
+         // User Port-1 data write interface will be active only when the port is enabled in 
+         // the port configurations Config-1, Config-2, Config-3 and Config-4
+         .p1_wr_clk                      (c3_p1_wr_clk), 
+         .p1_wr_en                       (c3_p1_wr_en),
+         .p1_wr_mask                     (c3_p1_wr_mask),
+         .p1_wr_data                     (c3_p1_wr_data),
+         .p1_wr_full                     (c3_p1_wr_full),
+         .p1_wr_count                    (c3_p1_wr_count),
+         .p1_wr_empty                    (c3_p1_wr_empty),
+         .p1_wr_underrun                 (c3_p1_wr_underrun),
+         .p1_wr_error                    (c3_p1_wr_error),
+         // User Port-1 data read interface will be active only when the port is enabled in 
+         // the port configurations Config-1, Config-2, Config-3 and Config-4
+         .p1_rd_clk                      (c3_p1_rd_clk), 
+         .p1_rd_en                       (c3_p1_rd_en),
+         .p1_rd_data                     (c3_p1_rd_data),
+         .p1_rd_empty                    (c3_p1_rd_empty),
+         .p1_rd_count                    (c3_p1_rd_count),
+         .p1_rd_full                     (c3_p1_rd_full),
+         .p1_rd_overflow                 (c3_p1_rd_overflow),
+         .p1_rd_error                    (c3_p1_rd_error),
+      
+         // User Port-2 command interface will be active only when the port is enabled in 
+         // the port configurations Config-1, Config-2 and Config-3
+         .p2_cmd_clk                     (c3_p2_cmd_clk), 
+         .p2_cmd_en                      (c3_p2_cmd_en), 
+         .p2_cmd_instr                   (c3_p2_cmd_instr),
+         .p2_cmd_bl                      (c3_p2_cmd_bl), 
+         .p2_cmd_byte_addr               (c3_p2_cmd_byte_addr), 
+         .p2_cmd_full                    (c3_p2_cmd_full),
+         .p2_cmd_empty                   (c3_p2_cmd_empty),
+         // User Port-2 data write interface will be active only when the port is enabled in 
+         // the port configurations Config-1 write direction, Config-2 and Config-3
+         .p2_wr_clk                      (c3_p2_wr_clk), 
+         .p2_wr_en                       (c3_p2_wr_en),
+         .p2_wr_mask                     (c3_p2_wr_mask),
+         .p2_wr_data                     (c3_p2_wr_data),
+         .p2_wr_full                     (c3_p2_wr_full),
+         .p2_wr_count                    (c3_p2_wr_count),
+         .p2_wr_empty                    (c3_p2_wr_empty),
+         .p2_wr_underrun                 (c3_p2_wr_underrun),
+         .p2_wr_error                    (c3_p2_wr_error),
+         // User Port-2 data read interface will be active only when the port is enabled in 
+         // the port configurations Config-1 read direction, Config-2 and Config-3
+         .p2_rd_clk                      (c3_p2_rd_clk), 
+         .p2_rd_en                       (c3_p2_rd_en),
+         .p2_rd_data                     (c3_p2_rd_data),
+         .p2_rd_empty                    (c3_p2_rd_empty),
+         .p2_rd_count                    (c3_p2_rd_count),
+         .p2_rd_full                     (c3_p2_rd_full),
+         .p2_rd_overflow                 (c3_p2_rd_overflow),
+         .p2_rd_error                    (c3_p2_rd_error),
+      
+         // User Port-3 command interface will be active only when the port is enabled in 
+         // the port configurations Config-1 and Config-2
+         .p3_cmd_clk                     (c3_p3_cmd_clk), 
+         .p3_cmd_en                      (c3_p3_cmd_en), 
+         .p3_cmd_instr                   (c3_p3_cmd_instr),
+         .p3_cmd_bl                      (c3_p3_cmd_bl), 
+         .p3_cmd_byte_addr               (c3_p3_cmd_byte_addr), 
+         .p3_cmd_full                    (c3_p3_cmd_full),
+         .p3_cmd_empty                   (c3_p3_cmd_empty),
+         // User Port-3 data write interface will be active only when the port is enabled in 
+         // the port configurations Config-1 write direction and Config-2
+         .p3_wr_clk                      (c3_p3_wr_clk), 
+         .p3_wr_en                       (c3_p3_wr_en),
+         .p3_wr_mask                     (c3_p3_wr_mask),
+         .p3_wr_data                     (c3_p3_wr_data),
+         .p3_wr_full                     (c3_p3_wr_full),
+         .p3_wr_count                    (c3_p3_wr_count),
+         .p3_wr_empty                    (c3_p3_wr_empty),
+         .p3_wr_underrun                 (c3_p3_wr_underrun),
+         .p3_wr_error                    (c3_p3_wr_error),
+         // User Port-3 data read interface will be active only when the port is enabled in 
+         // the port configurations Config-1 read direction and Config-2
+         .p3_rd_clk                      (c3_p3_rd_clk), 
+         .p3_rd_en                       (c3_p3_rd_en),
+         .p3_rd_data                     (c3_p3_rd_data),
+         .p3_rd_empty                    (c3_p3_rd_empty),
+         .p3_rd_count                    (c3_p3_rd_count),
+         .p3_rd_full                     (c3_p3_rd_full),
+         .p3_rd_overflow                 (c3_p3_rd_overflow),
+         .p3_rd_error                    (c3_p3_rd_error),
+      
+         // User Port-4 command interface will be active only when the port is enabled in 
+         // the port configuration Config-1
+         .p4_cmd_clk                     (c3_p4_cmd_clk), 
+         .p4_cmd_en                      (c3_p4_cmd_en), 
+         .p4_cmd_instr                   (c3_p4_cmd_instr),
+         .p4_cmd_bl                      (c3_p4_cmd_bl), 
+         .p4_cmd_byte_addr               (c3_p4_cmd_byte_addr), 
+         .p4_cmd_full                    (c3_p4_cmd_full),
+         .p4_cmd_empty                   (c3_p4_cmd_empty),
+         // User Port-4 data write interface will be active only when the port is enabled in 
+         // the port configuration Config-1 write direction
+         .p4_wr_clk                      (c3_p4_wr_clk), 
+         .p4_wr_en                       (c3_p4_wr_en),
+         .p4_wr_mask                     (c3_p4_wr_mask),
+         .p4_wr_data                     (c3_p4_wr_data),
+         .p4_wr_full                     (c3_p4_wr_full),
+         .p4_wr_count                    (c3_p4_wr_count),
+         .p4_wr_empty                    (c3_p4_wr_empty),
+         .p4_wr_underrun                 (c3_p4_wr_underrun),
+         .p4_wr_error                    (c3_p4_wr_error),
+         // User Port-4 data read interface will be active only when the port is enabled in 
+         // the port configuration Config-1 read direction
+         .p4_rd_clk                      (c3_p4_rd_clk), 
+         .p4_rd_en                       (c3_p4_rd_en),
+         .p4_rd_data                     (c3_p4_rd_data),
+         .p4_rd_empty                    (c3_p4_rd_empty),
+         .p4_rd_count                    (c3_p4_rd_count),
+         .p4_rd_full                     (c3_p4_rd_full),
+         .p4_rd_overflow                 (c3_p4_rd_overflow),
+         .p4_rd_error                    (c3_p4_rd_error),
+      
+         // User Port-5 command interface will be active only when the port is enabled in 
+         // the port configuration Config-1
+         .p5_cmd_clk                     (c3_p5_cmd_clk), 
+         .p5_cmd_en                      (c3_p5_cmd_en), 
+         .p5_cmd_instr                   (c3_p5_cmd_instr),
+         .p5_cmd_bl                      (c3_p5_cmd_bl), 
+         .p5_cmd_byte_addr               (c3_p5_cmd_byte_addr), 
+         .p5_cmd_full                    (c3_p5_cmd_full),
+         .p5_cmd_empty                   (c3_p5_cmd_empty),
+         // User Port-5 data write interface will be active only when the port is enabled in 
+         // the port configuration Config-1 write direction
+         .p5_wr_clk                      (c3_p5_wr_clk), 
+         .p5_wr_en                       (c3_p5_wr_en),
+         .p5_wr_mask                     (c3_p5_wr_mask),
+         .p5_wr_data                     (c3_p5_wr_data),
+         .p5_wr_full                     (c3_p5_wr_full),
+         .p5_wr_count                    (c3_p5_wr_count),
+         .p5_wr_empty                    (c3_p5_wr_empty),
+         .p5_wr_underrun                 (c3_p5_wr_underrun),
+         .p5_wr_error                    (c3_p5_wr_error),
+         // User Port-5 data read interface will be active only when the port is enabled in 
+         // the port configuration Config-1 read direction
+         .p5_rd_clk                      (c3_p5_rd_clk), 
+         .p5_rd_en                       (c3_p5_rd_en),
+         .p5_rd_data                     (c3_p5_rd_data),
+         .p5_rd_empty                    (c3_p5_rd_empty),
+         .p5_rd_count                    (c3_p5_rd_count),
+         .p5_rd_full                     (c3_p5_rd_full),
+         .p5_rd_overflow                 (c3_p5_rd_overflow),
+         .p5_rd_error                    (c3_p5_rd_error),
+
+         .selfrefresh_enter              (1'b0), 
+         .selfrefresh_mode               (c3_selfrefresh_mode)
+      );
+   
+
+
+
+
+
+endmodule   
+
+ 

--- a/systems/atlys/rtl/verilog/xilinx_ddr2/infrastructure.v
+++ b/systems/atlys/rtl/verilog/xilinx_ddr2/infrastructure.v
@@ -1,0 +1,296 @@
+//*****************************************************************************
+// (c) Copyright 2010 Xilinx, Inc. All rights reserved.
+//
+// This file contains confidential and proprietary information
+// of Xilinx, Inc. and is protected under U.S. and
+// international copyright and other intellectual property
+// laws.
+//
+// DISCLAIMER
+// This disclaimer is not a license and does not grant any
+// rights to the materials distributed herewith. Except as
+// otherwise provided in a valid license issued to you by
+// Xilinx, and to the maximum extent permitted by applicable
+// law: (1) THESE MATERIALS ARE MADE AVAILABLE "AS IS" AND
+// WITH ALL FAULTS, AND XILINX HEREBY DISCLAIMS ALL WARRANTIES
+// AND CONDITIONS, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING
+// BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, NON-
+// INFRINGEMENT, OR FITNESS FOR ANY PARTICULAR PURPOSE; and
+// (2) Xilinx shall not be liable (whether in contract or tort,
+// including negligence, or under any other theory of
+// liability) for any loss or damage of any kind or nature
+// related to, arising under or in connection with these
+// materials, including for any direct, or any indirect,
+// special, incidental, or consequential loss or damage
+// (including loss of data, profits, goodwill, or any type of
+// loss or damage suffered as a result of any action brought
+// by a third party) even if such damage or loss was
+// reasonably foreseeable or Xilinx had been advised of the
+// possibility of the same.
+//
+// CRITICAL APPLICATIONS
+// Xilinx products are not designed or intended to be fail-
+// safe, or for use in any application requiring fail-safe
+// performance, such as life-support or safety devices or
+// systems, Class III medical devices, nuclear facilities,
+// applications related to the deployment of airbags, or any
+// other applications that could lead to death, personal
+// injury, or severe property or environmental damage
+// (individually and collectively, "Critical
+// Applications"). Customer assumes the sole risk and
+// liability of any use of Xilinx products in Critical
+// Applications, subject only to applicable laws and
+// regulations governing limitations on product liability.
+//
+// THIS COPYRIGHT NOTICE AND DISCLAIMER MUST BE RETAINED AS
+// PART OF THIS FILE AT ALL TIMES.
+//
+//*****************************************************************************
+//   ____  ____
+//  /   /\/   /
+// /___/  \  /    Vendor             : Xilinx
+// \   \   \/     Version            : %version
+//  \   \         Application        : MIG
+//  /   /         Filename           : infrastructure.v
+// /___/   /\     Date Last Modified : $Date: 2010/10/27 17:40:11 $
+// \   \  /  \    Date Created       : Mon Mar 2 2009
+//  \___\/\___\
+//
+//Device           : Spartan-6
+//Design Name      : DDR/DDR2/DDR3/LPDDR
+//Purpose          : Clock generation/distribution and reset synchronization
+//Reference        :
+//Revision History :
+//*****************************************************************************
+
+
+`timescale 1ns/1ps
+
+module infrastructure #
+  (
+   parameter C_INCLK_PERIOD    = 2500,
+   parameter C_RST_ACT_LOW      = 1,
+   parameter C_INPUT_CLK_TYPE   = "DIFFERENTIAL",
+   parameter C_CLKOUT0_DIVIDE   = 1,
+   parameter C_CLKOUT1_DIVIDE   = 1,
+   parameter C_CLKOUT2_DIVIDE   = 16,
+   parameter C_CLKOUT3_DIVIDE   = 8,
+   parameter C_CLKFBOUT_MULT    = 2,
+   parameter C_DIVCLK_DIVIDE    = 1
+   
+   )
+  (
+   input  sys_clk_p,
+   input  sys_clk_n,
+   input  sys_clk,
+   input  sys_rst_n,
+   output clk0,
+   output rst0,
+   output async_rst,
+   output sysclk_2x,
+   output sysclk_2x_180,
+   output mcb_drp_clk,
+   output pll_ce_0,
+   output pll_ce_90,
+   output pll_lock
+
+   );
+
+  // # of clock cycles to delay deassertion of reset. Needs to be a fairly
+  // high number not so much for metastability protection, but to give time
+  // for reset (i.e. stable clock cycles) to propagate through all state
+  // machines and to all control signals (i.e. not all control signals have
+  // resets, instead they rely on base state logic being reset, and the effect
+  // of that reset propagating through the logic). Need this because we may not
+  // be getting stable clock cycles while reset asserted (i.e. since reset
+  // depends on PLL/DCM lock status)
+
+  localparam RST_SYNC_NUM = 25;
+  localparam CLK_PERIOD_NS = C_INCLK_PERIOD / 1000.0;
+  localparam CLK_PERIOD_INT = C_INCLK_PERIOD/1000;
+
+  wire                       clk_2x_0;
+  wire                       clk_2x_180;
+  wire                       clk0_bufg;
+  wire                       clk0_bufg_in;
+  wire                       mcb_drp_clk_bufg_in;
+  wire                       clkfbout_clkfbin;
+  wire                       locked;
+  reg [RST_SYNC_NUM-1:0]     rst0_sync_r    /* synthesis syn_maxfan = 10 */;
+  wire                       rst_tmp;
+  reg                        powerup_pll_locked;
+
+  wire                       sys_rst;
+  wire                       bufpll_mcb_locked;
+  (* KEEP = "TRUE" *) wire sys_clk_ibufg;
+
+  assign sys_rst = C_RST_ACT_LOW ? ~sys_rst_n: sys_rst_n;
+  assign clk0        = clk0_bufg;
+  assign pll_lock    = bufpll_mcb_locked;
+
+  generate
+    if (C_INPUT_CLK_TYPE == "DIFFERENTIAL") begin: diff_input_clk
+
+      //***********************************************************************
+      // Differential input clock input buffers
+      //***********************************************************************
+
+      IBUFGDS #
+        (
+         .DIFF_TERM    ("TRUE")
+         )
+        u_ibufg_sys_clk
+          (
+           .I  (sys_clk_p),
+           .IB (sys_clk_n),
+           .O  (sys_clk_ibufg)
+           );
+
+    end else if (C_INPUT_CLK_TYPE == "SINGLE_ENDED") begin: se_input_clk
+
+      //***********************************************************************
+      // SINGLE_ENDED input clock input buffers
+      //***********************************************************************
+/*SJK
+      IBUFG  u_ibufg_sys_clk
+          (
+           .I  (sys_clk),
+           .O  (sys_clk_ibufg)
+           );
+*/
+        assign sys_clk_ibufg = sys_clk;
+   end
+  endgenerate
+
+  //***************************************************************************
+  // Global clock generation and distribution
+  //***************************************************************************
+
+    PLL_ADV #
+        (
+         .BANDWIDTH          ("OPTIMIZED"),
+         .CLKIN1_PERIOD      (CLK_PERIOD_NS),
+         .CLKIN2_PERIOD      (CLK_PERIOD_NS),
+         .CLKOUT0_DIVIDE     (C_CLKOUT0_DIVIDE),
+         .CLKOUT1_DIVIDE     (C_CLKOUT1_DIVIDE),
+         .CLKOUT2_DIVIDE     (C_CLKOUT2_DIVIDE),
+         .CLKOUT3_DIVIDE     (C_CLKOUT3_DIVIDE),
+         .CLKOUT4_DIVIDE     (1),
+         .CLKOUT5_DIVIDE     (1),
+         .CLKOUT0_PHASE      (0.000),
+         .CLKOUT1_PHASE      (180.000),
+         .CLKOUT2_PHASE      (0.000),
+         .CLKOUT3_PHASE      (0.000),
+         .CLKOUT4_PHASE      (0.000),
+         .CLKOUT5_PHASE      (0.000),
+         .CLKOUT0_DUTY_CYCLE (0.500),
+         .CLKOUT1_DUTY_CYCLE (0.500),
+         .CLKOUT2_DUTY_CYCLE (0.500),
+         .CLKOUT3_DUTY_CYCLE (0.500),
+         .CLKOUT4_DUTY_CYCLE (0.500),
+         .CLKOUT5_DUTY_CYCLE (0.500),
+         .COMPENSATION       ("INTERNAL"),
+         .DIVCLK_DIVIDE      (C_DIVCLK_DIVIDE),
+         .CLKFBOUT_MULT      (C_CLKFBOUT_MULT),
+         .CLKFBOUT_PHASE     (0.0),
+         .REF_JITTER         (0.005000)
+         )
+        u_pll_adv
+          (
+           .CLKFBIN     (clkfbout_clkfbin),
+           .CLKINSEL    (1'b1),
+           .CLKIN1      (sys_clk_ibufg),
+           .CLKIN2      (1'b0),
+           .DADDR       (5'b0),
+           .DCLK        (1'b0),
+           .DEN         (1'b0),
+           .DI          (16'b0),
+           .DWE         (1'b0),
+           .REL         (1'b0),
+           .RST         (sys_rst),
+           .CLKFBDCM    (),
+           .CLKFBOUT    (clkfbout_clkfbin),
+           .CLKOUTDCM0  (),
+           .CLKOUTDCM1  (),
+           .CLKOUTDCM2  (),
+           .CLKOUTDCM3  (),
+           .CLKOUTDCM4  (),
+           .CLKOUTDCM5  (),
+           .CLKOUT0     (clk_2x_0),
+           .CLKOUT1     (clk_2x_180),
+           .CLKOUT2     (clk0_bufg_in),
+           .CLKOUT3     (mcb_drp_clk_bufg_in),
+           .CLKOUT4     (),
+           .CLKOUT5     (),
+           .DO          (),
+           .DRDY        (),
+           .LOCKED      (locked)
+           );
+
+ 
+
+   BUFG U_BUFG_CLK0
+    (
+     .O (clk0_bufg),
+     .I (clk0_bufg_in)
+     );
+
+   BUFG U_BUFG_CLK1
+    (
+     .O (mcb_drp_clk),
+     .I (mcb_drp_clk_bufg_in)
+     );
+
+
+  always @(posedge clk0_bufg , posedge sys_rst)
+      if(sys_rst)
+         powerup_pll_locked <= 1'b0;
+       
+      else if (bufpll_mcb_locked)
+         powerup_pll_locked <= 1'b1;
+
+  //***************************************************************************
+  // Reset synchronization
+  // NOTES:
+  //   1. shut down the whole operation if the PLL hasn't yet locked (and
+  //      by inference, this means that external SYS_RST_IN has been asserted -
+  //      PLL deasserts LOCKED as soon as SYS_RST_IN asserted)
+  //   2. asynchronously assert reset. This was we can assert reset even if
+  //      there is no clock (needed for things like 3-stating output buffers).
+  //      reset deassertion is synchronous.
+  //   3. asynchronous reset only look at pll_lock from PLL during power up. After
+  //      power up and pll_lock is asserted, the powerup_pll_locked will be asserted
+  //      forever until sys_rst is asserted again. PLL will lose lock when FPGA 
+  //      enters suspend mode. We don't want reset to MCB get
+  //      asserted in the application that needs suspend feature.
+  //***************************************************************************
+
+  assign rst_tmp = sys_rst | ~powerup_pll_locked;
+
+  assign async_rst = rst_tmp;
+  // synthesis attribute max_fanout of rst0_sync_r is 10
+  always @(posedge clk0_bufg or posedge rst_tmp)
+    if (rst_tmp)
+      rst0_sync_r <= {RST_SYNC_NUM{1'b1}};
+    else
+      // logical left shift by one (pads with 0)
+      rst0_sync_r <= rst0_sync_r << 1;
+
+
+  assign rst0    = rst0_sync_r[RST_SYNC_NUM-1];
+
+
+BUFPLL_MCB BUFPLL_MCB1 
+( .IOCLK0         (sysclk_2x),  
+  .IOCLK1         (sysclk_2x_180), 	 
+  .LOCKED         (locked),
+  .GCLK           (mcb_drp_clk),
+  .SERDESSTROBE0  (pll_ce_0), 
+  .SERDESSTROBE1  (pll_ce_90), 
+  .PLLIN0         (clk_2x_0),  
+  .PLLIN1         (clk_2x_180),
+  .LOCK           (bufpll_mcb_locked) 
+  );
+
+
+endmodule

--- a/systems/atlys/rtl/verilog/xilinx_ddr2/iodrp_controller.v
+++ b/systems/atlys/rtl/verilog/xilinx_ddr2/iodrp_controller.v
@@ -1,0 +1,302 @@
+//*****************************************************************************
+// (c) Copyright 2009 Xilinx, Inc. All rights reserved.
+//
+// This file contains confidential and proprietary information
+// of Xilinx, Inc. and is protected under U.S. and
+// international copyright and other intellectual property
+// laws.
+//
+// DISCLAIMER
+// This disclaimer is not a license and does not grant any
+// rights to the materials distributed herewith. Except as
+// otherwise provided in a valid license issued to you by
+// Xilinx, and to the maximum extent permitted by applicable
+// law: (1) THESE MATERIALS ARE MADE AVAILABLE "AS IS" AND
+// WITH ALL FAULTS, AND XILINX HEREBY DISCLAIMS ALL WARRANTIES
+// AND CONDITIONS, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING
+// BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, NON-
+// INFRINGEMENT, OR FITNESS FOR ANY PARTICULAR PURPOSE; and
+// (2) Xilinx shall not be liable (whether in contract or tort,
+// including negligence, or under any other theory of
+// liability) for any loss or damage of any kind or nature
+// related to, arising under or in connection with these
+// materials, including for any direct, or any indirect,
+// special, incidental, or consequential loss or damage
+// (including loss of data, profits, goodwill, or any type of
+// loss or damage suffered as a result of any action brought
+// by a third party) even if such damage or loss was
+// reasonably foreseeable or Xilinx had been advised of the
+// possibility of the same.
+//
+// CRITICAL APPLICATIONS
+// Xilinx products are not designed or intended to be fail-
+// safe, or for use in any application requiring fail-safe
+// performance, such as life-support or safety devices or
+// systems, Class III medical devices, nuclear facilities,
+// applications related to the deployment of airbags, or any
+// other applications that could lead to death, personal
+// injury, or severe property or environmental damage
+// (individually and collectively, "Critical
+// Applications"). Customer assumes the sole risk and
+// liability of any use of Xilinx products in Critical
+// Applications, subject only to applicable laws and
+// regulations governing limitations on product liability.
+//
+// THIS COPYRIGHT NOTICE AND DISCLAIMER MUST BE RETAINED AS
+// PART OF THIS FILE AT ALL TIMES.
+//
+//*****************************************************************************
+//   ____  ____
+//  /   /\/   /
+// /___/  \  /    Vendor: Xilinx
+// \   \   \/     Version: %version
+//  \   \         Application: MIG
+//  /   /         Filename: iodrp_controller.v
+// /___/   /\     Date Last Modified: $Date: 2010/10/27 17:40:12 $
+// \   \  /  \    Date Created: Mon Feb 9 2009
+//  \___\/\___\
+//
+//Device: Spartan6
+//Design Name: DDR/DDR2/DDR3/LPDDR
+//Purpose:  Xilinx reference design for IODRP controller for v0.9 device
+//
+//Reference:
+//
+//    Revision: Date:       Comment
+//    1.0:      02/06/09:   Initial version for MIG wrapper.
+//    1.1:      02/01/09:   updates to indentations.
+//    1.2:      02/12/09:   changed non-blocking assignments to blocking ones
+//                          for state machine always block.  Also, assigned
+//                          intial value to load_shift_n to avoid latch
+// End Revision
+//*******************************************************************************
+
+`timescale 1ps/1ps
+
+module iodrp_controller(
+  input   wire  [7:0] memcell_address,
+  input   wire  [7:0] write_data,
+  output  reg   [7:0] read_data,
+  input   wire        rd_not_write,
+  input   wire        cmd_valid,
+  output  wire        rdy_busy_n,
+  input   wire        use_broadcast,
+  input   wire        sync_rst,
+  input   wire        DRP_CLK,
+  output  reg         DRP_CS,
+  output  wire        DRP_SDI,  //output to IODRP SDI pin
+  output  reg         DRP_ADD,
+  output  reg         DRP_BKST,
+  input   wire        DRP_SDO   //input from IODRP SDO pin
+  );
+
+  reg   [7:0]   memcell_addr_reg;     // Register where memcell_address is captured during the READY state
+  reg   [7:0]   data_reg;             // Register which stores the write data until it is ready to be shifted out
+  reg   [7:0]   shift_through_reg;    // The shift register which shifts out SDO and shifts in SDI.
+                                      // This register is loaded before the address or data phase, but continues
+                                      // to shift for a writeback of read data
+  reg           load_shift_n;         // The signal which causes shift_through_reg to load the new value from data_out_mux, or continue to shift data in from DRP_SDO
+  reg           addr_data_sel_n;      // The signal which indicates where the shift_through_reg should load from.  0 -> data_reg  1 -> memcell_addr_reg
+  reg   [2:0]   bit_cnt;              // The counter for which bit is being shifted during address or data phase
+  reg           rd_not_write_reg;
+  reg           AddressPhase;         // This is set after the first address phase has executed
+  reg           capture_read_data;
+
+  (* FSM_ENCODING="one-hot" *) reg [2:0] state, nextstate;
+
+  wire  [7:0]   data_out_mux;         // The mux which selects between data_reg and memcell_addr_reg for sending to shift_through_reg
+  wire          DRP_SDI_pre;          // added so that DRP_SDI output is only active when DRP_CS is active
+
+  localparam  READY             = 3'h0;
+  localparam  DECIDE            = 3'h1;
+  localparam  ADDR_PHASE        = 3'h2;
+  localparam  ADDR_TO_DATA_GAP  = 3'h3;
+  localparam  ADDR_TO_DATA_GAP2 = 3'h4;
+  localparam  ADDR_TO_DATA_GAP3 = 3'h5;
+  localparam  DATA_PHASE        = 3'h6;
+  localparam  ALMOST_READY      = 3'h7;
+
+  localparam  IOI_DQ0           = 5'h01;
+  localparam  IOI_DQ1           = 5'h00;
+  localparam  IOI_DQ2           = 5'h03;
+  localparam  IOI_DQ3           = 5'h02;
+  localparam  IOI_DQ4           = 5'h05;
+  localparam  IOI_DQ5           = 5'h04;
+  localparam  IOI_DQ6           = 5'h07;
+  localparam  IOI_DQ7           = 5'h06;
+  localparam  IOI_DQ8           = 5'h09;
+  localparam  IOI_DQ9           = 5'h08;
+  localparam  IOI_DQ10          = 5'h0B;
+  localparam  IOI_DQ11          = 5'h0A;
+  localparam  IOI_DQ12          = 5'h0D;
+  localparam  IOI_DQ13          = 5'h0C;
+  localparam  IOI_DQ14          = 5'h0F;
+  localparam  IOI_DQ15          = 5'h0E;
+  localparam  IOI_UDQS_CLK      = 5'h1D;
+  localparam  IOI_UDQS_PIN      = 5'h1C;
+  localparam  IOI_LDQS_CLK      = 5'h1F;
+  localparam  IOI_LDQS_PIN      = 5'h1E;
+  //synthesis translate_off
+  reg   [32*8-1:0]  state_ascii;
+  always @ (state) begin
+    case (state)
+      READY             :state_ascii  <= "READY";
+      DECIDE            :state_ascii  <= "DECIDE";
+      ADDR_PHASE        :state_ascii  <= "ADDR_PHASE";
+      ADDR_TO_DATA_GAP  :state_ascii  <= "ADDR_TO_DATA_GAP";
+      ADDR_TO_DATA_GAP2 :state_ascii  <= "ADDR_TO_DATA_GAP2";
+      ADDR_TO_DATA_GAP3 :state_ascii  <= "ADDR_TO_DATA_GAP3";
+      DATA_PHASE        :state_ascii  <= "DATA_PHASE";
+      ALMOST_READY      :state_ascii  <= "ALMOST_READY";
+    endcase // case(state)
+  end
+  //synthesis translate_on
+  /*********************************************
+   *   Input Registers
+   *********************************************/
+  always @ (posedge DRP_CLK) begin
+     if(state == READY) begin
+       memcell_addr_reg <= memcell_address;
+       data_reg <= write_data;
+       rd_not_write_reg <= rd_not_write;
+     end
+  end
+
+  assign rdy_busy_n = (state == READY);
+
+
+  /*********************************************
+   *   Shift Registers / Bit Counter
+   *********************************************/
+  assign data_out_mux = addr_data_sel_n ? memcell_addr_reg : data_reg;
+
+  always @ (posedge DRP_CLK) begin
+    if(sync_rst)
+      shift_through_reg <= 8'b0;
+    else begin
+      if (load_shift_n)     //Assume the shifter is either loading or shifting, bit 0 is shifted out first
+        shift_through_reg <= data_out_mux;
+      else
+        shift_through_reg <= {DRP_SDO, shift_through_reg[7:1]};
+    end
+  end
+
+  always @ (posedge DRP_CLK) begin
+    if (((state == ADDR_PHASE) | (state == DATA_PHASE)) & !sync_rst)
+      bit_cnt <= bit_cnt + 1;
+    else
+      bit_cnt <= 3'b000;
+  end
+
+  always @ (posedge DRP_CLK) begin
+    if(sync_rst) begin
+      read_data   <= 8'h00;
+//     capture_read_data <= 1'b0;
+    end
+    else begin
+//       capture_read_data <= (state == DATA_PHASE);
+//       if(capture_read_data)
+      if(state == ALMOST_READY)
+        read_data <= shift_through_reg;
+//      else
+//        read_data <= read_data;
+    end
+  end
+
+  always @ (posedge DRP_CLK) begin
+    if(sync_rst) begin
+      AddressPhase  <= 1'b0;
+    end
+    else begin
+      if (AddressPhase) begin
+        // Keep it set until we finish the cycle
+        AddressPhase <= AddressPhase && ~(state == ALMOST_READY);
+      end
+      else begin
+        // set the address phase when ever we finish the address phase
+        AddressPhase <= (state == ADDR_PHASE) && (bit_cnt == 3'b111);
+      end
+    end
+  end
+
+  /*********************************************
+   *   DRP Signals
+   *********************************************/
+  always @ (posedge DRP_CLK) begin
+    DRP_ADD     <= (nextstate == ADDR_PHASE);
+    DRP_CS      <= (nextstate == ADDR_PHASE) | (nextstate == DATA_PHASE);
+    if (state == READY)
+      DRP_BKST  <= use_broadcast;
+  end
+
+//  assign DRP_SDI_pre  = (DRP_CS)? shift_through_reg[0] : 1'b0;  //if DRP_CS is inactive, just drive 0 out - this is a possible place to pipeline for increased performance
+//  assign DRP_SDI      = (rd_not_write_reg & DRP_CS & !DRP_ADD)? DRP_SDO : DRP_SDI_pre; //If reading, then feed SDI back out SDO - this is a possible place to pipeline for increased performance
+  assign DRP_SDI = shift_through_reg[0]; // The new read method only requires that we shift out the address and the write data
+
+  /*********************************************
+   *   State Machine
+   *********************************************/
+  always @ (*) begin
+    addr_data_sel_n = 1'b0;
+    load_shift_n    = 1'b0;
+    case (state)
+      READY:  begin
+        if(cmd_valid)
+          nextstate   = DECIDE;
+        else
+          nextstate   = READY;
+      end
+      DECIDE: begin
+        load_shift_n    = 1;
+        addr_data_sel_n = 1;
+        nextstate       = ADDR_PHASE;
+      end
+      ADDR_PHASE: begin
+        if(&bit_cnt)
+          if (rd_not_write_reg)
+            if (AddressPhase)
+              // After the second pass go to end of statemachine
+              nextstate = ALMOST_READY;
+            else
+              // execute a second address phase for the read access.
+              nextstate = DECIDE;
+          else
+            nextstate = ADDR_TO_DATA_GAP;
+        else
+          nextstate   = ADDR_PHASE;
+      end
+      ADDR_TO_DATA_GAP: begin
+        load_shift_n  = 1;
+        nextstate     = ADDR_TO_DATA_GAP2;
+      end
+      ADDR_TO_DATA_GAP2: begin
+        load_shift_n  = 1;
+        nextstate     = ADDR_TO_DATA_GAP3;
+      end
+      ADDR_TO_DATA_GAP3: begin
+        load_shift_n  = 1;
+        nextstate     = DATA_PHASE;
+      end
+      DATA_PHASE: begin
+        if(&bit_cnt)
+          nextstate   = ALMOST_READY;
+        else
+          nextstate   = DATA_PHASE;
+      end
+      ALMOST_READY: begin
+        nextstate     = READY;
+      end
+      default: begin
+        nextstate     = READY;
+      end
+    endcase
+  end
+
+  always @ (posedge DRP_CLK) begin
+    if(sync_rst)
+      state <= READY;
+    else
+      state <= nextstate;
+  end
+
+endmodule

--- a/systems/atlys/rtl/verilog/xilinx_ddr2/iodrp_mcb_controller.v
+++ b/systems/atlys/rtl/verilog/xilinx_ddr2/iodrp_mcb_controller.v
@@ -1,0 +1,427 @@
+//*****************************************************************************
+// (c) Copyright 2009 Xilinx, Inc. All rights reserved.
+//
+// This file contains confidential and proprietary information
+// of Xilinx, Inc. and is protected under U.S. and
+// international copyright and other intellectual property
+// laws.
+//
+// DISCLAIMER
+// This disclaimer is not a license and does not grant any
+// rights to the materials distributed herewith. Except as
+// otherwise provided in a valid license issued to you by
+// Xilinx, and to the maximum extent permitted by applicable
+// law: (1) THESE MATERIALS ARE MADE AVAILABLE "AS IS" AND
+// WITH ALL FAULTS, AND XILINX HEREBY DISCLAIMS ALL WARRANTIES
+// AND CONDITIONS, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING
+// BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, NON-
+// INFRINGEMENT, OR FITNESS FOR ANY PARTICULAR PURPOSE; and
+// (2) Xilinx shall not be liable (whether in contract or tort,
+// including negligence, or under any other theory of
+// liability) for any loss or damage of any kind or nature
+// related to, arising under or in connection with these
+// materials, including for any direct, or any indirect,
+// special, incidental, or consequential loss or damage
+// (including loss of data, profits, goodwill, or any type of
+// loss or damage suffered as a result of any action brought
+// by a third party) even if such damage or loss was
+// reasonably foreseeable or Xilinx had been advised of the
+// possibility of the same.
+//
+// CRITICAL APPLICATIONS
+// Xilinx products are not designed or intended to be fail-
+// safe, or for use in any application requiring fail-safe
+// performance, such as life-support or safety devices or
+// systems, Class III medical devices, nuclear facilities,
+// applications related to the deployment of airbags, or any
+// other applications that could lead to death, personal
+// injury, or severe property or environmental damage
+// (individually and collectively, "Critical
+// Applications"). Customer assumes the sole risk and
+// liability of any use of Xilinx products in Critical
+// Applications, subject only to applicable laws and
+// regulations governing limitations on product liability.
+//
+// THIS COPYRIGHT NOTICE AND DISCLAIMER MUST BE RETAINED AS
+// PART OF THIS FILE AT ALL TIMES.
+//
+//*****************************************************************************
+//   ____  ____
+//  /   /\/   /
+// /___/  \  /    Vendor: Xilinx
+// \   \   \/     Version: %version
+//  \   \         Application: MIG
+//  /   /         Filename: iodrp_mcb_controller.v
+// /___/   /\     Date Last Modified: $Date: 2010/10/27 17:40:12 $
+// \   \  /  \    Date Created: Mon Feb 9 2009
+//  \___\/\___\
+//
+//Device: Spartan6
+//Design Name: DDR/DDR2/DDR3/LPDDR
+//Purpose:  Xilinx reference design for IODRP controller for v0.9 device
+//Reference:
+//
+//  Revision:      Date:  Comment
+//       1.0:  3/19/09:  Initial version for IODRP_MCB read operations.
+//       1.1:  4/03/09:  SLH - Added left shift for certain IOI's
+// End Revision
+//**********************************************************************************
+
+`timescale 1ps/1ps
+
+`ifdef ALTERNATE_READ
+`else
+  `define ALTERNATE_READ 1'b1
+`endif
+
+module iodrp_mcb_controller(
+  input   wire  [7:0] memcell_address,
+  input   wire  [7:0] write_data,
+  output  reg   [7:0] read_data = 0,
+  input   wire        rd_not_write,
+  input   wire        cmd_valid,
+  output  wire        rdy_busy_n,
+  input   wire        use_broadcast,
+  input   wire  [4:0] drp_ioi_addr,
+  input   wire        sync_rst,
+  input   wire        DRP_CLK,
+  output  reg         DRP_CS,
+  output  wire        DRP_SDI,  //output to IODRP SDI pin
+  output  reg         DRP_ADD,
+  output  reg         DRP_BKST,
+  input   wire        DRP_SDO,   //input from IODRP SDO pin
+  output  reg         MCB_UIREAD = 1'b0
+  );
+
+   reg [7:0]          memcell_addr_reg;     // Register where memcell_address is captured during the READY state
+   reg [7:0]          data_reg;             // Register which stores the write data until it is ready to be shifted out
+   reg [8:0]          shift_through_reg;    // The shift register which shifts out SDO and shifts in SDI.
+                                            //    This register is loaded before the address or data phase, but continues to shift for a writeback of read data
+   reg                load_shift_n;         // The signal which causes shift_through_reg to load the new value from data_out_mux, or continue to shift data in from DRP_SDO
+   reg                addr_data_sel_n;      // The signal which indicates where the shift_through_reg should load from.  0 -> data_reg  1 -> memcell_addr_reg
+   reg [2:0]          bit_cnt= 3'b0;        // The counter for which bit is being shifted during address or data phase
+   reg                rd_not_write_reg;
+   reg                AddressPhase;         // This is set after the first address phase has executed
+   reg                DRP_CS_pre;
+   reg                extra_cs;
+
+   (* FSM_ENCODING="GRAY" *) reg [3:0] state, nextstate;
+
+   wire [8:0]   data_out;
+   reg  [8:0]   data_out_mux; // The mux which selects between data_reg and memcell_addr_reg for sending to shift_through_reg
+   wire DRP_SDI_pre;          //added so that DRP_SDI output is only active when DRP_CS is active
+
+   localparam READY             = 4'h0;
+   localparam DECIDE            = 4'h1;
+   localparam ADDR_PHASE        = 4'h2;
+   localparam ADDR_TO_DATA_GAP  = 4'h3;
+   localparam ADDR_TO_DATA_GAP2 = 4'h4;
+   localparam ADDR_TO_DATA_GAP3 = 4'h5;
+   localparam DATA_PHASE        = 4'h6;
+   localparam ALMOST_READY      = 4'h7;
+   localparam ALMOST_READY2     = 4'h8;
+   localparam ALMOST_READY3     = 4'h9;
+
+   localparam IOI_DQ0           = 5'h01;
+   localparam IOI_DQ1           = 5'h00;
+   localparam IOI_DQ2           = 5'h03;
+   localparam IOI_DQ3           = 5'h02;
+   localparam IOI_DQ4           = 5'h05;
+   localparam IOI_DQ5           = 5'h04;
+   localparam IOI_DQ6           = 5'h07;
+   localparam IOI_DQ7           = 5'h06;
+   localparam IOI_DQ8           = 5'h09;
+   localparam IOI_DQ9           = 5'h08;
+   localparam IOI_DQ10          = 5'h0B;
+   localparam IOI_DQ11          = 5'h0A;
+   localparam IOI_DQ12          = 5'h0D;
+   localparam IOI_DQ13          = 5'h0C;
+   localparam IOI_DQ14          = 5'h0F;
+   localparam IOI_DQ15          = 5'h0E;
+   localparam IOI_UDQS_CLK      = 5'h1D;
+   localparam IOI_UDQS_PIN      = 5'h1C;
+   localparam IOI_LDQS_CLK      = 5'h1F;
+   localparam IOI_LDQS_PIN      = 5'h1E;
+
+   //synthesis translate_off
+   reg [32*8-1:0] state_ascii;
+   always @ (state) begin
+      case (state)
+  READY     :state_ascii<="READY";
+  DECIDE      :state_ascii<="DECIDE";
+  ADDR_PHASE    :state_ascii<="ADDR_PHASE";
+  ADDR_TO_DATA_GAP  :state_ascii<="ADDR_TO_DATA_GAP";
+  ADDR_TO_DATA_GAP2 :state_ascii<="ADDR_TO_DATA_GAP2";
+  ADDR_TO_DATA_GAP3 :state_ascii<="ADDR_TO_DATA_GAP3";
+  DATA_PHASE    :state_ascii<="DATA_PHASE";
+  ALMOST_READY    :state_ascii<="ALMOST_READY";
+  ALMOST_READY2   :state_ascii<="ALMOST_READY2";
+  ALMOST_READY3   :state_ascii<="ALMOST_READY3";
+      endcase // case(state)
+   end
+   //synthesis translate_on
+
+   /*********************************************
+    *   Input Registers
+    *********************************************/
+   always @ (posedge DRP_CLK) begin
+      if(state == READY) begin
+        memcell_addr_reg <= memcell_address;
+        data_reg <= write_data;
+        rd_not_write_reg <= rd_not_write;
+      end
+   end
+
+   assign rdy_busy_n = (state == READY);
+
+   // The changes below are to compensate for an issue with 1.0 silicon.
+   // It may still be necessary to add a clock cycle to the ADD and CS signals
+
+//`define DRP_v1_0_FIX    // Uncomment out this line for synthesis
+
+task shift_n_expand (
+  input   [7:0] data_in,
+  output  [8:0] data_out
+  );
+
+  begin
+    if (data_in[0])
+      data_out[1:0]  = 2'b11;
+    else
+      data_out[1:0]  = 2'b00;
+
+    if (data_in[1:0] == 2'b10)
+      data_out[2:1]  = 2'b11;
+    else
+      data_out[2:1]  = {data_in[1], data_out[1]};
+
+    if (data_in[2:1] == 2'b10)
+      data_out[3:2]  = 2'b11;
+    else
+      data_out[3:2]  = {data_in[2], data_out[2]};
+
+    if (data_in[3:2] == 2'b10)
+      data_out[4:3]  = 2'b11;
+    else
+      data_out[4:3]  = {data_in[3], data_out[3]};
+
+    if (data_in[4:3] == 2'b10)
+      data_out[5:4]  = 2'b11;
+    else
+      data_out[5:4]  = {data_in[4], data_out[4]};
+
+    if (data_in[5:4] == 2'b10)
+      data_out[6:5]  = 2'b11;
+    else
+      data_out[6:5]  = {data_in[5], data_out[5]};
+
+    if (data_in[6:5] == 2'b10)
+      data_out[7:6]  = 2'b11;
+    else
+      data_out[7:6]  = {data_in[6], data_out[6]};
+
+    if (data_in[7:6] == 2'b10)
+      data_out[8:7]  = 2'b11;
+    else
+      data_out[8:7]  = {data_in[7], data_out[7]};
+  end
+endtask
+
+
+   always @(*) begin
+    case(drp_ioi_addr)
+`ifdef DRP_v1_0_FIX
+      IOI_DQ0       : data_out_mux  = data_out<<1;
+      IOI_DQ1       : data_out_mux  = data_out;
+      IOI_DQ2       : data_out_mux  = data_out<<1;
+//      IOI_DQ2       : data_out_mux  = data_out;
+      IOI_DQ3       : data_out_mux  = data_out;
+      IOI_DQ4       : data_out_mux  = data_out;
+      IOI_DQ5       : data_out_mux  = data_out;
+      IOI_DQ6       : shift_n_expand (data_out, data_out_mux);
+//      IOI_DQ6       : data_out_mux  = data_out;
+      IOI_DQ7       : data_out_mux  = data_out;
+      IOI_DQ8       : data_out_mux  = data_out<<1;
+      IOI_DQ9       : data_out_mux  = data_out;
+      IOI_DQ10      : data_out_mux  = data_out<<1;
+      IOI_DQ11      : data_out_mux  = data_out;
+      IOI_DQ12      : data_out_mux  = data_out<<1;
+      IOI_DQ13      : data_out_mux  = data_out;
+      IOI_DQ14      : data_out_mux  = data_out<<1;
+      IOI_DQ15      : data_out_mux  = data_out;
+      IOI_UDQS_CLK  : data_out_mux  = data_out<<1;
+      IOI_UDQS_PIN  : data_out_mux  = data_out<<1;
+      IOI_LDQS_CLK  : data_out_mux  = data_out;
+      IOI_LDQS_PIN  : data_out_mux  = data_out;
+`else
+`endif
+      IOI_DQ0       : data_out_mux  = data_out;
+      IOI_DQ1       : data_out_mux  = data_out;
+      IOI_DQ2       : data_out_mux  = data_out;
+      IOI_DQ3       : data_out_mux  = data_out;
+      IOI_DQ4       : data_out_mux  = data_out;
+      IOI_DQ5       : data_out_mux  = data_out;
+      IOI_DQ6       : data_out_mux  = data_out;
+      IOI_DQ7       : data_out_mux  = data_out;
+      IOI_DQ8       : data_out_mux  = data_out;
+      IOI_DQ9       : data_out_mux  = data_out;
+      IOI_DQ10      : data_out_mux  = data_out;
+      IOI_DQ11      : data_out_mux  = data_out;
+      IOI_DQ12      : data_out_mux  = data_out;
+      IOI_DQ13      : data_out_mux  = data_out;
+      IOI_DQ14      : data_out_mux  = data_out;
+      IOI_DQ15      : data_out_mux  = data_out;
+      IOI_UDQS_CLK  : data_out_mux  = data_out;
+      IOI_UDQS_PIN  : data_out_mux  = data_out;
+      IOI_LDQS_CLK  : data_out_mux  = data_out;
+      IOI_LDQS_PIN  : data_out_mux  = data_out;
+      default       : data_out_mux  = data_out;
+    endcase
+   end
+
+
+   /*********************************************
+    *   Shift Registers / Bit Counter
+    *********************************************/
+   assign     data_out = (addr_data_sel_n)? {1'b0, memcell_addr_reg} : {1'b0, data_reg};
+
+   always @ (posedge DRP_CLK) begin
+      if(sync_rst)
+        shift_through_reg <= 9'b0;
+      else begin
+        if (load_shift_n)     //Assume the shifter is either loading or shifting, bit 0 is shifted out first
+          shift_through_reg <= data_out_mux;
+        else
+          shift_through_reg <= {1'b0, DRP_SDO, shift_through_reg[7:1]};
+      end
+   end
+
+   always @ (posedge DRP_CLK) begin
+      if (((state == ADDR_PHASE) | (state == DATA_PHASE)) & !sync_rst)
+        bit_cnt <= bit_cnt + 1;
+      else
+        bit_cnt <= 3'b0;
+   end
+
+  always @ (posedge DRP_CLK) begin
+    if(sync_rst) begin
+      read_data <= 8'h00;
+    end
+    else begin
+      if(state == ALMOST_READY3)
+        read_data <= shift_through_reg;
+    end
+  end
+
+  always @ (posedge DRP_CLK) begin
+    if(sync_rst) begin
+      AddressPhase  <= 1'b0;
+    end
+    else begin
+      if (AddressPhase) begin
+        // Keep it set until we finish the cycle
+        AddressPhase <= AddressPhase && ~(state == ALMOST_READY2);
+      end
+      else begin
+        // set the address phase when ever we finish the address phase
+        AddressPhase <= (state == ADDR_PHASE) && (bit_cnt == 3'b111);
+      end
+    end
+  end
+
+   /*********************************************
+    *   DRP Signals
+    *********************************************/
+   always @ (posedge DRP_CLK) begin
+      DRP_ADD     <= (nextstate == ADDR_PHASE);
+      DRP_CS      <= (nextstate == ADDR_PHASE) | (nextstate == DATA_PHASE);
+//      DRP_CS      <= (drp_ioi_addr != IOI_DQ0) ? (nextstate == ADDR_PHASE) | (nextstate == DATA_PHASE) : (bit_cnt != 3'b111) && (nextstate == ADDR_PHASE) | (nextstate == DATA_PHASE);
+      MCB_UIREAD  <= (nextstate == DATA_PHASE) && rd_not_write_reg;
+      if (state == READY)
+        DRP_BKST  <= use_broadcast;
+   end
+
+   assign DRP_SDI_pre = (DRP_CS)? shift_through_reg[0] : 1'b0;  //if DRP_CS is inactive, just drive 0 out - this is a possible place to pipeline for increased performance
+   assign DRP_SDI = (rd_not_write_reg & DRP_CS & !DRP_ADD)? DRP_SDO : DRP_SDI_pre; //If reading, then feed SDI back out SDO - this is a possible place to pipeline for increased performance
+
+
+   /*********************************************
+    *   State Machine
+    *********************************************/
+  always @ (*) begin
+    addr_data_sel_n = 1'b0;
+    load_shift_n = 1'b0;
+    case (state)
+      READY:  begin
+         load_shift_n = 0;
+         if(cmd_valid)
+          nextstate = DECIDE;
+         else
+          nextstate = READY;
+        end
+      DECIDE: begin
+          load_shift_n = 1;
+          addr_data_sel_n = 1;
+          nextstate = ADDR_PHASE;
+        end
+      ADDR_PHASE: begin
+         load_shift_n = 0;
+         if(&bit_cnt[2:0])
+           if (`ALTERNATE_READ && rd_not_write_reg)
+             if (AddressPhase)
+               // After the second pass go to end of statemachine
+               nextstate = ALMOST_READY;
+             else
+               // execute a second address phase for the alternative access method.
+               nextstate = DECIDE;
+           else
+            nextstate = ADDR_TO_DATA_GAP;
+         else
+          nextstate = ADDR_PHASE;
+        end
+      ADDR_TO_DATA_GAP: begin
+          load_shift_n = 1;
+          nextstate = ADDR_TO_DATA_GAP2;
+        end
+      ADDR_TO_DATA_GAP2: begin
+         load_shift_n = 1;
+         nextstate = ADDR_TO_DATA_GAP3;
+        end
+      ADDR_TO_DATA_GAP3: begin
+         load_shift_n = 1;
+         nextstate = DATA_PHASE;
+        end
+      DATA_PHASE: begin
+         load_shift_n = 0;
+         if(&bit_cnt)
+            nextstate = ALMOST_READY;
+         else
+          nextstate = DATA_PHASE;
+        end
+      ALMOST_READY: begin
+         load_shift_n = 0;
+         nextstate = ALMOST_READY2;
+         end
+      ALMOST_READY2: begin
+         load_shift_n = 0;
+         nextstate = ALMOST_READY3;
+         end
+      ALMOST_READY3: begin
+         load_shift_n = 0;
+         nextstate = READY;
+         end
+      default: begin
+         load_shift_n = 0;
+         nextstate = READY;
+       end
+    endcase
+  end
+
+  always @ (posedge DRP_CLK) begin
+    if(sync_rst)
+      state <= READY;
+    else
+      state <= nextstate;
+   end
+
+endmodule

--- a/systems/atlys/rtl/verilog/xilinx_ddr2/mcb_raw_wrapper.v
+++ b/systems/atlys/rtl/verilog/xilinx_ddr2/mcb_raw_wrapper.v
@@ -1,0 +1,6496 @@
+//*****************************************************************************
+// (c) Copyright 2009 Xilinx, Inc. All rights reserved.
+//
+// This file contains confidential and proprietary information
+// of Xilinx, Inc. and is protected under U.S. and
+// international copyright and other intellectual property
+// laws.
+//
+// DISCLAIMER
+// This disclaimer is not a license and does not grant any
+// rights to the materials distributed herewith. Except as
+// otherwise provided in a valid license issued to you by
+// Xilinx, and to the maximum extent permitted by applicable
+// law: (1) THESE MATERIALS ARE MADE AVAILABLE "AS IS" AND
+// WITH ALL FAULTS, AND XILINX HEREBY DISCLAIMS ALL WARRANTIES
+// AND CONDITIONS, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING
+// BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, NON-
+// INFRINGEMENT, OR FITNESS FOR ANY PARTICULAR PURPOSE; and
+// (2) Xilinx shall not be liable (whether in contract or tort,
+// including negligence, or under any other theory of
+// liability) for any loss or damage of any kind or nature
+// related to, arising under or in connection with these
+// materials, including for any direct, or any indirect,
+// special, incidental, or consequential loss or damage
+// (including loss of data, profits, goodwill, or any type of
+// loss or damage suffered as a result of any action brought
+// by a third party) even if such damage or loss was
+// reasonably foreseeable or Xilinx had been advised of the
+// possibility of the same.
+//
+// CRITICAL APPLICATIONS
+// Xilinx products are not designed or intended to be fail-
+// safe, or for use in any application requiring fail-safe
+// performance, such as life-support or safety devices or
+// systems, Class III medical devices, nuclear facilities,
+// applications related to the deployment of airbags, or any
+// other applications that could lead to death, personal
+// injury, or severe property or environmental damage
+// (individually and collectively, "Critical
+// Applications"). Customer assumes the sole risk and
+// liability of any use of Xilinx products in Critical
+// Applications, subject only to applicable laws and
+// regulations governing limitations on product liability.
+//
+// THIS COPYRIGHT NOTICE AND DISCLAIMER MUST BE RETAINED AS
+// PART OF THIS FILE AT ALL TIMES.
+//
+//*****************************************************************************
+//   ____  ____
+//  /   /\/   /
+// /___/  \  /    Vendor: Xilinx
+// \   \   \/     Version: %version
+//  \   \         Application: MIG
+//  /   /         Filename: mcb_raw_wrapper.v
+// /___/   /\     Date Last Modified: $Date: 2010/10/27 17:40:12 $
+// \   \  /  \    Date Created: Thu June 24 2008
+//  \___\/\___\
+//
+//Device: Spartan6
+//Design Name: DDR/DDR2/DDR3/LPDDR 
+//Purpose:
+//Reference:
+//   This module is the intialization control logic of the memory interface.
+//   All commands are issued from here acoording to the burst, CAS Latency and
+//   the user commands.
+//   
+// Revised History:  
+//    Rev 1.1 - added port_enable assignment for all configurations  and rearrange 
+//              assignment siganls according to port number
+//            - added timescale directive  -SN 7-28-08
+//            - added C_ARB_NUM_TIME_SLOTS and removed the slot 12 through 
+//              15 -SN 7-28-08
+//            - changed C_MEM_DDR2_WRT_RECOVERY = (C_MEM_TWR /C_MEMCLK_PERIOD) -SN 7-28-08
+//            - removed ghighb, gpwrdnb, gsr, gwe in port declaration. 
+//              For now tb need to force the signals inside the MCB and Wrapper
+//              until a glbl.v is ready.  Not sure how to do this in NCVerilog 
+//              flow. -SN 7-28-08
+//
+//    Rev 1.2 -- removed p*_cmd_error signals -SN 8-05-08
+//    Rev 1.3 -- Added gate logic for data port rd_en and wr_en in Config 3,4,5   - SN 8-8-08
+//    Rev 1.4 -- update changes that required by MCB core.  - SN 9-11-09
+//    Rev 1.5 -- update. CMD delays has been removed in Sept 26 database. -- SN 9-28-08
+//               delay_cas_90,delay_ras_90,delay_cke_90,delay_odt_90,delay_rst_90 
+//               delay_we_90 ,delay_address,delay_ba_90 =
+//               --removed :assign #50 delay_dqnum = dqnum;
+//               --removed :assign #50 delay_dqpum = dqpum;
+//               --removed :assign #50 delay_dqnlm = dqnlm;
+//               --removed :assign #50 delay_dqplm = dqplm;
+//               --removed : delay_dqsIO_w_en_90_n
+//               --removed : delay_dqsIO_w_en_90_p              
+//               --removed : delay_dqsIO_w_en_0     
+//               -- corrected spelling error: C_MEM_RTRAS
+//    Rev 1.6 -- update IODRP2 and OSERDES connection and was updated by Chip.  1-12-09              
+//                 -- rename the memc_wrapper.v to mcb_raw_wrapper.v
+//    Rev 1.7   -- .READEN    is removed in IODRP2_MCB 1-28-09
+//              -- connection has been updated                            
+//    Rev 1.8   -- update memory parameter equations.    1-30_2009
+//              -- added portion of Soft IP               
+//              -- CAL_CLK_DIV is not used but MCB still has it
+//    Rev  1.9  -- added Error checking for Invalid command to unidirectional port   
+//    Rev  1.10 -- changed the backend connection so that Simulation will work while
+//                 sw tools try to fix the model issues.                  2-3-2009      
+//                 sysclk_2x_90 name is changed to sysclk_2x_180 . It created confusions.
+//                 It is acutally 180 degree difference.
+//    Rev  1.11 -- Added soft_calibration_top. 
+//    Rev  1.12 -- fixed ui_clk connection to MCB when soft_calib_ip is on. 5-14-2009   
+//    Rev  1.13 -- Added PULLUP/PULLDN for DQS/DQSN, UDQS/UDQSN lines.
+//    Rev  1.14 -- Added minium condition for tRTP valud/                        
+//    REv  1.15 -- Bring the SKIP_IN_TERM_CAL and SKIP_DYNAMIC_CAL from calib_ip to top.  6-16-2009
+//    Rev  1.16 -- Fixed the WTR for DDR. 6-23-2009
+//    Rev  1.17 -- Fixed width mismatch for px_cmd_ra,px_cmd_ca,px_cmd_ba 7-02-2009
+//    Rev  1.18 -- Added lumpdelay parameters for 1.0 silicon support to bypass Calibration 7-10-2010
+//    Rev  1.19 -- Added soft fix to support refresh command. 7-15-2009.
+//    Rev  1.20 -- Turned on the CALIB_SOFT_IP and C_MC_CALIBRATION_MODE is used to enable/disable
+//                 Dynamic DQS calibration in Soft Calibration module.
+//    Rev  1.21 -- Added extra generate mcbx_dram_odt pin condition. It will not be generated if
+//                 RTT value is set to "disabled"
+//              -- Corrected the UIUDQSDEC connection between soft_calib and MCB.
+//              -- PLL_LOCK pin to MCB tie high. Soft Calib module asserts MCB_RST when pll_lock is deasserted. 1-19-2010                
+//    Rev  1.22 -- Added DDR2 Initialization fix to meet 400 ns wait as outlined in step d) of JEDEC DDR2 spec .
+//    Rev  1.23 -- Added DDR2 Initialization fix when C_CALIB_SOFT_IP set to "FALSE"
+//*************************************************************************************************************************
+`define DEBUG
+`timescale 1ps / 1ps
+
+module mcb_raw_wrapper #
+ 
+ (
+
+parameter  C_MEMCLK_PERIOD          = 2500,       // /Mem clk period (in ps)
+parameter  C_PORT_ENABLE            = 6'b111111,    //  config1 : 6b'111111,  config2: 4'b1111. config3 : 3'b111, config4: 2'b11, config5 1'b1
+                                                  //  C_PORT_ENABLE[5] => User port 5,  ...,C_PORT_ENABLE[0] => User port 0
+// Should the C_MEM_ADDR_ORDER made available to user ??
+parameter  C_MEM_ADDR_ORDER             = "BANK_ROW_COLUMN" , //RowBankCol//ADDR_ORDER_MC : 0: Bank Row Col 1: Row Bank Col. User Address mapping oreder
+
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////
+//  The parameter belows are not exposed to non-embedded users.
+
+// for now this arb_time_slot_x attributes will not exposed to user and will be generated from MIG tool 
+// to translate the logical port to physical port. For advance user, translate the logical port
+// to physical port before passing them to this wrapper.
+// MIG need to save the user setting in project file.
+parameter  C_ARB_NUM_TIME_SLOTS     = 12,                      // For advance mode, allow user to either choose 10 or 12
+parameter  C_ARB_TIME_SLOT_0        = 18'o012345,               // Config 1: "B32_B32_X32_X32_X32_X32"
+parameter  C_ARB_TIME_SLOT_1        = 18'o123450,               //            User port 0 --->MCB port 0,User port 1 --->MCB port 1 
+parameter  C_ARB_TIME_SLOT_2        = 18'o234501,               //            User port 2 --->MCB port 2,User port 3 --->MCB port 3
+parameter  C_ARB_TIME_SLOT_3        = 18'o345012,               //            User port 4 --->MCB port 4,User port 5 --->MCB port 5
+parameter  C_ARB_TIME_SLOT_4        = 18'o450123,               // Config 2: "B32_B32_B32_B32"  
+parameter  C_ARB_TIME_SLOT_5        = 18'o501234,             //            User port 0     --->  MCB port 0
+parameter  C_ARB_TIME_SLOT_6        = 18'o012345,             //            User port 1     --->  MCB port 1
+parameter  C_ARB_TIME_SLOT_7        = 18'o123450,             //            User port 2     --->  MCB port 2
+parameter  C_ARB_TIME_SLOT_8        = 18'o234501,             //            User port 3     --->  MCB port 4
+parameter  C_ARB_TIME_SLOT_9        = 18'o345012,             // Config 3: "B64_B32_B3"   
+parameter  C_ARB_TIME_SLOT_10       = 18'o450123,             //            User port 0     --->  MCB port 0
+parameter  C_ARB_TIME_SLOT_11       = 18'o501234,             //            User port 1     --->  MCB port 2
+                                                               //            User port 2     --->  MCB port 4
+                                                               // Config 4: "B64_B64"              
+                                                               //            User port 0     --->  MCB port 0
+                                                               //            User port 1     --->  MCB port 2
+                                                               // Config 5  "B128"              
+                                                               //            User port 0     --->  MCB port 0
+parameter  C_PORT_CONFIG               =  "B128",     
+
+
+
+// Memory Timings
+parameter  C_MEM_TRAS              =   45000,            //CEIL (tRAS/tCK)
+parameter  C_MEM_TRCD               =   12500,            //CEIL (tRCD/tCK)
+parameter  C_MEM_TREFI              =   7800,             //CEIL (tREFI/tCK) number of clocks
+parameter  C_MEM_TRFC               =   127500,           //CEIL (tRFC/tCK)
+parameter  C_MEM_TRP                =   12500,            //CEIL (tRP/tCK)
+parameter  C_MEM_TWR                =   15000,            //CEIL (tWR/tCK)
+parameter  C_MEM_TRTP               =   7500,             //CEIL (tRTP/tCK)
+parameter  C_MEM_TWTR               =   7500,
+
+parameter  C_NUM_DQ_PINS               =  8,                   
+parameter  C_MEM_TYPE                  =  "DDR3",  
+parameter  C_MEM_DENSITY               =  "512M",
+parameter  C_MEM_BURST_LEN             =  8,       // MIG Rules for setting this parameter
+                                                   // For DDR3  this one always set to 8; 
+                                                   // For DDR2  Config 1 : MemWidth x8,x16:=> 4; MemWidth  x4     => 8
+                                                   //           Config 2 : MemWidth x8,x16:=> 4; MemWidth  x4     => 8
+                                                   //           Config 3 : Data Port Width: 32   MemWidth x8,x16:=> 4; MemWidth  x4     => 8
+                                                   //                      Data Port Width: 64   MemWidth x16   :=> 4; MemWidth  x8,x4     => 8
+                                                   //           Config 4 : Data Port Width: 64   MemWidth x16   :=> 4; MemWidth  x4,x8, => 8    
+                                                   //           Config 5 : Data Port Width: 128  MemWidth x4, x8,x16: => 8
+                                                                                           
+                                               
+                                                              
+parameter  C_MEM_CAS_LATENCY           =  4,
+parameter  C_MEM_ADDR_WIDTH            =  13,    // extracted from selected Memory part
+parameter  C_MEM_BANKADDR_WIDTH        =  3,     // extracted from selected Memory part
+parameter  C_MEM_NUM_COL_BITS          =  11,    // extracted from selected Memory part
+
+parameter  C_MEM_DDR3_CAS_LATENCY      = 7,   
+parameter  C_MEM_MOBILE_PA_SR          = "FULL",  //"FULL", "HALF" Mobile DDR Partial Array Self-Refresh 
+parameter  C_MEM_DDR1_2_ODS            = "FULL",  //"FULL"  :REDUCED" 
+parameter  C_MEM_DDR3_ODS              = "DIV6",   
+parameter  C_MEM_DDR2_RTT              = "50OHMS",    
+parameter  C_MEM_DDR3_RTT              =  "DIV2",  
+parameter  C_MEM_MDDR_ODS              =  "FULL",   
+
+parameter  C_MEM_DDR2_DIFF_DQS_EN      =  "YES", 
+parameter  C_MEM_DDR2_3_PA_SR          =  "OFF",  
+parameter  C_MEM_DDR3_CAS_WR_LATENCY   =   5,        // this parameter is hardcoded  by MIG tool which depends on the memory clock frequency
+                                                     //C_MEMCLK_PERIOD ave = 2.5ns to < 3.3 ns, CWL = 5 
+                                                     //C_MEMCLK_PERIOD ave = 1.875ns to < 2.5 ns, CWL = 6 
+                                                     //C_MEMCLK_PERIOD ave = 1.5ns to <1.875ns, CSL = 7 
+                                                     //C_MEMCLK_PERIOD avg = 1.25ns to < 1.5ns , CWL = 8
+
+parameter  C_MEM_DDR3_AUTO_SR         =  "ENABLED",
+parameter  C_MEM_DDR2_3_HIGH_TEMP_SR  =  "NORMAL",
+parameter  C_MEM_DDR3_DYN_WRT_ODT     =  "OFF",
+parameter  C_MEM_TZQINIT_MAXCNT       = 10'd512,  // DDR3 Minimum delay between resets
+
+//Calibration 
+parameter  C_MC_CALIB_BYPASS        = "NO",
+parameter  C_MC_CALIBRATION_RA      = 15'h0000,
+parameter  C_MC_CALIBRATION_BA      = 3'h0,
+
+parameter C_CALIB_SOFT_IP           = "TRUE",
+parameter C_SKIP_IN_TERM_CAL = 1'b0,     //provides option to skip the input termination calibration
+parameter C_SKIP_DYNAMIC_CAL = 1'b0,     //provides option to skip the dynamic delay calibration
+parameter C_SKIP_DYN_IN_TERM = 1'b1,     // provides option to skip the input termination calibration
+parameter C_SIMULATION       = "FALSE",  // Tells us whether the design is being simulated or implemented
+
+////////////////LUMP DELAY Params ////////////////////////////
+/// ADDED for 1.0 silicon support to bypass Calibration //////
+/// 07-10-09 chipl
+//////////////////////////////////////////////////////////////
+parameter LDQSP_TAP_DELAY_VAL  = 0,  // 0 to 255 inclusive
+parameter UDQSP_TAP_DELAY_VAL  = 0,  // 0 to 255 inclusive
+parameter LDQSN_TAP_DELAY_VAL  = 0,  // 0 to 255 inclusive
+parameter UDQSN_TAP_DELAY_VAL  = 0,  // 0 to 255 inclusive
+parameter DQ0_TAP_DELAY_VAL  = 0,  // 0 to 255 inclusive
+parameter DQ1_TAP_DELAY_VAL  = 0,  // 0 to 255 inclusive
+parameter DQ2_TAP_DELAY_VAL  = 0,  // 0 to 255 inclusive
+parameter DQ3_TAP_DELAY_VAL  = 0,  // 0 to 255 inclusive
+parameter DQ4_TAP_DELAY_VAL  = 0,  // 0 to 255 inclusive
+parameter DQ5_TAP_DELAY_VAL  = 0,  // 0 to 255 inclusive
+parameter DQ6_TAP_DELAY_VAL  = 0,  // 0 to 255 inclusive
+parameter DQ7_TAP_DELAY_VAL  = 0,  // 0 to 255 inclusive
+parameter DQ8_TAP_DELAY_VAL  = 0,  // 0 to 255 inclusive
+parameter DQ9_TAP_DELAY_VAL  = 0,  // 0 to 255 inclusive
+parameter DQ10_TAP_DELAY_VAL = 0,  // 0 to 255 inclusive
+parameter DQ11_TAP_DELAY_VAL = 0,  // 0 to 255 inclusive
+parameter DQ12_TAP_DELAY_VAL = 0,  // 0 to 255 inclusive
+parameter DQ13_TAP_DELAY_VAL = 0,  // 0 to 255 inclusive
+parameter DQ14_TAP_DELAY_VAL = 0,  // 0 to 255 inclusive
+parameter DQ15_TAP_DELAY_VAL = 0,  // 0 to 255 inclusive
+//*************
+// MIG tool need to do DRC on this parameter to make sure this is valid Column address to avoid boundary crossing for the current Burst Size setting.
+parameter  C_MC_CALIBRATION_CA      = 12'h000,
+parameter  C_MC_CALIBRATION_CLK_DIV     = 1,
+parameter  C_MC_CALIBRATION_MODE    = "CALIBRATION"     ,   // "CALIBRATION", "NOCALIBRATION"
+parameter  C_MC_CALIBRATION_DELAY   = "HALF",   // "QUARTER", "HALF","THREEQUARTER", "FULL"
+
+parameter C_P0_MASK_SIZE           = 4,
+parameter C_P0_DATA_PORT_SIZE      = 32,
+parameter C_P1_MASK_SIZE           = 4,
+parameter C_P1_DATA_PORT_SIZE         = 32
+
+    )
+  (
+  
+      // high-speed PLL clock interface
+      
+      input sysclk_2x,                         
+      input sysclk_2x_180,                      
+      input pll_ce_0,
+      input pll_ce_90,
+      input pll_lock,                          
+      input sys_rst,                         
+      // Not needed as ioi netlist are not used
+//***********************************************************************************
+//  Below User Port siganls needs to be customized when generating codes from MIG tool
+//  The corresponding internal codes that directly use the commented out port signals 
+//  needs to be removed when gernerating wrapper outputs.
+//!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+      //User Port0 Interface Signals
+      // p0_xxxx signals  shows up in Config 1 , Config 2 , Config 3, Config4 and Config 5
+      // cmd port 0 signals
+
+      input             p0_arb_en,
+      input             p0_cmd_clk,
+      input             p0_cmd_en,
+      input [2:0]       p0_cmd_instr,
+      input [5:0]       p0_cmd_bl,
+      input [29:0]      p0_cmd_byte_addr,
+      output            p0_cmd_empty,
+      output            p0_cmd_full,
+
+      // Data Wr Port signals
+      // p0_wr_xx signals  shows up in Config 1 
+      // p0_wr_xx signals  shows up in Config 2
+      // p0_wr_xx signals  shows up in Config 3
+      // p0_wr_xx signals  shows up in Config 4
+      // p0_wr_xx signals  shows up in Config 5
+      
+      input             p0_wr_clk,
+      input             p0_wr_en,
+      input [C_P0_MASK_SIZE - 1:0]      p0_wr_mask,
+      input [C_P0_DATA_PORT_SIZE - 1:0] p0_wr_data,
+      output            p0_wr_full,        //
+      output            p0_wr_empty,//
+      output [6:0]      p0_wr_count,//
+      output            p0_wr_underrun,//
+      output            p0_wr_error,//
+
+      //Data Rd Port signals
+      // p0_rd_xx signals  shows up in Config 1 
+      // p0_rd_xx signals  shows up in Config 2
+      // p0_rd_xx signals  shows up in Config 3
+      // p0_rd_xx signals  shows up in Config 4
+      // p0_rd_xx signals  shows up in Config 5
+      
+      input             p0_rd_clk,
+      input             p0_rd_en,
+      output [C_P0_DATA_PORT_SIZE - 1:0]        p0_rd_data,
+      output            p0_rd_full,//
+      output            p0_rd_empty,//
+      output [6:0]      p0_rd_count,
+      output            p0_rd_overflow,//
+      output            p0_rd_error,//
+
+      
+      //****************************
+      //User Port1 Interface Signals
+      // This group of signals only appear on Config 1,2,3,4 when generated from MIG tool
+
+      input             p1_arb_en,
+      input             p1_cmd_clk,
+      input             p1_cmd_en,
+      input [2:0]       p1_cmd_instr,
+      input [5:0]       p1_cmd_bl,
+      input [29:0]      p1_cmd_byte_addr,
+      output            p1_cmd_empty,
+      output            p1_cmd_full,
+
+      // Data Wr Port signals
+      input             p1_wr_clk,
+      input             p1_wr_en,
+      input [C_P1_MASK_SIZE - 1:0]      p1_wr_mask,
+      input [C_P1_DATA_PORT_SIZE - 1:0] p1_wr_data,
+      output            p1_wr_full,
+      output            p1_wr_empty,
+      output [6:0]      p1_wr_count,
+      output            p1_wr_underrun,
+      output            p1_wr_error,
+
+      //Data Rd Port signals
+      input             p1_rd_clk,
+      input             p1_rd_en,
+      output [C_P1_DATA_PORT_SIZE - 1:0]        p1_rd_data,
+      output            p1_rd_full,
+      output            p1_rd_empty,
+      output [6:0]      p1_rd_count,
+      output            p1_rd_overflow,
+      output            p1_rd_error,
+
+      
+      //****************************
+      //User Port2 Interface Signals
+      // This group of signals only appear on Config 1,2,3 when generated from MIG tool
+      // p2_xxxx signals  shows up in Config 1 , Config 2 and Config 3
+      // p_cmd port 2 signals
+
+      input             p2_arb_en,
+      input             p2_cmd_clk,
+      input             p2_cmd_en,
+      input [2:0]       p2_cmd_instr,
+      input [5:0]       p2_cmd_bl,
+      input [29:0]      p2_cmd_byte_addr,
+      output            p2_cmd_empty,
+      output            p2_cmd_full,
+
+      // Data Wr Port signals
+      // p2_wr_xx signals  shows up in Config 1 and Wr Dir  
+      // p2_wr_xx signals  shows up in Config 2
+      // p2_wr_xx signals  shows up in Config 3
+      
+      input             p2_wr_clk,
+      input             p2_wr_en,
+      input [3:0]       p2_wr_mask,
+      input [31:0]      p2_wr_data,
+      output            p2_wr_full,
+      output            p2_wr_empty,
+      output [6:0]      p2_wr_count,
+      output            p2_wr_underrun,
+      output            p2_wr_error,
+
+      //Data Rd Port signals
+      // p2_rd_xx signals  shows up in Config 1 and Rd Dir
+      // p2_rd_xx signals  shows up in Config 2
+      // p2_rd_xx signals  shows up in Config 3
+      
+      input             p2_rd_clk,
+      input             p2_rd_en,
+      output [31:0]     p2_rd_data,
+      output            p2_rd_full,
+      output            p2_rd_empty,
+      output [6:0]      p2_rd_count,
+      output            p2_rd_overflow,
+      output            p2_rd_error,
+
+      
+      //****************************
+      //User Port3 Interface Signals
+      // This group of signals only appear on Config 1,2 when generated from MIG tool
+
+      input             p3_arb_en,
+      input             p3_cmd_clk,
+      input             p3_cmd_en,
+      input [2:0]       p3_cmd_instr,
+      input [5:0]       p3_cmd_bl,
+      input [29:0]      p3_cmd_byte_addr,
+      output            p3_cmd_empty,
+      output            p3_cmd_full,
+
+      // Data Wr Port signals
+      // p3_wr_xx signals  shows up in Config 1 and Wr Dir
+      // p3_wr_xx signals  shows up in Config 2
+      
+      input             p3_wr_clk,
+      input             p3_wr_en,
+      input [3:0]       p3_wr_mask,
+      input [31:0]      p3_wr_data,
+      output            p3_wr_full,
+      output            p3_wr_empty,
+      output [6:0]      p3_wr_count,
+      output            p3_wr_underrun,
+      output            p3_wr_error,
+
+      //Data Rd Port signals
+      // p3_rd_xx signals  shows up in Config 1 and Rd Dir when generated from MIG ttols
+      // p3_rd_xx signals  shows up in Config 2 
+      
+      input             p3_rd_clk,
+      input             p3_rd_en,
+      output [31:0]     p3_rd_data,
+      output            p3_rd_full,
+      output            p3_rd_empty,
+      output [6:0]      p3_rd_count,
+      output            p3_rd_overflow,
+      output            p3_rd_error,
+      //****************************
+      //User Port4 Interface Signals
+      // This group of signals only appear on Config 1,2,3,4 when generated from MIG tool
+      // p4_xxxx signals only shows up in Config 1
+
+      input             p4_arb_en,
+      input             p4_cmd_clk,
+      input             p4_cmd_en,
+      input [2:0]       p4_cmd_instr,
+      input [5:0]       p4_cmd_bl,
+      input [29:0]      p4_cmd_byte_addr,
+      output            p4_cmd_empty,
+      output            p4_cmd_full,
+
+      // Data Wr Port signals
+      // p4_wr_xx signals only shows up in Config 1 and Wr Dir
+      
+      input             p4_wr_clk,
+      input             p4_wr_en,
+      input [3:0]       p4_wr_mask,
+      input [31:0]      p4_wr_data,
+      output            p4_wr_full,
+      output            p4_wr_empty,
+      output [6:0]      p4_wr_count,
+      output            p4_wr_underrun,
+      output            p4_wr_error,
+
+      //Data Rd Port signals
+      // p4_rd_xx signals only shows up in Config 1 and Rd Dir
+      
+      input             p4_rd_clk,
+      input             p4_rd_en,
+      output [31:0]     p4_rd_data,
+      output            p4_rd_full,
+      output            p4_rd_empty,
+      output [6:0]      p4_rd_count,
+      output            p4_rd_overflow,
+      output            p4_rd_error,
+
+
+      //****************************
+      //User Port5 Interface Signals
+      // p5_xxxx signals only shows up in Config 1; p5_wr_xx or p5_rd_xx depends on the user port settings
+
+      input             p5_arb_en,
+      input             p5_cmd_clk,
+      input             p5_cmd_en,
+      input [2:0]       p5_cmd_instr,
+      input [5:0]       p5_cmd_bl,
+      input [29:0]      p5_cmd_byte_addr,
+      output            p5_cmd_empty,
+      output            p5_cmd_full,
+
+      // Data Wr Port signals
+      input             p5_wr_clk,
+      input             p5_wr_en,
+      input [3:0]       p5_wr_mask,
+      input [31:0]      p5_wr_data,
+      output            p5_wr_full,
+      output            p5_wr_empty,
+      output [6:0]      p5_wr_count,
+      output            p5_wr_underrun,
+      output            p5_wr_error,
+
+      //Data Rd Port signals
+      input             p5_rd_clk,
+      input             p5_rd_en,
+      output [31:0]     p5_rd_data,
+      output            p5_rd_full,
+      output            p5_rd_empty,
+      output [6:0]      p5_rd_count,
+      output            p5_rd_overflow,
+      output            p5_rd_error,
+      
+//*****************************************************
+      // memory interface signals    
+      output [C_MEM_ADDR_WIDTH-1:0]     mcbx_dram_addr,  
+      output [C_MEM_BANKADDR_WIDTH-1:0] mcbx_dram_ba,
+      output                            mcbx_dram_ras_n,                        
+      output                            mcbx_dram_cas_n,                        
+      output                            mcbx_dram_we_n,                         
+                                      
+      output                            mcbx_dram_cke,                          
+      output                            mcbx_dram_clk,                          
+      output                            mcbx_dram_clk_n,                        
+      inout [C_NUM_DQ_PINS-1:0]         mcbx_dram_dq,              
+      inout                             mcbx_dram_dqs,                          
+      inout                             mcbx_dram_dqs_n,                        
+      inout                             mcbx_dram_udqs,                         
+      inout                             mcbx_dram_udqs_n,                       
+      
+      output                            mcbx_dram_udm,                          
+      output                            mcbx_dram_ldm,                          
+      output                            mcbx_dram_odt,                          
+      output                            mcbx_dram_ddr3_rst,                     
+      // Calibration signals
+      input calib_recal,              // Input signal to trigger calibration
+     // output calib_done,        // 0=calibration not done or is in progress.  
+                                // 1=calibration is complete.  Also a MEM_READY indicator
+                                
+   //Input - RZQ pin from board - expected to have a 2*R resistor to ground
+   //Input - Z-stated IO pin - either unbonded IO, or IO garanteed not to be driven externally
+                                
+      inout                             rzq,           // RZQ pin from board - expected to have a 2*R resistor to ground
+      inout                             zio,           // Z-stated IO pin - either unbonded IO, or IO garanteed not to be driven externally
+      // new added signals *********************************
+      // these signals are for dynamic Calibration IP
+      input                             ui_read,
+      input                             ui_add,
+      input                             ui_cs,
+      input                             ui_clk,
+      input                             ui_sdi,
+      input     [4:0]                   ui_addr,
+      input                             ui_broadcast,
+      input                             ui_drp_update,
+      input                             ui_done_cal,
+      input                             ui_cmd,
+      input                             ui_cmd_in,
+      input                             ui_cmd_en,
+      input     [3:0]                   ui_dqcount,
+      input                             ui_dq_lower_dec,
+      input                             ui_dq_lower_inc,
+      input                             ui_dq_upper_dec,
+      input                             ui_dq_upper_inc,
+      input                             ui_udqs_inc,
+      input                             ui_udqs_dec,
+      input                             ui_ldqs_inc,
+      input                             ui_ldqs_dec,
+      output     [7:0]                  uo_data,
+      output                            uo_data_valid,
+      output                            uo_done_cal,
+      output                            uo_cmd_ready_in,
+      output                            uo_refrsh_flag,
+      output                            uo_cal_start,
+      output                            uo_sdo,
+      output   [31:0]                   status,
+      input                             selfrefresh_enter,              
+      output                            selfrefresh_mode
+         );
+  function integer cdiv (input integer num,
+                         input integer div); // ceiling divide
+    begin
+      cdiv = (num/div) + (((num%div)>0) ? 1 : 0);
+    end
+  endfunction // cdiv
+
+// parameters added by AM for OSERDES2 12/09/2008, these parameters may not have to change 
+localparam C_OSERDES2_DATA_RATE_OQ = "SDR";           //SDR, DDR
+localparam C_OSERDES2_DATA_RATE_OT = "SDR";           //SDR, DDR
+localparam C_OSERDES2_SERDES_MODE_MASTER  = "MASTER";        //MASTER, SLAVE
+localparam C_OSERDES2_SERDES_MODE_SLAVE   = "SLAVE";        //MASTER, SLAVE
+localparam C_OSERDES2_OUTPUT_MODE_SE      = "SINGLE_ENDED";   //SINGLE_ENDED, DIFFERENTIAL
+localparam C_OSERDES2_OUTPUT_MODE_DIFF    = "DIFFERENTIAL";
+ 
+localparam C_BUFPLL_0_LOCK_SRC       = "LOCK_TO_0";
+
+localparam C_DQ_IODRP2_DATA_RATE             = "SDR";
+localparam C_DQ_IODRP2_SERDES_MODE_MASTER    = "MASTER";
+localparam C_DQ_IODRP2_SERDES_MODE_SLAVE     = "SLAVE";
+
+localparam C_DQS_IODRP2_DATA_RATE             = "SDR";
+localparam C_DQS_IODRP2_SERDES_MODE_MASTER    = "MASTER";
+localparam C_DQS_IODRP2_SERDES_MODE_SLAVE     = "SLAVE";
+
+
+
+     
+
+
+// MIG always set the below ADD_LATENCY to zero
+localparam  C_MEM_DDR3_ADD_LATENCY      =  "OFF";
+localparam  C_MEM_DDR2_ADD_LATENCY      =  0; 
+localparam  C_MEM_MOBILE_TC_SR          =  0; // not supported
+
+     
+//////////////////////////////////////////////////////////////////////////////////
+                                              // Attribute Declarations
+                                              // Attributes set from GUI
+                                              //
+                                         //
+   // the local param for the time slot varis according to User Port Configuration  
+   // This section also needs to be customized when gernerating wrapper outputs.
+   //*****************************************************************************
+
+
+// For Configuration 1  and this section will be used in RAW file
+localparam arbtimeslot0   = {C_ARB_TIME_SLOT_0   };
+localparam arbtimeslot1   = {C_ARB_TIME_SLOT_1   };
+localparam arbtimeslot2   = {C_ARB_TIME_SLOT_2   };
+localparam arbtimeslot3   = {C_ARB_TIME_SLOT_3   };
+localparam arbtimeslot4   = {C_ARB_TIME_SLOT_4   };
+localparam arbtimeslot5   = {C_ARB_TIME_SLOT_5   };
+localparam arbtimeslot6   = {C_ARB_TIME_SLOT_6   };
+localparam arbtimeslot7   = {C_ARB_TIME_SLOT_7   };
+localparam arbtimeslot8   = {C_ARB_TIME_SLOT_8   };
+localparam arbtimeslot9   = {C_ARB_TIME_SLOT_9   };
+localparam arbtimeslot10  = {C_ARB_TIME_SLOT_10  };
+localparam arbtimeslot11  = {C_ARB_TIME_SLOT_11  };
+
+
+// convert the memory timing to memory clock units. I
+localparam MEM_RAS_VAL  = ((C_MEM_TRAS + C_MEMCLK_PERIOD -1) /C_MEMCLK_PERIOD);
+localparam MEM_RCD_VAL  = ((C_MEM_TRCD  + C_MEMCLK_PERIOD -1) /C_MEMCLK_PERIOD);
+localparam MEM_REFI_VAL = ((C_MEM_TREFI + C_MEMCLK_PERIOD -1) /C_MEMCLK_PERIOD) - 25;
+localparam MEM_RFC_VAL  = ((C_MEM_TRFC  + C_MEMCLK_PERIOD -1) /C_MEMCLK_PERIOD);
+localparam MEM_RP_VAL   = ((C_MEM_TRP   + C_MEMCLK_PERIOD -1) /C_MEMCLK_PERIOD);
+localparam MEM_WR_VAL   = ((C_MEM_TWR   + C_MEMCLK_PERIOD -1) /C_MEMCLK_PERIOD);
+localparam MEM_RTP_CK    = cdiv(C_MEM_TRTP,C_MEMCLK_PERIOD);
+localparam MEM_RTP_VAL = (C_MEM_TYPE == "DDR3") ? (MEM_RTP_CK < 4) ? 4 : MEM_RTP_CK
+                                               : (MEM_RTP_CK < 2) ? 2 : MEM_RTP_CK;
+localparam MEM_WTR_VAL  = (C_MEM_TYPE == "DDR")   ? 2 :
+                          (C_MEM_TYPE == "DDR3")  ? 4 : 
+                          (C_MEM_TYPE == "MDDR")  ? C_MEM_TWTR : 
+                          (C_MEM_TYPE == "LPDDR")  ? C_MEM_TWTR : 
+                          ((C_MEM_TYPE == "DDR2") && (((C_MEM_TWTR  + C_MEMCLK_PERIOD -1) /C_MEMCLK_PERIOD) > 2)) ? ((C_MEM_TWTR  + C_MEMCLK_PERIOD -1) /C_MEMCLK_PERIOD) : 
+                          (C_MEM_TYPE == "DDR2")  ? 2 
+                                                  : 3 ;
+localparam  C_MEM_DDR2_WRT_RECOVERY = (C_MEM_TYPE != "DDR2") ? 5: ((C_MEM_TWR   + C_MEMCLK_PERIOD -1) /C_MEMCLK_PERIOD);
+localparam  C_MEM_DDR3_WRT_RECOVERY = (C_MEM_TYPE != "DDR3") ? 5: ((C_MEM_TWR   + C_MEMCLK_PERIOD -1) /C_MEMCLK_PERIOD);
+//localparam MEM_TYPE = (C_MEM_TYPE == "LPDDR") ? "MDDR": C_MEM_TYPE;
+
+
+
+////////////////////////////////////////////////////////////////////////////
+// wire Declarations
+////////////////////////////////////////////////////////////////////////////
+
+
+
+
+
+wire [31:0]  addr_in0;
+reg [127:0]  allzero = 0;
+
+
+// UNISIM Model <-> IOI
+//dqs clock network interface
+wire       dqs_out_p;              
+wire       dqs_out_n;              
+
+wire       dqs_sys_p;              //from dqs_gen to IOclk network
+wire       dqs_sys_n;              //from dqs_gen to IOclk network
+wire       udqs_sys_p;
+wire       udqs_sys_n;
+
+wire       dqs_p;                  // open net now ?
+wire       dqs_n;                  // open net now ?
+
+
+
+// IOI and IOB enable/tristate interface
+wire dqIO_w_en_0;                //enable DQ pads
+wire dqsIO_w_en_90_p;            //enable p side of DQS
+wire dqsIO_w_en_90_n;            //enable n side of DQS
+
+
+//memory chip control interface
+wire [14:0]   address_90;
+wire [2:0]    ba_90;     
+wire          ras_90;
+wire          cas_90;
+wire          we_90 ;
+wire          cke_90;
+wire          odt_90;
+wire          rst_90;
+
+// calibration IDELAY control  signals
+wire          ioi_drp_clk;          //DRP interface - synchronous clock output
+wire  [4:0]   ioi_drp_addr;         //DRP interface - IOI selection
+wire          ioi_drp_sdo;          //DRP interface - serial output for commmands
+wire          ioi_drp_sdi;          //DRP interface - serial input for commands
+wire          ioi_drp_cs;           //DRP interface - chip select doubles as DONE signal
+wire          ioi_drp_add;          //DRP interface - serial address signal
+wire          ioi_drp_broadcast;  
+wire          ioi_drp_train;    
+
+
+   // Calibration datacapture siganls
+   
+wire  [3:0]dqdonecount; //select signal for the datacapture 16 to 1 mux
+wire  dq_in_p;          //positive signal sent to calibration logic
+wire  dq_in_n;          //negative signal sent to calibration logic
+wire  cal_done;   
+   
+
+//DQS calibration interface
+wire       udqs_n;
+wire       udqs_p;
+
+
+wire            udqs_dqocal_p;
+wire            udqs_dqocal_n;
+
+
+// MUI enable interface
+wire df_en_n90  ;
+
+//INTERNAL SIGNAL FOR DRP chain
+// IOI <-> MUI
+wire ioi_int_tmp;
+
+wire [15:0]dqo_n;  
+wire [15:0]dqo_p;  
+wire dqnlm;      
+wire dqplm;      
+wire dqnum;      
+wire dqpum;      
+
+
+// IOI <-> IOB   routes
+wire  [C_MEM_ADDR_WIDTH-1:0]ioi_addr; 
+wire  [C_MEM_BANKADDR_WIDTH-1:0]ioi_ba;    
+wire  ioi_cas;   
+wire  ioi_ck;    
+wire  ioi_ckn;    
+wire  ioi_cke;   
+wire  [C_NUM_DQ_PINS-1:0]ioi_dq; 
+wire  ioi_dqs;   
+wire  ioi_dqsn;
+wire  ioi_udqs;
+wire  ioi_udqsn;   
+wire  ioi_odt;   
+wire  ioi_ras;   
+wire  ioi_rst;   
+wire  ioi_we;   
+wire  ioi_udm;
+wire  ioi_ldm;
+
+wire  [15:0] in_dq;
+wire  [C_NUM_DQ_PINS-1:0] in_pre_dq;
+
+
+
+wire            in_dqs;     
+wire            in_pre_dqsp;
+wire            in_pre_dqsn;
+wire            in_pre_udqsp;
+wire            in_pre_udqsn;
+wire            in_udqs;
+     // Memory tri-state control signals
+wire  [C_MEM_ADDR_WIDTH-1:0]t_addr; 
+wire  [C_MEM_BANKADDR_WIDTH-1:0]t_ba;    
+wire  t_cas;
+wire  t_ck ;
+wire  t_ckn;
+wire  t_cke;
+wire  [C_NUM_DQ_PINS-1:0]t_dq;
+wire  t_dqs;     
+wire  t_dqsn;
+wire  t_udqs;
+wire  t_udqsn;
+wire  t_odt;     
+wire  t_ras;     
+wire  t_rst;     
+wire  t_we ;     
+
+
+wire  t_udm  ;
+wire  t_ldm  ;
+
+
+
+wire             idelay_dqs_ioi_s;
+wire             idelay_dqs_ioi_m;
+wire             idelay_udqs_ioi_s;
+wire             idelay_udqs_ioi_m;
+
+
+wire  dqs_pin;
+wire  udqs_pin;
+
+// USER Interface signals
+
+
+// translated memory addresses
+wire [14:0]p0_cmd_ra;
+wire [2:0]p0_cmd_ba; 
+wire [11:0]p0_cmd_ca;
+wire [14:0]p1_cmd_ra;
+wire [2:0]p1_cmd_ba; 
+wire [11:0]p1_cmd_ca;
+wire [14:0]p2_cmd_ra;
+wire [2:0]p2_cmd_ba; 
+wire [11:0]p2_cmd_ca;
+wire [14:0]p3_cmd_ra;
+wire [2:0]p3_cmd_ba; 
+wire [11:0]p3_cmd_ca;
+wire [14:0]p4_cmd_ra;
+wire [2:0]p4_cmd_ba; 
+wire [11:0]p4_cmd_ca;
+wire [14:0]p5_cmd_ra;
+wire [2:0]p5_cmd_ba; 
+wire [11:0]p5_cmd_ca;
+
+   // user command wires mapped from logical ports to physical ports
+wire        mig_p0_arb_en;   
+wire        mig_p0_cmd_clk;    
+wire        mig_p0_cmd_en;     
+wire [14:0] mig_p0_cmd_ra;     
+wire [2:0]  mig_p0_cmd_ba;     
+wire [11:0] mig_p0_cmd_ca;     
+
+wire [2:0]  mig_p0_cmd_instr;   
+wire [5:0]  mig_p0_cmd_bl;      
+wire        mig_p0_cmd_empty;   
+wire        mig_p0_cmd_full;    
+
+
+wire        mig_p1_arb_en;   
+wire        mig_p1_cmd_clk;    
+wire        mig_p1_cmd_en;     
+wire [14:0] mig_p1_cmd_ra;     
+wire [2:0] mig_p1_cmd_ba;     
+wire [11:0] mig_p1_cmd_ca;     
+
+wire [2:0]  mig_p1_cmd_instr;   
+wire [5:0]  mig_p1_cmd_bl;      
+wire        mig_p1_cmd_empty;   
+wire        mig_p1_cmd_full;    
+
+wire        mig_p2_arb_en;   
+wire        mig_p2_cmd_clk;    
+wire        mig_p2_cmd_en;     
+wire [14:0] mig_p2_cmd_ra;     
+wire [2:0] mig_p2_cmd_ba;     
+wire [11:0] mig_p2_cmd_ca;     
+                  
+wire [2:0]  mig_p2_cmd_instr;   
+wire [5:0]  mig_p2_cmd_bl;      
+wire        mig_p2_cmd_empty;   
+wire        mig_p2_cmd_full;    
+
+wire        mig_p3_arb_en;   
+wire        mig_p3_cmd_clk;    
+wire        mig_p3_cmd_en;     
+wire [14:0] mig_p3_cmd_ra;     
+wire [2:0] mig_p3_cmd_ba;     
+wire [11:0] mig_p3_cmd_ca;     
+
+wire [2:0]  mig_p3_cmd_instr;   
+wire [5:0]  mig_p3_cmd_bl;      
+wire        mig_p3_cmd_empty;   
+wire        mig_p3_cmd_full;    
+
+wire        mig_p4_arb_en;   
+wire        mig_p4_cmd_clk;    
+wire        mig_p4_cmd_en;     
+wire [14:0] mig_p4_cmd_ra;     
+wire [2:0] mig_p4_cmd_ba;     
+wire [11:0] mig_p4_cmd_ca;     
+
+wire [2:0]  mig_p4_cmd_instr;   
+wire [5:0]  mig_p4_cmd_bl;      
+wire        mig_p4_cmd_empty;   
+wire        mig_p4_cmd_full;    
+
+wire        mig_p5_arb_en;   
+wire        mig_p5_cmd_clk;    
+wire        mig_p5_cmd_en;     
+wire [14:0] mig_p5_cmd_ra;     
+wire [2:0] mig_p5_cmd_ba;     
+wire [11:0] mig_p5_cmd_ca;     
+
+wire [2:0]  mig_p5_cmd_instr;   
+wire [5:0]  mig_p5_cmd_bl;      
+wire        mig_p5_cmd_empty;   
+wire        mig_p5_cmd_full;    
+
+wire        mig_p0_wr_clk;
+wire        mig_p0_rd_clk;
+wire        mig_p1_wr_clk;
+wire        mig_p1_rd_clk;
+wire        mig_p2_clk;
+wire        mig_p3_clk;
+wire        mig_p4_clk;
+wire        mig_p5_clk;
+
+wire       mig_p0_wr_en;
+wire       mig_p0_rd_en;
+wire       mig_p1_wr_en;
+wire       mig_p1_rd_en;
+wire       mig_p2_en;
+wire       mig_p3_en; 
+wire       mig_p4_en; 
+wire       mig_p5_en; 
+
+
+wire [31:0]mig_p0_wr_data;
+wire [31:0]mig_p1_wr_data;
+wire [31:0]mig_p2_wr_data;
+wire [31:0]mig_p3_wr_data;
+wire [31:0]mig_p4_wr_data;
+wire [31:0]mig_p5_wr_data;
+
+
+wire  [C_P0_MASK_SIZE-1:0]mig_p0_wr_mask;
+wire  [C_P1_MASK_SIZE-1:0]mig_p1_wr_mask;
+wire  [3:0]mig_p2_wr_mask;
+wire  [3:0]mig_p3_wr_mask;
+wire  [3:0]mig_p4_wr_mask;
+wire  [3:0]mig_p5_wr_mask;
+
+
+wire  [31:0]mig_p0_rd_data; 
+wire  [31:0]mig_p1_rd_data; 
+wire  [31:0]mig_p2_rd_data; 
+wire  [31:0]mig_p3_rd_data; 
+wire  [31:0]mig_p4_rd_data; 
+wire  [31:0]mig_p5_rd_data; 
+
+wire  mig_p0_rd_overflow;
+wire  mig_p1_rd_overflow;
+wire  mig_p2_overflow;
+wire  mig_p3_overflow;
+
+wire  mig_p4_overflow;
+wire  mig_p5_overflow;
+
+wire  mig_p0_wr_underrun;
+wire  mig_p1_wr_underrun;
+wire  mig_p2_underrun;  
+wire  mig_p3_underrun;  
+wire  mig_p4_underrun;  
+wire  mig_p5_underrun;  
+
+wire       mig_p0_rd_error;
+wire       mig_p0_wr_error;
+wire       mig_p1_rd_error;
+wire       mig_p1_wr_error;
+wire       mig_p2_error;    
+wire       mig_p3_error;    
+wire       mig_p4_error;    
+wire       mig_p5_error;    
+
+
+wire  [6:0]mig_p0_wr_count;
+wire  [6:0]mig_p1_wr_count;
+wire  [6:0]mig_p0_rd_count;
+wire  [6:0]mig_p1_rd_count;
+
+wire  [6:0]mig_p2_count;
+wire  [6:0]mig_p3_count;
+wire  [6:0]mig_p4_count;
+wire  [6:0]mig_p5_count;
+
+wire  mig_p0_wr_full;
+wire  mig_p1_wr_full;
+
+wire mig_p0_rd_empty;
+wire mig_p1_rd_empty;
+wire mig_p0_wr_empty;
+wire mig_p1_wr_empty;
+wire mig_p0_rd_full;
+wire mig_p1_rd_full;
+wire mig_p2_full;
+wire mig_p3_full;
+wire mig_p4_full;
+wire mig_p5_full;
+wire mig_p2_empty;
+wire mig_p3_empty;
+wire mig_p4_empty;
+wire mig_p5_empty;
+
+// SELFREESH control signal for suspend feature
+wire selfrefresh_mcb_enter;
+wire selfrefresh_mcb_mode ;
+// Testing Interface signals
+wire           tst_cmd_test_en;
+wire   [7:0]   tst_sel;
+wire   [15:0]  tst_in;
+wire           tst_scan_clk;
+wire           tst_scan_rst;
+wire           tst_scan_set;
+wire           tst_scan_en;
+wire           tst_scan_in;
+wire           tst_scan_mode;
+
+wire           p0w_tst_en;
+wire           p0r_tst_en;
+wire           p1w_tst_en;
+wire           p1r_tst_en;
+wire           p2_tst_en;
+wire           p3_tst_en;
+wire           p4_tst_en;
+wire           p5_tst_en;
+
+wire           p0_tst_wr_clk_en;
+wire           p0_tst_rd_clk_en;
+wire           p1_tst_wr_clk_en;
+wire           p1_tst_rd_clk_en;
+wire           p2_tst_clk_en;
+wire           p3_tst_clk_en;
+wire           p4_tst_clk_en;
+wire           p5_tst_clk_en;
+
+wire   [3:0]   p0w_tst_wr_mode;
+wire   [3:0]   p0r_tst_mode;
+wire   [3:0]   p1w_tst_wr_mode;
+wire   [3:0]   p1r_tst_mode;
+wire   [3:0]   p2_tst_mode;
+wire   [3:0]   p3_tst_mode;
+wire   [3:0]   p4_tst_mode;
+wire   [3:0]   p5_tst_mode;
+
+wire           p0r_tst_pin_en;
+wire           p0w_tst_pin_en;
+wire           p1r_tst_pin_en;
+wire           p1w_tst_pin_en;
+wire           p2_tst_pin_en;
+wire           p3_tst_pin_en;
+wire           p4_tst_pin_en;
+wire           p5_tst_pin_en;
+wire           p0w_tst_overflow;
+wire           p1w_tst_overflow;
+
+wire  [3:0]   p0r_tst_mask_o;
+wire  [3:0]   p0w_tst_mask_o;
+wire  [3:0]   p1r_tst_mask_o;
+wire  [3:0]   p1w_tst_mask_o;
+wire  [3:0]   p2_tst_mask_o;
+wire  [3:0]   p3_tst_mask_o;
+wire  [3:0]   p4_tst_mask_o;
+wire  [3:0]   p5_tst_mask_o;
+wire  [3:0]   p0r_tst_wr_mask;
+
+wire  [3:0]   p1r_tst_wr_mask;
+wire [31:0]  p1r_tst_wr_data;
+wire [31:0]  p0r_tst_wr_data;
+wire [31:0]   p0w_tst_rd_data;
+wire [31:0]   p1w_tst_rd_data;
+
+wire  [38:0]  tst_cmd_out;
+wire           MCB_SYSRST;
+wire ioclk0;
+wire ioclk90;
+wire mcb_ui_clk;                               
+wire hard_done_cal;                                
+wire cke_train;
+//testing
+wire       ioi_drp_update;
+wire [7:0] aux_sdi_sdo;
+
+wire [4:0] mcb_ui_addr;
+wire [3:0] mcb_ui_dqcount;
+reg  syn_uiclk_pll_lock;
+
+wire int_sys_rst /* synthesis syn_maxfan = 1 */;
+// synthesis attribute max_fanout of int_sys_rst is 1
+
+
+reg [15:0]    wait_200us_counter;
+reg           cke_train_reg;        
+reg           wait_200us_done_r1,wait_200us_done_r2;
+
+assign ioclk0 = sysclk_2x;
+assign ioclk90 = sysclk_2x_180;
+
+//Added 2/22 - Add flop to pll_lock status signal to improve timing
+always @ (posedge ui_clk)
+begin 
+  
+   syn_uiclk_pll_lock <= pll_lock;
+   
+end   
+assign int_sys_rst =  sys_rst | ~syn_uiclk_pll_lock;
+
+//Address Remapping
+// Byte Address remapping
+// 
+// Bank Address[x:0] & Row Address[x:0]  & Column Address[x:0]
+// column address remap for port 0
+ generate //  port bus remapping sections for CONFIG 2   15,3,12
+
+if(C_NUM_DQ_PINS == 16) begin : x16_Addr
+           if (C_MEM_ADDR_ORDER == "ROW_BANK_COLUMN") begin  // C_MEM_ADDR_ORDER = 0 : Bank Row  Column
+                 // port 0 address remapping
+                
+                
+                if (C_MEM_ADDR_WIDTH == 15)   //Row        
+                       assign p0_cmd_ra = p0_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS + 1];                         
+                else
+                       assign p0_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] ,  p0_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS   :C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS + 1]};                         
+
+
+                if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                       assign p0_cmd_ba = p0_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS   :  C_MEM_NUM_COL_BITS + 1];
+                else
+                       assign p0_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH] , p0_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +   C_MEM_NUM_COL_BITS   :  C_MEM_NUM_COL_BITS + 1]};
+                
+                if (C_MEM_NUM_COL_BITS == 12)  //Column
+                       assign p0_cmd_ca = p0_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1];
+                else
+                       assign p0_cmd_ca = {allzero[12:C_MEM_NUM_COL_BITS + 1], p0_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1]};
+
+                
+                 // port 1 address remapping
+                
+                
+                if (C_MEM_ADDR_WIDTH == 15)   //Row        
+                       assign p1_cmd_ra = p1_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS + 1];                         
+                else
+                       assign p1_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] ,  p1_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS   :C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS + 1]};                         
+
+
+                if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                       assign p1_cmd_ba = p1_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS   :  C_MEM_NUM_COL_BITS + 1];
+                else
+                       assign p1_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH] , p1_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +   C_MEM_NUM_COL_BITS   :  C_MEM_NUM_COL_BITS + 1]};
+                
+                if (C_MEM_NUM_COL_BITS == 12)  //Column
+                       assign p1_cmd_ca = p1_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1];
+                else
+                       assign p1_cmd_ca = {allzero[12:C_MEM_NUM_COL_BITS  + 1], p1_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1]};
+
+                 // port 2 address remapping
+                
+                
+                if (C_MEM_ADDR_WIDTH == 15)   //Row        
+                       assign p2_cmd_ra = p2_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS + 1];                         
+                else
+                       assign p2_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] ,  p2_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS   :C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS + 1]};                         
+
+
+                if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                       assign p2_cmd_ba = p2_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS   :  C_MEM_NUM_COL_BITS + 1];
+                else
+                       assign p2_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH] , p2_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +   C_MEM_NUM_COL_BITS   :  C_MEM_NUM_COL_BITS + 1]};
+                
+                if (C_MEM_NUM_COL_BITS == 12)  //Column
+                       assign p2_cmd_ca = p2_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1];
+                else
+                       assign p2_cmd_ca = {allzero[12:C_MEM_NUM_COL_BITS + 1], p2_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1]};
+
+                 // port 3 address remapping
+                
+                
+                if (C_MEM_ADDR_WIDTH == 15)   //Row        
+                       assign p3_cmd_ra = p3_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS + 1];                         
+                else
+                       assign p3_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] ,  p3_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS   :C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS + 1]};                         
+
+
+                if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                       assign p3_cmd_ba = p3_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS   :  C_MEM_NUM_COL_BITS + 1];
+                else
+                       assign p3_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH] , p3_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +   C_MEM_NUM_COL_BITS   :  C_MEM_NUM_COL_BITS + 1]};
+                
+                if (C_MEM_NUM_COL_BITS == 12)  //Column
+                       assign p3_cmd_ca = p3_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1];
+                else
+                       assign p3_cmd_ca = {allzero[12:C_MEM_NUM_COL_BITS + 1], p3_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1]};
+
+                 // port 4 address remapping
+                
+                
+                if (C_MEM_ADDR_WIDTH == 15)   //Row        
+                       assign p4_cmd_ra = p4_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS + 1];                         
+                else
+                       assign p4_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] ,  p4_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS   :C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS + 1]};                         
+
+
+                if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                       assign p4_cmd_ba = p4_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS   :  C_MEM_NUM_COL_BITS + 1];
+                else
+                       assign p4_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH] , p4_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +   C_MEM_NUM_COL_BITS   :  C_MEM_NUM_COL_BITS + 1]};
+                
+                if (C_MEM_NUM_COL_BITS == 12)  //Column
+                       assign p4_cmd_ca = p4_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1];
+                else
+                       assign p4_cmd_ca = {allzero[12:C_MEM_NUM_COL_BITS + 1], p4_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1]};
+
+                 // port 5 address remapping
+                
+                
+                if (C_MEM_ADDR_WIDTH == 15)   //Row        
+                       assign p5_cmd_ra = p5_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS + 1];                         
+                else
+                       assign p5_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] ,  p5_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS   :C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS + 1]};                         
+
+
+                if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                       assign p5_cmd_ba = p5_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS   :  C_MEM_NUM_COL_BITS + 1];
+                else
+                       assign p5_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH] , p5_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +   C_MEM_NUM_COL_BITS   :  C_MEM_NUM_COL_BITS + 1]};
+                
+                if (C_MEM_NUM_COL_BITS == 12)  //Column
+                       assign p5_cmd_ca = p5_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1];
+                else
+                       assign p5_cmd_ca = {allzero[12:C_MEM_NUM_COL_BITS + 1], p5_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1]};
+
+
+                
+                
+                end
+                
+          else  // ***************C_MEM_ADDR_ORDER = 1 :  Row Bank Column
+              begin
+                 // port 0 address remapping
+
+                if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                       assign p0_cmd_ba = p0_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS  : C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS + 1];
+                else
+                       assign p0_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH] , p0_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS  : C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS + 1]};
+                
+                
+                if (C_MEM_ADDR_WIDTH == 15)           
+                       assign p0_cmd_ra = p0_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_NUM_COL_BITS + 1];                         
+                else
+                       assign p0_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] ,  p0_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_NUM_COL_BITS + 1]};                         
+                
+                if (C_MEM_NUM_COL_BITS == 12)  //Column
+                       assign p0_cmd_ca = p0_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1];
+                else
+                       assign p0_cmd_ca = {allzero[12:C_MEM_NUM_COL_BITS + 1], p0_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1]};
+
+
+                 // port 1 address remapping
+
+                if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                       assign p1_cmd_ba = p1_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS  : C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS + 1];
+                else
+                       assign p1_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH] , p1_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS  : C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS + 1]};
+                
+                
+                if (C_MEM_ADDR_WIDTH == 15)           
+                       assign p1_cmd_ra = p1_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_NUM_COL_BITS + 1];                         
+                else
+                       assign p1_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] ,  p1_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_NUM_COL_BITS + 1]};                         
+                
+                if (C_MEM_NUM_COL_BITS == 12)  //Column
+                       assign p1_cmd_ca = p1_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1];
+                else
+                       assign p1_cmd_ca = {allzero[12:C_MEM_NUM_COL_BITS + 1], p1_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1]};
+
+                 // port 2 address remapping
+
+                if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                       assign p2_cmd_ba = p2_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS  : C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS + 1];
+                else
+                       assign p2_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH] , p2_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS  : C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS + 1]};
+                
+                
+                if (C_MEM_ADDR_WIDTH == 15)           
+                       assign p2_cmd_ra = p2_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_NUM_COL_BITS + 1];                         
+                else
+                       assign p2_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] ,  p2_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_NUM_COL_BITS + 1]};                         
+                
+                if (C_MEM_NUM_COL_BITS == 12)  //Column
+                       assign p2_cmd_ca = p2_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1];
+                else
+                       assign p2_cmd_ca = {allzero[12:C_MEM_NUM_COL_BITS + 1], p2_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1]};
+
+                 // port 3 address remapping
+
+                if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                       assign p3_cmd_ba = p3_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS  : C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS + 1];
+                else
+                       assign p3_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH] , p3_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS  : C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS + 1]};
+                
+                
+                if (C_MEM_ADDR_WIDTH == 15)           
+                       assign p3_cmd_ra = p3_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_NUM_COL_BITS + 1];                         
+                else
+                       assign p3_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] ,  p3_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_NUM_COL_BITS + 1]};                         
+                
+                if (C_MEM_NUM_COL_BITS == 12)  //Column
+                       assign p3_cmd_ca = p3_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1];
+                else
+                       assign p3_cmd_ca = {allzero[12:C_MEM_NUM_COL_BITS + 1], p3_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1]};
+
+                 // port 4 address remapping
+
+                if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                       assign p4_cmd_ba = p4_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS  : C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS + 1];
+                else
+                       assign p4_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH] , p4_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS  : C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS + 1]};
+                
+                
+                if (C_MEM_ADDR_WIDTH == 15)           
+                       assign p4_cmd_ra = p4_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_NUM_COL_BITS + 1];                         
+                else
+                       assign p4_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] ,  p4_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_NUM_COL_BITS + 1]};                         
+                
+                if (C_MEM_NUM_COL_BITS == 12)  //Column
+                       assign p4_cmd_ca = p4_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1];
+                else
+                       assign p4_cmd_ca = {allzero[12:C_MEM_NUM_COL_BITS + 1], p4_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1]};
+
+                 // port 5 address remapping
+
+                if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                       assign p5_cmd_ba = p5_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS  : C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS + 1];
+                else
+                       assign p5_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH] , p5_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS  : C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS + 1]};
+                
+                
+                if (C_MEM_ADDR_WIDTH == 15)           
+                       assign p5_cmd_ra = p5_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_NUM_COL_BITS + 1];                         
+                else
+                       assign p5_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] ,  p5_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_NUM_COL_BITS   : C_MEM_NUM_COL_BITS + 1]};                         
+                
+                if (C_MEM_NUM_COL_BITS == 12)  //Column
+                       assign p5_cmd_ca = p5_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1];
+                else
+                       assign p5_cmd_ca = {allzero[12:C_MEM_NUM_COL_BITS + 1], p5_cmd_byte_addr[C_MEM_NUM_COL_BITS : 1]};
+
+         
+              end
+       
+end else if(C_NUM_DQ_PINS == 8) begin : x8_Addr
+           if (C_MEM_ADDR_ORDER == "ROW_BANK_COLUMN") begin  // C_MEM_ADDR_ORDER = 1 : Bank Row Column
+                 // port 0 address remapping
+
+                 if (C_MEM_ADDR_WIDTH == 15)  //Row
+                          assign p0_cmd_ra = p0_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1  : C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS ];
+                 else
+                          assign p0_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] , p0_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1  : C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS ]};
+
+
+                 if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                          assign p0_cmd_ba = p0_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 :  C_MEM_NUM_COL_BITS ];  //14,3,10
+                 else
+                          assign p0_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH],  
+                                   p0_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_NUM_COL_BITS ]};  //14,3,10
+                 
+                 
+                 if (C_MEM_NUM_COL_BITS == 12)  //Column
+                          assign p0_cmd_ca[11:0] = p0_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0];
+                 else
+                          assign p0_cmd_ca[11:0] = {allzero[11 : C_MEM_NUM_COL_BITS] , p0_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0]};
+                 
+                 
+                // port 1 address remapping
+                 if (C_MEM_ADDR_WIDTH == 15)  //Row
+                          assign p1_cmd_ra = p1_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1  : C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS ];
+                 else
+                          assign p1_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] , p1_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1  : C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS ]};
+
+
+                 if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                          assign p1_cmd_ba = p1_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 :  C_MEM_NUM_COL_BITS ];  //14,3,10
+                 else
+                          assign p1_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH],  
+                                   p1_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_NUM_COL_BITS ]};  //14,3,10
+                 
+                 
+                 if (C_MEM_NUM_COL_BITS == 12)  //Column
+                          assign p1_cmd_ca[11:0] = p1_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0];
+                 else
+                          assign p1_cmd_ca[11:0] = {allzero[11 : C_MEM_NUM_COL_BITS] , p1_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0]};
+                 
+                
+                // port 2 address remapping
+                 if (C_MEM_ADDR_WIDTH == 15)  //Row
+                          assign p2_cmd_ra = p2_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1  : C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS ];
+                 else
+                          assign p2_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] , p2_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1  : C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS ]};
+
+
+                 if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                          assign p2_cmd_ba = p2_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 :  C_MEM_NUM_COL_BITS ];  //14,3,10
+                 else
+                          assign p2_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH],  
+                                   p2_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_NUM_COL_BITS ]};  //14,2,10  ***
+                 
+                 
+                 if (C_MEM_NUM_COL_BITS == 12)  //Column
+                          assign p2_cmd_ca[11:0] = p2_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0];
+                 else
+                          assign p2_cmd_ca[11:0] = {allzero[11 : C_MEM_NUM_COL_BITS] , p2_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0]};
+                 
+
+
+              //   port 3 address remapping
+                 if (C_MEM_ADDR_WIDTH == 15)  //Row
+                          assign p3_cmd_ra = p3_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1  : C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS ];
+                 else
+                          assign p3_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] , p3_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1  : C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS ]};
+
+
+                 if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                          assign p3_cmd_ba = p3_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 :  C_MEM_NUM_COL_BITS ];  //14,3,10
+                 else
+                          assign p3_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH],  
+                                   p3_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_NUM_COL_BITS ]};  //14,3,10
+                 
+                 
+                 if (C_MEM_NUM_COL_BITS == 12)  //Column
+                          assign p3_cmd_ca[11:0] = p3_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0];
+                 else
+                          assign p3_cmd_ca[11:0] = {allzero[11 : C_MEM_NUM_COL_BITS] , p3_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0]};
+                 
+                
+              //   port 4 address remapping
+                 if (C_MEM_ADDR_WIDTH == 15)  //Row
+                          assign p4_cmd_ra = p4_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1  : C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS ];
+                 else
+                          assign p4_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] , p4_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1  : C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS ]};
+
+
+                 if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                          assign p4_cmd_ba = p4_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 :  C_MEM_NUM_COL_BITS ];  //14,3,10
+                 else
+                          assign p4_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH],  
+                                   p4_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_NUM_COL_BITS ]};  //14,3,10
+                 
+                 
+                 if (C_MEM_NUM_COL_BITS == 12)  //Column
+                          assign p4_cmd_ca[11:0] = p4_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0];
+                 else
+                          assign p4_cmd_ca[11:0] = {allzero[11 : C_MEM_NUM_COL_BITS] , p4_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0]};
+                 
+
+              //   port 5 address remapping
+              
+                 if (C_MEM_ADDR_WIDTH == 15)  //Row
+                          assign p5_cmd_ra = p5_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1  : C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS ];
+                 else
+                          assign p5_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] , p5_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1  : C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS ]};
+
+
+                 if (C_MEM_BANKADDR_WIDTH  == 3 )  //Bank
+                          assign p5_cmd_ba = p5_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 :  C_MEM_NUM_COL_BITS ];  //14,3,10
+                 else
+                          assign p5_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH],  
+                                   p5_cmd_byte_addr[C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_NUM_COL_BITS ]};  //14,3,10
+                 
+                 
+                 if (C_MEM_NUM_COL_BITS == 12)  //Column
+                          assign p5_cmd_ca[11:0] = p5_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0];
+                 else
+                          assign p5_cmd_ca[11:0] = {allzero[11 : C_MEM_NUM_COL_BITS] , p5_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0]};
+                 
+                end
+               
+            else  //  x8 ***************C_MEM_ADDR_ORDER = 0 : Bank Row Column
+              begin
+                 // port 0 address remapping
+                 if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                          assign p0_cmd_ba = p0_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS ];  
+                 else
+                          assign p0_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH],  
+                                   p0_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS ]};  
+
+
+                 if (C_MEM_ADDR_WIDTH == 15) //Row
+                          assign p0_cmd_ra = p0_cmd_byte_addr[C_MEM_ADDR_WIDTH  + C_MEM_NUM_COL_BITS - 1  :  C_MEM_NUM_COL_BITS ];
+                 else
+                          assign p0_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] , p0_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS - 1  : C_MEM_NUM_COL_BITS ]};                
+                                   
+                 
+                 if (C_MEM_NUM_COL_BITS == 12) //Column
+                          assign p0_cmd_ca[11:0] = p0_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0];
+                 else
+                          assign p0_cmd_ca[11:0] = {allzero[11 : C_MEM_NUM_COL_BITS] , p0_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0]};
+
+
+                // port 1 address remapping
+                 if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                          assign p1_cmd_ba = p1_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS ];  
+                 else
+                          assign p1_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH],  
+                                   p1_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS ]};  
+                                   
+                 if (C_MEM_ADDR_WIDTH == 15) //Row
+                          assign p1_cmd_ra = p1_cmd_byte_addr[C_MEM_ADDR_WIDTH  + C_MEM_NUM_COL_BITS - 1  :  C_MEM_NUM_COL_BITS ];
+                 else
+                          assign p1_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] , p1_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS - 1  : C_MEM_NUM_COL_BITS ]};
+                 
+                 if (C_MEM_NUM_COL_BITS == 12) //Column
+                          assign p1_cmd_ca[11:0] = p1_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0];
+                 else
+                          assign p1_cmd_ca[11:0] = {allzero[11 : C_MEM_NUM_COL_BITS] , p1_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0]};
+                
+               //port 2 address remapping
+                if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank    2,13,10    24,23
+                       assign p2_cmd_ba = p2_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS ];  
+                else
+                       assign p2_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH],  
+                                        p2_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS  ]};  
+      
+                 if (C_MEM_ADDR_WIDTH == 15) //Row
+                          assign p2_cmd_ra = p2_cmd_byte_addr[C_MEM_ADDR_WIDTH  + C_MEM_NUM_COL_BITS - 1  :  C_MEM_NUM_COL_BITS ];
+                 else
+                          assign p2_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] , p2_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS - 1  : C_MEM_NUM_COL_BITS ]};
+                 
+                 if (C_MEM_NUM_COL_BITS == 12) //Column
+                          assign p2_cmd_ca[11:0] = p2_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0];
+                 else
+                          assign p2_cmd_ca[11:0] = {allzero[11 : C_MEM_NUM_COL_BITS] , p2_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0]};
+
+              // port 3 address remapping
+                 if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                          assign p3_cmd_ba = p3_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS ];  
+                 else
+                          assign p3_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH],  
+                                   p3_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS ]};  
+                                   
+                 if (C_MEM_ADDR_WIDTH == 15) //Row
+                          assign p3_cmd_ra = p3_cmd_byte_addr[C_MEM_ADDR_WIDTH  + C_MEM_NUM_COL_BITS - 1  :  C_MEM_NUM_COL_BITS ];
+                 else
+                          assign p3_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] , p3_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS - 1  : C_MEM_NUM_COL_BITS ]};
+                 
+                 if (C_MEM_NUM_COL_BITS == 12) //Column
+                          assign p3_cmd_ca[11:0] = p3_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0];
+                 else
+                          assign p3_cmd_ca[11:0] = {allzero[11 : C_MEM_NUM_COL_BITS] , p3_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0]};
+   
+   
+                 //   port 4 address remapping
+                 if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                          assign p4_cmd_ba = p4_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS ];  
+                 else
+                          assign p4_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH],  
+                                   p4_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS ]};  
+                                   
+                 if (C_MEM_ADDR_WIDTH == 15) //Row
+                          assign p4_cmd_ra = p4_cmd_byte_addr[C_MEM_ADDR_WIDTH  + C_MEM_NUM_COL_BITS - 1  :  C_MEM_NUM_COL_BITS ];
+                 else
+                          assign p4_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] , p4_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS - 1  : C_MEM_NUM_COL_BITS ]};
+                 
+                 if (C_MEM_NUM_COL_BITS == 12) //Column
+                          assign p4_cmd_ca[11:0] = p4_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0];
+                 else
+                          assign p4_cmd_ca[11:0] = {allzero[11 : C_MEM_NUM_COL_BITS] , p4_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0]};
+
+                 //   port 5 address remapping
+   
+                 if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                          assign p5_cmd_ba = p5_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS ];  
+                 else
+                          assign p5_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH],  
+                                   p5_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1 : C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS ]};  
+                                   
+                 if (C_MEM_ADDR_WIDTH == 15) //Row
+                          assign p5_cmd_ra = p5_cmd_byte_addr[C_MEM_ADDR_WIDTH  + C_MEM_NUM_COL_BITS - 1  :  C_MEM_NUM_COL_BITS ];
+                 else
+                          assign p5_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH] , p5_cmd_byte_addr[C_MEM_ADDR_WIDTH  +  C_MEM_NUM_COL_BITS - 1  : C_MEM_NUM_COL_BITS ]};
+                 
+                 if (C_MEM_NUM_COL_BITS == 12) //Column
+                          assign p5_cmd_ca[11:0] = p5_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0];
+                 else
+                          assign p5_cmd_ca[11:0] = {allzero[11 : C_MEM_NUM_COL_BITS] , p5_cmd_byte_addr[C_MEM_NUM_COL_BITS - 1 : 0]};
+             
+            end
+
+              //
+
+end else if(C_NUM_DQ_PINS == 4) begin : x4_Addr
+
+           if (C_MEM_ADDR_ORDER == "ROW_BANK_COLUMN") begin  // C_MEM_ADDR_ORDER = 1 :  Row Bank Column
+
+               //   port 0 address remapping
+               
+               
+               if (C_MEM_ADDR_WIDTH == 15) //Row
+                     assign p0_cmd_ra = p0_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 1];
+               else         
+                     assign p0_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH ] , p0_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 1]};
+                        
+
+               if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                      assign p0_cmd_ba =  p0_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 :  C_MEM_NUM_COL_BITS - 1];
+               else
+                      assign p0_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH ] , p0_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 :  C_MEM_NUM_COL_BITS - 1]};
+
+                        
+               if (C_MEM_NUM_COL_BITS == 12) //Column
+                     assign p0_cmd_ca = {p0_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};                                //14,3,11
+               else
+                     assign p0_cmd_ca = {allzero[11 : C_MEM_NUM_COL_BITS ] ,  p0_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+
+           
+              //   port 1 address remapping
+               if (C_MEM_ADDR_WIDTH == 15) //Row
+                     assign p1_cmd_ra = p1_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 1];
+               else         
+                     assign p1_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH ] , p1_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 1]};
+                        
+
+               if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                      assign p1_cmd_ba =  p1_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 :  C_MEM_NUM_COL_BITS - 1];
+               else
+                      assign p1_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH ] , p1_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 :  C_MEM_NUM_COL_BITS - 1]};
+
+                        
+               if (C_MEM_NUM_COL_BITS == 12) //Column
+                     assign p1_cmd_ca = {p1_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};                                //14,3,11
+               else
+                     assign p1_cmd_ca = {allzero[11 : C_MEM_NUM_COL_BITS ] ,  p1_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+
+               //   port 2 address remapping
+               if (C_MEM_ADDR_WIDTH == 15) //Row
+                     assign p2_cmd_ra = p2_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 1];
+               else         
+                     assign p2_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH ] , p2_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 1]};
+                        
+
+               if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                      assign p2_cmd_ba =  p2_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 :  C_MEM_NUM_COL_BITS - 1];
+               else
+                      assign p2_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH ] , p2_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 :  C_MEM_NUM_COL_BITS - 1]};
+
+                        
+               if (C_MEM_NUM_COL_BITS == 12) //Column
+                     assign p2_cmd_ca = {p2_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};                                //14,3,11
+               else
+                     assign p2_cmd_ca = {allzero[11 : C_MEM_NUM_COL_BITS ] ,  p2_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+
+              //   port 3 address remapping
+
+               if (C_MEM_ADDR_WIDTH == 15) //Row
+                     assign p3_cmd_ra = p3_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 1];
+               else         
+                     assign p3_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH ] , p3_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 1]};
+                        
+
+               if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                      assign p3_cmd_ba =  p3_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 :  C_MEM_NUM_COL_BITS - 1];
+               else
+                      assign p3_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH ] , p3_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 :  C_MEM_NUM_COL_BITS - 1]};
+
+                        
+               if (C_MEM_NUM_COL_BITS == 12) //Column
+                     assign p3_cmd_ca = {p3_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};                                //14,3,11
+               else
+                     assign p3_cmd_ca = {allzero[11 : C_MEM_NUM_COL_BITS ] ,  p3_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+
+ 
+
+          if(C_PORT_CONFIG == "B32_B32_R32_R32_R32_R32" ||
+             C_PORT_CONFIG == "B32_B32_R32_R32_R32_W32" ||
+             C_PORT_CONFIG == "B32_B32_R32_R32_W32_R32" ||
+             C_PORT_CONFIG == "B32_B32_R32_R32_W32_W32" ||
+             C_PORT_CONFIG == "B32_B32_R32_W32_R32_R32" ||
+             C_PORT_CONFIG == "B32_B32_R32_W32_R32_W32" ||
+             C_PORT_CONFIG == "B32_B32_R32_W32_W32_R32" ||
+             C_PORT_CONFIG == "B32_B32_R32_W32_W32_W32" ||
+             C_PORT_CONFIG == "B32_B32_W32_R32_R32_R32" ||
+             C_PORT_CONFIG == "B32_B32_W32_R32_R32_W32" ||
+             C_PORT_CONFIG == "B32_B32_W32_R32_W32_R32" ||
+             C_PORT_CONFIG == "B32_B32_W32_R32_W32_W32" ||
+             C_PORT_CONFIG == "B32_B32_W32_W32_R32_R32" ||
+             C_PORT_CONFIG == "B32_B32_W32_W32_R32_W32" ||
+             C_PORT_CONFIG == "B32_B32_W32_W32_W32_R32" ||
+             C_PORT_CONFIG == "B32_B32_W32_W32_W32_W32"
+             ) //begin : x4_Addr_CFG1_OR_CFG2
+               begin
+               if (C_MEM_ADDR_WIDTH == 15) //Row
+                     assign p4_cmd_ra = p4_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 1];
+               else         
+                     assign p4_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH ] , p4_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 1]};
+                        
+
+               if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                      assign p4_cmd_ba =  p4_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 :  C_MEM_NUM_COL_BITS - 1];
+               else
+                      assign p4_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH ] , p4_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 :  C_MEM_NUM_COL_BITS - 1]};
+
+                        
+               if (C_MEM_NUM_COL_BITS == 12) //Column
+                     assign p4_cmd_ca = {p4_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};                                //14,3,11
+               else
+                     assign p4_cmd_ca = {allzero[11 : C_MEM_NUM_COL_BITS ] ,  p4_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+
+
+
+               if (C_MEM_ADDR_WIDTH == 15) //Row
+                     assign p5_cmd_ra = p5_cmd_byte_addr[C_MEM_ADDR_WIDTH + C_MEM_BANKADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 1];
+               else         
+                     assign p5_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH ] , p5_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 : C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 1]};
+                        
+
+               if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                      assign p5_cmd_ba =  p5_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 :  C_MEM_NUM_COL_BITS - 1];
+               else
+                      assign p5_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH ] , p5_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_NUM_COL_BITS - 2 :  C_MEM_NUM_COL_BITS - 1]};
+
+                        
+               if (C_MEM_NUM_COL_BITS == 12) //Column
+                     assign p5_cmd_ca = {p5_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};                                //14,3,11
+               else
+                     assign p5_cmd_ca = {allzero[11 : C_MEM_NUM_COL_BITS ] ,  p5_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+
+              end
+              
+              
+           end
+         else   // C_MEM_ADDR_ORDER = 1 :  Row Bank Column
+            begin
+            
+               //   port 0 address remapping
+               if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                      assign p0_cmd_ba =  p0_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1];
+               else
+                      assign p0_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH ] , p0_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1]};
+               
+               
+               if (C_MEM_ADDR_WIDTH == 15) //Row
+                     assign p0_cmd_ra = p0_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_NUM_COL_BITS - 1];
+               else         
+                     assign p0_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH ] , p0_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_NUM_COL_BITS - 1]};
+                        
+                        
+               if (C_MEM_NUM_COL_BITS == 12) //Column
+                     assign p0_cmd_ca = {p0_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+               else
+                     assign p0_cmd_ca = {allzero[11 : C_MEM_NUM_COL_BITS ] ,  p0_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+               
+           
+              //   port 1 address remapping
+               if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                      assign p1_cmd_ba =  p1_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1];
+               else
+                      assign p1_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH ] , p1_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1]};
+               
+               
+               if (C_MEM_ADDR_WIDTH == 15) //Row
+                     assign p1_cmd_ra = p1_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_NUM_COL_BITS - 1];
+               else         
+                     assign p1_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH ] , p1_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_NUM_COL_BITS - 1]};
+                        
+                        
+               if (C_MEM_NUM_COL_BITS == 12) //Column
+                     assign p1_cmd_ca = {p1_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+               else
+                     assign p1_cmd_ca = {allzero[11 : C_MEM_NUM_COL_BITS ] ,  p1_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+               //   port 2 address remapping
+               if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                      assign p2_cmd_ba =  p2_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1];
+               else
+                      assign p2_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH ] , p2_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1]};
+               
+             //***  
+               if (C_MEM_ADDR_WIDTH == 15) //Row
+                     assign p2_cmd_ra = p2_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_NUM_COL_BITS - 1];
+               else         
+                     assign p2_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH ] , p2_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_NUM_COL_BITS - 1]};
+                        
+                        
+               if (C_MEM_NUM_COL_BITS == 12) //Column
+                     assign p2_cmd_ca = {p2_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+               else
+                     assign p2_cmd_ca = {allzero[11 : C_MEM_NUM_COL_BITS ] ,  p2_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+              //   port 3 address remapping
+
+               if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                      assign p3_cmd_ba =  p3_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1];
+               else
+                      assign p3_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH ] , p3_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1]};
+               
+               
+               if (C_MEM_ADDR_WIDTH == 15) //Row
+                     assign p3_cmd_ra = p3_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_NUM_COL_BITS - 1];
+               else         
+                     assign p3_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH ] , p3_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_NUM_COL_BITS - 1]};
+                        
+                        
+               if (C_MEM_NUM_COL_BITS == 12) //Column
+                     assign p3_cmd_ca = {p3_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+               else
+                     assign p3_cmd_ca = {allzero[11 : C_MEM_NUM_COL_BITS ] ,  p3_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+ 
+
+          if(C_PORT_CONFIG == "B32_B32_R32_R32_R32_R32" ||
+             C_PORT_CONFIG == "B32_B32_R32_R32_R32_W32" ||
+             C_PORT_CONFIG == "B32_B32_R32_R32_W32_R32" ||
+             C_PORT_CONFIG == "B32_B32_R32_R32_W32_W32" ||
+             C_PORT_CONFIG == "B32_B32_R32_W32_R32_R32" ||
+             C_PORT_CONFIG == "B32_B32_R32_W32_R32_W32" ||
+             C_PORT_CONFIG == "B32_B32_R32_W32_W32_R32" ||
+             C_PORT_CONFIG == "B32_B32_R32_W32_W32_W32" ||
+             C_PORT_CONFIG == "B32_B32_W32_R32_R32_R32" ||
+             C_PORT_CONFIG == "B32_B32_W32_R32_R32_W32" ||
+             C_PORT_CONFIG == "B32_B32_W32_R32_W32_R32" ||
+             C_PORT_CONFIG == "B32_B32_W32_R32_W32_W32" ||
+             C_PORT_CONFIG == "B32_B32_W32_W32_R32_R32" ||
+             C_PORT_CONFIG == "B32_B32_W32_W32_R32_W32" ||
+             C_PORT_CONFIG == "B32_B32_W32_W32_W32_R32" ||
+             C_PORT_CONFIG == "B32_B32_W32_W32_W32_W32"
+             ) //begin : x4_Addr_CFG1_OR_CFG2
+               begin
+               if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                      assign p4_cmd_ba =  p4_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1];
+               else
+                      assign p4_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH ] , p4_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1]};
+               
+               
+               if (C_MEM_ADDR_WIDTH == 15) //Row
+                     assign p4_cmd_ra = p4_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_NUM_COL_BITS - 1];
+               else         
+                     assign p4_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH ] , p4_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_NUM_COL_BITS - 1]};
+                        
+                        
+               if (C_MEM_NUM_COL_BITS == 12) //Column
+                     assign p4_cmd_ca = {p4_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+               else
+                     assign p4_cmd_ca = {allzero[11 : C_MEM_NUM_COL_BITS ] ,  p4_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+
+
+               if (C_MEM_BANKADDR_WIDTH  == 3 ) //Bank
+                      assign p5_cmd_ba =  p5_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1];
+               else
+                      assign p5_cmd_ba = {allzero[2 : C_MEM_BANKADDR_WIDTH ] , p5_cmd_byte_addr[C_MEM_BANKADDR_WIDTH + C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 1]};
+               
+               
+               if (C_MEM_ADDR_WIDTH == 15) //Row
+                     assign p5_cmd_ra = p5_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_NUM_COL_BITS - 1];
+               else         
+                     assign p5_cmd_ra = {allzero[14 : C_MEM_ADDR_WIDTH ] , p5_cmd_byte_addr[C_MEM_ADDR_WIDTH +  C_MEM_NUM_COL_BITS - 2 : C_MEM_NUM_COL_BITS - 1]};
+                        
+                        
+               if (C_MEM_NUM_COL_BITS == 12) //Column
+                     assign p5_cmd_ca = {p5_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+               else
+                     assign p5_cmd_ca = {allzero[11 : C_MEM_NUM_COL_BITS ] ,  p5_cmd_byte_addr[C_MEM_NUM_COL_BITS - 2 : 0] , 1'b0};
+              end
+            
+            
+            
+            end
+           
+end // block: x4_Addr
+
+
+endgenerate
+
+
+
+generate 
+   //   if(C_PORT_CONFIG[183:160] == "B32") begin : u_config1_0
+   if(C_PORT_CONFIG == "B32_B32_R32_R32_R32_R32" ||
+      C_PORT_CONFIG == "B32_B32_R32_R32_R32_W32" ||
+      C_PORT_CONFIG == "B32_B32_R32_R32_W32_R32" ||
+      C_PORT_CONFIG == "B32_B32_R32_R32_W32_W32" ||
+      C_PORT_CONFIG == "B32_B32_R32_W32_R32_R32" ||
+      C_PORT_CONFIG == "B32_B32_R32_W32_R32_W32" ||
+      C_PORT_CONFIG == "B32_B32_R32_W32_W32_R32" ||
+      C_PORT_CONFIG == "B32_B32_R32_W32_W32_W32" ||
+      C_PORT_CONFIG == "B32_B32_W32_R32_R32_R32" ||
+      C_PORT_CONFIG == "B32_B32_W32_R32_R32_W32" ||
+      C_PORT_CONFIG == "B32_B32_W32_R32_W32_R32" ||
+      C_PORT_CONFIG == "B32_B32_W32_R32_W32_W32" ||
+      C_PORT_CONFIG == "B32_B32_W32_W32_R32_R32" ||
+      C_PORT_CONFIG == "B32_B32_W32_W32_R32_W32" ||
+      C_PORT_CONFIG == "B32_B32_W32_W32_W32_R32" ||
+      C_PORT_CONFIG == "B32_B32_W32_W32_W32_W32"
+      ) begin : u_config1_0      
+
+  //synthesis translate_off 
+  always @(*)
+  begin
+    if ( C_PORT_CONFIG[119:96]  == "W32" && p2_cmd_en == 1'b1 
+         && p2_cmd_instr[2] == 1'b0 && p2_cmd_instr[0] == 1'b1 )
+          begin
+           $display("ERROR - Invalid Command for write only port 2");
+           $finish;
+          end
+  end
+              
+  always @(*)
+  begin
+    if ( C_PORT_CONFIG[119:96]  == "R32" && p2_cmd_en == 1'b1 
+         && p2_cmd_instr[2] == 1'b0 && p2_cmd_instr[0] == 1'b0 )
+          begin
+           $display("ERROR - Invalid Command for read only port 2");
+           $finish;
+          end
+  end
+// Catch Invalid command during simulation for Port 3              
+  always @(*)
+  begin
+    if ( C_PORT_CONFIG[87:64]  == "W32" && p3_cmd_en == 1'b1 
+         && p3_cmd_instr[2] == 1'b0 && p3_cmd_instr[0] == 1'b1 )
+          begin
+           $display("ERROR - Invalid Command for write only port 3");
+           $finish;
+          end
+  end
+              
+  always @(*)
+  begin
+    if ( C_PORT_CONFIG[87:64]  == "R32" && p3_cmd_en == 1'b1 
+         && p3_cmd_instr[2] == 1'b0  && p3_cmd_instr[0] == 1'b0 )
+          begin
+           $display("ERROR - Invalid Command for read only port 3");
+           $finish;
+          end
+  end
+  
+// Catch Invalid command during simulation for Port 4              
+  always @(*)
+  begin
+    if ( C_PORT_CONFIG[55:32]  == "W32" && p4_cmd_en == 1'b1 
+         && p4_cmd_instr[2] == 1'b0 && p4_cmd_instr[0] == 1'b1 )
+          begin
+           $display("ERROR - Invalid Command for write only port 4");
+           $finish;
+          end
+  end
+              
+  always @(*)
+  begin
+    if ( C_PORT_CONFIG[55:32]  == "R32" && p4_cmd_en == 1'b1 
+         && p4_cmd_instr[2] == 1'b0 && p4_cmd_instr[0] == 1'b0 )
+          begin
+           $display("ERROR - Invalid Command for read only port 4");
+           $finish;
+          end
+  end
+// Catch Invalid command during simulation for Port 5              
+  always @(*)
+  begin
+    if ( C_PORT_CONFIG[23:0]  == "W32" && p5_cmd_en == 1'b1 
+         && p5_cmd_instr[2] == 1'b0 && p5_cmd_instr[0] == 1'b1 )
+          begin
+           $display("ERROR - Invalid Command for write only port 5");
+           $finish;
+          end
+  end
+              
+  always @(*)
+  begin
+    if ( C_PORT_CONFIG[23:0]  == "R32" && p5_cmd_en == 1'b1 
+         && p5_cmd_instr[2] == 1'b0  && p5_cmd_instr[0] == 1'b0 )
+          begin
+           $display("ERROR - Invalid Command for read only port 5");
+           $finish;
+          end
+  end  
+   //synthesis translate_on 
+
+
+  // the local declaration of input port signals doesn't work.  The mig_p1_xxx through mig_p5_xxx always ends up
+  // high Z even though there are signals on p1_cmd_xxx through p5_cmd_xxxx.
+  // The only solutions that I have is to have MIG tool remove the entire internal codes that doesn't belongs to the Configuration..
+  //
+
+               // Inputs from Application CMD Port
+
+               if (C_PORT_ENABLE[0] == 1'b1)
+               begin
+
+                   assign mig_p0_arb_en      =      p0_arb_en ;
+                   assign mig_p0_cmd_clk     =      p0_cmd_clk  ;
+                   assign mig_p0_cmd_en      =      p0_cmd_en   ;
+                   assign mig_p0_cmd_ra      =      p0_cmd_ra  ;
+                   assign mig_p0_cmd_ba      =      p0_cmd_ba   ;
+                   assign mig_p0_cmd_ca      =      p0_cmd_ca  ;
+                   assign mig_p0_cmd_instr   =      p0_cmd_instr;
+                   assign mig_p0_cmd_bl      =      {(p0_cmd_instr[2] | p0_cmd_bl[5]),p0_cmd_bl[4:0]}  ;
+                   assign p0_cmd_empty       =      mig_p0_cmd_empty;
+                   assign p0_cmd_full        =      mig_p0_cmd_full ;
+                   
+               end else
+               begin
+               
+                   assign mig_p0_arb_en      =     'b0;
+                   assign mig_p0_cmd_clk     =     'b0;
+                   assign mig_p0_cmd_en      =     'b0;
+                   assign mig_p0_cmd_ra      =     'b0;
+                   assign mig_p0_cmd_ba      =     'b0;
+                   assign mig_p0_cmd_ca      =     'b0;
+                   assign mig_p0_cmd_instr   =     'b0;
+                   assign mig_p0_cmd_bl      =     'b0;
+                   assign p0_cmd_empty       =     'b0;
+                   assign p0_cmd_full        =     'b0;
+                   
+               end
+               
+
+               if (C_PORT_ENABLE[1] == 1'b1)
+               begin
+
+
+                   assign mig_p1_arb_en      =      p1_arb_en ;
+                   assign mig_p1_cmd_clk     =      p1_cmd_clk  ;
+                   assign mig_p1_cmd_en      =      p1_cmd_en   ;
+                   assign mig_p1_cmd_ra      =      p1_cmd_ra  ;
+                   assign mig_p1_cmd_ba      =      p1_cmd_ba   ;
+                   assign mig_p1_cmd_ca      =      p1_cmd_ca  ;
+                   assign mig_p1_cmd_instr   =      p1_cmd_instr;
+                   assign mig_p1_cmd_bl      =      {(p1_cmd_instr[2] | p1_cmd_bl[5]),p1_cmd_bl[4:0]}  ;
+                   assign p1_cmd_empty       =      mig_p1_cmd_empty;
+                   assign p1_cmd_full        =      mig_p1_cmd_full ;
+                   
+               end else
+               begin
+                   assign mig_p1_arb_en      =     'b0;
+                   assign mig_p1_cmd_clk     =     'b0;
+                   assign mig_p1_cmd_en      =     'b0;
+                   assign mig_p1_cmd_ra      =     'b0;
+                   assign mig_p1_cmd_ba      =     'b0;
+                   assign mig_p1_cmd_ca      =     'b0;
+                   assign mig_p1_cmd_instr   =     'b0;
+                   assign mig_p1_cmd_bl      =     'b0;
+                   assign p1_cmd_empty       =      'b0;
+                   assign p1_cmd_full        =      'b0;
+                   
+                   
+               end
+               
+
+               if (C_PORT_ENABLE[2] == 1'b1)
+               begin
+
+                   assign mig_p2_arb_en      =      p2_arb_en ;
+                   assign mig_p2_cmd_clk     =      p2_cmd_clk  ;
+                   assign mig_p2_cmd_en      =      p2_cmd_en   ;
+                   assign mig_p2_cmd_ra      =      p2_cmd_ra  ;
+                   assign mig_p2_cmd_ba      =      p2_cmd_ba   ;
+                   assign mig_p2_cmd_ca      =      p2_cmd_ca  ;
+                   assign mig_p2_cmd_instr   =      p2_cmd_instr;
+                   assign mig_p2_cmd_bl      =      {(p2_cmd_instr[2] | p2_cmd_bl[5]),p2_cmd_bl[4:0]}  ;
+                   assign p2_cmd_empty   =      mig_p2_cmd_empty;
+                   assign p2_cmd_full    =      mig_p2_cmd_full ;
+                   
+               end else
+               begin
+
+                   assign mig_p2_arb_en      =      'b0;
+                   assign mig_p2_cmd_clk     =      'b0;
+                   assign mig_p2_cmd_en      =      'b0;
+                   assign mig_p2_cmd_ra      =      'b0;
+                   assign mig_p2_cmd_ba      =      'b0;
+                   assign mig_p2_cmd_ca      =      'b0;
+                   assign mig_p2_cmd_instr   =      'b0;
+                   assign mig_p2_cmd_bl      =      'b0;
+                   assign p2_cmd_empty   =       'b0;
+                   assign p2_cmd_full    =       'b0;
+                   
+               end
+               
+ 
+
+               if (C_PORT_ENABLE[3] == 1'b1)
+               begin
+
+                   assign mig_p3_arb_en    =        p3_arb_en ;
+                   assign mig_p3_cmd_clk     =      p3_cmd_clk  ;
+                   assign mig_p3_cmd_en      =      p3_cmd_en   ;
+                   assign mig_p3_cmd_ra      =      p3_cmd_ra  ;
+                   assign mig_p3_cmd_ba      =      p3_cmd_ba   ;
+                   assign mig_p3_cmd_ca      =      p3_cmd_ca  ;
+                   assign mig_p3_cmd_instr   =      p3_cmd_instr;
+                   assign mig_p3_cmd_bl      =      {(p3_cmd_instr[2] | p3_cmd_bl[5]),p3_cmd_bl[4:0]}  ;
+                   assign p3_cmd_empty   =      mig_p3_cmd_empty;
+                   assign p3_cmd_full    =      mig_p3_cmd_full ;
+                   
+               end else
+               begin
+                   assign mig_p3_arb_en    =       'b0;
+                   assign mig_p3_cmd_clk     =     'b0;
+                   assign mig_p3_cmd_en      =     'b0;
+                   assign mig_p3_cmd_ra      =     'b0;
+                   assign mig_p3_cmd_ba      =     'b0;
+                   assign mig_p3_cmd_ca      =     'b0;
+                   assign mig_p3_cmd_instr   =     'b0;
+                   assign mig_p3_cmd_bl      =     'b0;
+                   assign p3_cmd_empty   =     'b0;
+                   assign p3_cmd_full    =     'b0;
+                   
+               end
+               
+               if (C_PORT_ENABLE[4] == 1'b1)
+               begin
+
+                   assign mig_p4_arb_en    =        p4_arb_en ;
+                   assign mig_p4_cmd_clk     =      p4_cmd_clk  ;
+                   assign mig_p4_cmd_en      =      p4_cmd_en   ;
+                   assign mig_p4_cmd_ra      =      p4_cmd_ra  ;
+                   assign mig_p4_cmd_ba      =      p4_cmd_ba   ;
+                   assign mig_p4_cmd_ca      =      p4_cmd_ca  ;
+                   assign mig_p4_cmd_instr   =      p4_cmd_instr;
+                   assign mig_p4_cmd_bl      =      {(p4_cmd_instr[2] | p4_cmd_bl[5]),p4_cmd_bl[4:0]}  ;
+                   assign p4_cmd_empty   =      mig_p4_cmd_empty;
+                   assign p4_cmd_full    =      mig_p4_cmd_full ;
+                   
+               end else
+               begin
+                   assign mig_p4_arb_en      =      'b0;
+                   assign mig_p4_cmd_clk     =      'b0;
+                   assign mig_p4_cmd_en      =      'b0;
+                   assign mig_p4_cmd_ra      =      'b0;
+                   assign mig_p4_cmd_ba      =      'b0;
+                   assign mig_p4_cmd_ca      =      'b0;
+                   assign mig_p4_cmd_instr   =      'b0;
+                   assign mig_p4_cmd_bl      =      'b0;
+                   assign p4_cmd_empty   =      'b0;
+                   assign p4_cmd_full    =      'b0;
+                   
+
+
+               end
+
+               if (C_PORT_ENABLE[5] == 1'b1)
+               begin
+
+                   assign  mig_p5_arb_en    =     p5_arb_en ;
+                   assign  mig_p5_cmd_clk   =     p5_cmd_clk  ;
+                   assign  mig_p5_cmd_en    =     p5_cmd_en   ;
+                   assign  mig_p5_cmd_ra    =     p5_cmd_ra  ;
+                   assign  mig_p5_cmd_ba    =     p5_cmd_ba   ;
+                   assign  mig_p5_cmd_ca    =     p5_cmd_ca  ;
+                   assign mig_p5_cmd_instr  =     p5_cmd_instr;
+                   assign mig_p5_cmd_bl     =     {(p5_cmd_instr[2] | p5_cmd_bl[5]),p5_cmd_bl[4:0]}  ;
+                   assign p5_cmd_empty   =     mig_p5_cmd_empty;
+                   assign p5_cmd_full    =     mig_p5_cmd_full ;
+                   
+               end else
+               begin
+                   assign  mig_p5_arb_en     =   'b0;
+                   assign  mig_p5_cmd_clk    =   'b0;
+                   assign  mig_p5_cmd_en     =   'b0;
+                   assign  mig_p5_cmd_ra     =   'b0;
+                   assign  mig_p5_cmd_ba     =   'b0;
+                   assign  mig_p5_cmd_ca     =   'b0;
+                   assign mig_p5_cmd_instr   =   'b0;
+                   assign mig_p5_cmd_bl      =   'b0;
+                   assign p5_cmd_empty   =     'b0;
+                   assign p5_cmd_full    =     'b0;
+                   
+               
+               end
+
+
+
+
+              // Inputs from Application User Port
+              
+              // Port 0
+               if (C_PORT_ENABLE[0] == 1'b1)
+               begin
+                assign mig_p0_wr_clk   = p0_wr_clk;
+                assign mig_p0_rd_clk   = p0_rd_clk;
+                assign mig_p0_wr_en    = p0_wr_en;
+                assign mig_p0_rd_en    = p0_rd_en;
+                assign mig_p0_wr_mask  = p0_wr_mask[3:0];
+                assign mig_p0_wr_data  = p0_wr_data[31:0];
+                assign p0_rd_data        = mig_p0_rd_data;
+                assign p0_rd_full        = mig_p0_rd_full;
+                assign p0_rd_empty       = mig_p0_rd_empty;
+                assign p0_rd_error       = mig_p0_rd_error;
+                assign p0_wr_error       = mig_p0_wr_error;
+                assign p0_rd_overflow    = mig_p0_rd_overflow;
+                assign p0_wr_underrun    = mig_p0_wr_underrun;
+                assign p0_wr_empty       = mig_p0_wr_empty;
+                assign p0_wr_full        = mig_p0_wr_full;
+                assign p0_wr_count       = mig_p0_wr_count;
+                assign p0_rd_count       = mig_p0_rd_count  ; 
+                
+                
+               end
+               else
+               begin
+                assign mig_p0_wr_clk     = 'b0;
+                assign mig_p0_rd_clk     = 'b0;
+                assign mig_p0_wr_en      = 'b0;
+                assign mig_p0_rd_en      = 'b0;
+                assign mig_p0_wr_mask    = 'b0;
+                assign mig_p0_wr_data    = 'b0;
+                assign p0_rd_data        = 'b0;
+                assign p0_rd_full        = 'b0;
+                assign p0_rd_empty       = 'b0;
+                assign p0_rd_error       = 'b0;
+                assign p0_wr_error       = 'b0;
+                assign p0_rd_overflow    = 'b0;
+                assign p0_wr_underrun    = 'b0;
+                assign p0_wr_empty       = 'b0;
+                assign p0_wr_full        = 'b0;
+                assign p0_wr_count       = 'b0;
+                assign p0_rd_count       = 'b0;
+                
+                
+               end
+              
+              
+              // Port 1
+               if (C_PORT_ENABLE[1] == 1'b1)
+               begin
+              
+                assign mig_p1_wr_clk   = p1_wr_clk;
+                assign mig_p1_rd_clk   = p1_rd_clk;                
+                assign mig_p1_wr_en    = p1_wr_en;
+                assign mig_p1_wr_mask  = p1_wr_mask[3:0];                
+                assign mig_p1_wr_data  = p1_wr_data[31:0];
+                assign mig_p1_rd_en    = p1_rd_en;
+                assign p1_rd_data     = mig_p1_rd_data;
+                assign p1_rd_empty    = mig_p1_rd_empty;
+                assign p1_rd_full     = mig_p1_rd_full;
+                assign p1_rd_error    = mig_p1_rd_error;
+                assign p1_wr_error    = mig_p1_wr_error;
+                assign p1_rd_overflow = mig_p1_rd_overflow;
+                assign p1_wr_underrun    = mig_p1_wr_underrun;
+                assign p1_wr_empty    = mig_p1_wr_empty;
+                assign p1_wr_full    = mig_p1_wr_full;
+                assign p1_wr_count  = mig_p1_wr_count;
+                assign p1_rd_count  = mig_p1_rd_count  ; 
+                
+               end else
+               begin
+              
+                assign mig_p1_wr_clk   = 'b0;
+                assign mig_p1_rd_clk   = 'b0;            
+                assign mig_p1_wr_en    = 'b0;
+                assign mig_p1_wr_mask  = 'b0;          
+                assign mig_p1_wr_data  = 'b0;
+                assign mig_p1_rd_en    = 'b0;
+                assign p1_rd_data     =  'b0;
+                assign p1_rd_empty    =  'b0;
+                assign p1_rd_full     =  'b0;
+                assign p1_rd_error    =  'b0;
+                assign p1_wr_error    =  'b0;
+                assign p1_rd_overflow =  'b0;
+                assign p1_wr_underrun =  'b0;
+                assign p1_wr_empty    =  'b0;
+                assign p1_wr_full     =  'b0;
+                assign p1_wr_count    =  'b0;
+                assign p1_rd_count    =  'b0;
+                
+                
+               end
+                
+                
+                
+
+
+// whenever PORT 2 is in Write mode           
+         if(C_PORT_CONFIG[183:160] == "B32" && C_PORT_CONFIG[119:96] == "W32") begin : u_config1_2W
+                  if (C_PORT_ENABLE[2] == 1'b1)
+                  begin
+                       assign mig_p2_clk      = p2_wr_clk;
+                       assign mig_p2_wr_data  = p2_wr_data[31:0];
+                       assign mig_p2_wr_mask  = p2_wr_mask[3:0];
+                       assign mig_p2_en       = p2_wr_en; // this signal will not shown up if the port 5 is for read dir
+                       assign p2_wr_error     = mig_p2_error;                       
+                       assign p2_wr_full      = mig_p2_full;
+                       assign p2_wr_empty     = mig_p2_empty;
+                       assign p2_wr_underrun  = mig_p2_underrun;
+                       assign p2_wr_count     = mig_p2_count  ; // wr port
+                       
+                       
+                  end else
+                  begin
+                       assign mig_p2_clk      = 'b0;
+                       assign mig_p2_wr_data  = 'b0;
+                       assign mig_p2_wr_mask  = 'b0;
+                       assign mig_p2_en       = 'b0;
+                       assign p2_wr_error     = 'b0;
+                       assign p2_wr_full      = 'b0;
+                       assign p2_wr_empty     = 'b0;
+                       assign p2_wr_underrun  = 'b0;
+                       assign p2_wr_count     = 'b0;
+                                                
+                  end                           
+                   assign p2_rd_data        = 'b0;
+                   assign p2_rd_overflow    = 'b0;
+                   assign p2_rd_error       = 'b0;
+                   assign p2_rd_full        = 'b0;
+                   assign p2_rd_empty       = 'b0;
+                   assign p2_rd_count       = 'b0;
+//                   assign p2_rd_error       = 'b0;
+                       
+                       
+                         
+         end else if(C_PORT_CONFIG[183:160] == "B32" && C_PORT_CONFIG[119:96] == "R32") begin : u_config1_2R
+
+                  if (C_PORT_ENABLE[2] == 1'b1)
+                  begin
+                       assign mig_p2_clk        = p2_rd_clk;
+                       assign p2_rd_data        = mig_p2_rd_data;
+                       assign mig_p2_en         = p2_rd_en;  
+                       assign p2_rd_overflow    = mig_p2_overflow;
+                       assign p2_rd_error       = mig_p2_error;
+                       assign p2_rd_full        = mig_p2_full;
+                       assign p2_rd_empty       = mig_p2_empty;
+                       assign p2_rd_count       = mig_p2_count  ; // wr port
+                       
+                  end else       
+                  begin
+                       assign mig_p2_clk        = 'b0;
+                       assign p2_rd_data        = 'b0;
+                       assign mig_p2_en         = 'b0;
+                       
+                       assign p2_rd_overflow    = 'b0;
+                       assign p2_rd_error       = 'b0;
+                       assign p2_rd_full        = 'b0;
+                       assign p2_rd_empty       = 'b0;
+                       assign p2_rd_count       = 'b0;
+                       
+                  end
+                  assign mig_p2_wr_data  = 'b0;
+                  assign mig_p2_wr_mask  = 'b0;
+                  assign p2_wr_error     = 'b0;
+                  assign p2_wr_full      = 'b0;
+                  assign p2_wr_empty     = 'b0;
+                  assign p2_wr_underrun  = 'b0;
+                  assign p2_wr_count     = 'b0;
+          
+          end 
+          if(C_PORT_CONFIG[183:160] == "B32" && C_PORT_CONFIG[87:64]  == "W32") begin : u_config1_3W
+// whenever PORT 3 is in Write mode         
+
+                  if (C_PORT_ENABLE[3] == 1'b1)
+                  begin
+
+                       assign mig_p3_clk   = p3_wr_clk;
+                       assign mig_p3_wr_data  = p3_wr_data[31:0];
+                       assign mig_p3_wr_mask  = p3_wr_mask[3:0];
+                       assign mig_p3_en       = p3_wr_en; 
+                       assign p3_wr_full      = mig_p3_full;
+                       assign p3_wr_empty     = mig_p3_empty;
+                       assign p3_wr_underrun  = mig_p3_underrun;
+                       assign p3_wr_count     = mig_p3_count  ; // wr port
+                       assign p3_wr_error     = mig_p3_error;
+                       
+                  end else 
+                  begin
+                       assign mig_p3_clk      = 'b0;
+                       assign mig_p3_wr_data  = 'b0;
+                       assign mig_p3_wr_mask  = 'b0;
+                       assign mig_p3_en       = 'b0;
+                       assign p3_wr_full      = 'b0;
+                       assign p3_wr_empty     = 'b0;
+                       assign p3_wr_underrun  = 'b0;
+                       assign p3_wr_count     = 'b0;
+                       assign p3_wr_error     = 'b0;
+                                                
+                  end
+                   assign p3_rd_overflow = 'b0;
+                   assign p3_rd_error    = 'b0;
+                   assign p3_rd_full     = 'b0;
+                   assign p3_rd_empty    = 'b0;
+                   assign p3_rd_count    = 'b0;
+                   assign p3_rd_data     = 'b0;
+       
+                       
+         end else if(C_PORT_CONFIG[183:160] == "B32" && C_PORT_CONFIG[87:64]  == "R32") begin : u_config1_3R
+       
+                  if (C_PORT_ENABLE[3] == 1'b1)
+                  begin
+
+                       assign mig_p3_clk     = p3_rd_clk;
+                       assign p3_rd_data     = mig_p3_rd_data;                
+                       assign mig_p3_en      = p3_rd_en;  // this signal will not shown up if the port 5 is for write dir
+                       assign p3_rd_overflow = mig_p3_overflow;
+                       assign p3_rd_error    = mig_p3_error;
+                       assign p3_rd_full     = mig_p3_full;
+                       assign p3_rd_empty    = mig_p3_empty;
+                       assign p3_rd_count    = mig_p3_count  ; // wr port
+                  end else
+                  begin 
+                       assign mig_p3_clk     = 'b0;
+                       assign mig_p3_en      = 'b0;
+                       assign p3_rd_overflow = 'b0;
+                       assign p3_rd_full     = 'b0;
+                       assign p3_rd_empty    = 'b0;
+                       assign p3_rd_count    = 'b0;
+                       assign p3_rd_error    = 'b0;
+                       assign p3_rd_data     = 'b0;
+                  end                  
+                  assign p3_wr_full      = 'b0;
+                  assign p3_wr_empty     = 'b0;
+                  assign p3_wr_underrun  = 'b0;
+                  assign p3_wr_count     = 'b0;
+                  assign p3_wr_error     = 'b0;
+                  assign mig_p3_wr_data  = 'b0;
+                  assign mig_p3_wr_mask  = 'b0;
+         end 
+         if(C_PORT_CONFIG[183:160] == "B32" && C_PORT_CONFIG[55:32]  == "W32") begin : u_config1_4W
+       // whenever PORT 4 is in Write mode       
+
+                  if (C_PORT_ENABLE[4] == 1'b1)
+                  begin
+       
+                       assign mig_p4_clk      = p4_wr_clk;
+                       assign mig_p4_wr_data  = p4_wr_data[31:0];
+                       assign mig_p4_wr_mask  = p4_wr_mask[3:0];
+                       assign mig_p4_en       = p4_wr_en; // this signal will not shown up if the port 5 is for read dir
+                       assign p4_wr_full      = mig_p4_full;
+                       assign p4_wr_empty     = mig_p4_empty;
+                       assign p4_wr_underrun  = mig_p4_underrun;
+                       assign p4_wr_count     = mig_p4_count  ; // wr port
+                       assign p4_wr_error     = mig_p4_error;
+
+                  end else
+                  begin
+                       assign mig_p4_clk      = 'b0;
+                       assign mig_p4_wr_data  = 'b0;
+                       assign mig_p4_wr_mask  = 'b0;
+                       assign mig_p4_en       = 'b0;
+                       assign p4_wr_full      = 'b0;
+                       assign p4_wr_empty     = 'b0;
+                       assign p4_wr_underrun  = 'b0;
+                       assign p4_wr_count     = 'b0;
+                       assign p4_wr_error     = 'b0;
+                  end                           
+                   assign p4_rd_overflow    = 'b0;
+                   assign p4_rd_error       = 'b0;
+                   assign p4_rd_full        = 'b0;
+                   assign p4_rd_empty       = 'b0;
+                   assign p4_rd_count       = 'b0;
+                   assign p4_rd_data        = 'b0;
+       
+         end else if(C_PORT_CONFIG[183:160] == "B32" && C_PORT_CONFIG[55:32]  == "R32") begin : u_config1_4R
+                       
+                  if (C_PORT_ENABLE[4] == 1'b1)
+                  begin
+                       assign mig_p4_clk        = p4_rd_clk;
+                       assign p4_rd_data        = mig_p4_rd_data;                
+                       assign mig_p4_en         = p4_rd_en;  // this signal will not shown up if the port 5 is for write dir
+                       assign p4_rd_overflow    = mig_p4_overflow;
+                       assign p4_rd_error       = mig_p4_error;
+                       assign p4_rd_full        = mig_p4_full;
+                       assign p4_rd_empty       = mig_p4_empty;
+                       assign p4_rd_count       = mig_p4_count  ; // wr port
+                       
+                  end else
+                  begin
+                       assign mig_p4_clk        = 'b0;
+                       assign p4_rd_data        = 'b0;
+                       assign mig_p4_en         = 'b0;
+                       assign p4_rd_overflow    = 'b0;
+                       assign p4_rd_error       = 'b0;
+                       assign p4_rd_full        = 'b0;
+                       assign p4_rd_empty       = 'b0;
+                       assign p4_rd_count       = 'b0;
+                  end                  
+                  assign p4_wr_full      = 'b0;
+                  assign p4_wr_empty     = 'b0;
+                  assign p4_wr_underrun  = 'b0;
+                  assign p4_wr_count     = 'b0;
+                  assign p4_wr_error     = 'b0;
+                  assign mig_p4_wr_data  = 'b0;
+                  assign mig_p4_wr_mask  = 'b0;
+
+
+                       
+                       
+         end 
+         
+         if(C_PORT_CONFIG[183:160] == "B32" && C_PORT_CONFIG[23:0] == "W32") begin : u_config1_5W
+       // whenever PORT 5 is in Write mode           
+
+                       
+                  if (C_PORT_ENABLE[5] == 1'b1)
+                  begin
+                       assign mig_p5_clk   = p5_wr_clk;
+                       assign mig_p5_wr_data  = p5_wr_data[31:0];
+                       assign mig_p5_wr_mask  = p5_wr_mask[3:0];
+                       assign mig_p5_en       = p5_wr_en; 
+                       assign p5_wr_full      = mig_p5_full;
+                       assign p5_wr_empty     = mig_p5_empty;
+                       assign p5_wr_underrun  = mig_p5_underrun;
+                       assign p5_wr_count     = mig_p5_count  ; 
+                       assign p5_wr_error     = mig_p5_error;
+                       
+                  end else
+                  begin
+                       assign mig_p5_clk      = 'b0;
+                       assign mig_p5_wr_data  = 'b0;
+                       assign mig_p5_wr_mask  = 'b0;
+                       assign mig_p5_en       = 'b0;
+                       assign p5_wr_full      = 'b0;
+                       assign p5_wr_empty     = 'b0;
+                       assign p5_wr_underrun  = 'b0;
+                       assign p5_wr_count     = 'b0;
+                       assign p5_wr_error     = 'b0;
+                  end                           
+                   assign p5_rd_data        = 'b0;
+                   assign p5_rd_overflow    = 'b0;
+                   assign p5_rd_error       = 'b0;
+                   assign p5_rd_full        = 'b0;
+                   assign p5_rd_empty       = 'b0;
+                   assign p5_rd_count       = 'b0;
+                  
+       
+                       
+                         
+         end else if(C_PORT_CONFIG[183:160] == "B32" && C_PORT_CONFIG[23:0] == "R32") begin : u_config1_5R
+
+                  if (C_PORT_ENABLE[5] == 1'b1)
+                  begin
+
+                       assign mig_p5_clk        = p5_rd_clk;
+                       assign p5_rd_data        = mig_p5_rd_data;                
+                       assign mig_p5_en         = p5_rd_en;  
+                       assign p5_rd_overflow    = mig_p5_overflow;
+                       assign p5_rd_error       = mig_p5_error;
+                       assign p5_rd_full        = mig_p5_full;
+                       assign p5_rd_empty       = mig_p5_empty;
+                       assign p5_rd_count       = mig_p5_count  ; 
+                       
+                 end else
+                 begin
+                       assign mig_p5_clk        = 'b0;
+                       assign p5_rd_data        = 'b0;           
+                       assign mig_p5_en         = 'b0;
+                       assign p5_rd_overflow    = 'b0;
+                       assign p5_rd_error       = 'b0;
+                       assign p5_rd_full        = 'b0;
+                       assign p5_rd_empty       = 'b0;
+                       assign p5_rd_count       = 'b0;
+                 
+                 end
+                 assign p5_wr_full      = 'b0;
+                 assign p5_wr_empty     = 'b0;
+                 assign p5_wr_underrun  = 'b0;
+                 assign p5_wr_count     = 'b0;
+                 assign p5_wr_error     = 'b0;
+                 assign mig_p5_wr_data  = 'b0;
+                 assign mig_p5_wr_mask  = 'b0;
+                       
+         end
+                
+  end else if(C_PORT_CONFIG == "B32_B32_B32_B32" ) begin : u_config_2
+
+           
+               // Inputs from Application CMD Port
+               // *************  need to hook up rd /wr error outputs
+               
+                  if (C_PORT_ENABLE[0] == 1'b1)
+                  begin
+                           // command port signals
+                           assign mig_p0_arb_en      =      p0_arb_en ;
+                           assign mig_p0_cmd_clk     =      p0_cmd_clk  ;
+                           assign mig_p0_cmd_en      =      p0_cmd_en   ;
+                           assign mig_p0_cmd_ra      =      p0_cmd_ra  ;
+                           assign mig_p0_cmd_ba      =      p0_cmd_ba   ;
+                           assign mig_p0_cmd_ca      =      p0_cmd_ca  ;
+                           assign mig_p0_cmd_instr   =      p0_cmd_instr;
+                           assign mig_p0_cmd_bl      =       {(p0_cmd_instr[2] | p0_cmd_bl[5]),p0_cmd_bl[4:0]}   ;
+                           
+                           // Data port signals
+                           assign mig_p0_rd_en    = p0_rd_en;                            
+                           assign mig_p0_wr_clk   = p0_wr_clk;
+                           assign mig_p0_rd_clk   = p0_rd_clk;
+                           assign mig_p0_wr_en    = p0_wr_en;
+                           assign mig_p0_wr_data  = p0_wr_data[31:0]; 
+                           assign mig_p0_wr_mask  = p0_wr_mask[3:0];
+                           assign p0_wr_count     = mig_p0_wr_count;
+                           assign p0_rd_count  = mig_p0_rd_count  ; 
+
+                           
+                           
+                 end else
+                 begin
+                           assign mig_p0_arb_en      =       'b0;
+                           assign mig_p0_cmd_clk     =       'b0;
+                           assign mig_p0_cmd_en      =       'b0;
+                           assign mig_p0_cmd_ra      =       'b0;
+                           assign mig_p0_cmd_ba      =       'b0;
+                           assign mig_p0_cmd_ca      =       'b0;
+                           assign mig_p0_cmd_instr   =       'b0;
+                           assign mig_p0_cmd_bl      =       'b0;
+                           
+                           assign mig_p0_rd_en    = 'b0;                    
+                           assign mig_p0_wr_clk   = 'b0;
+                           assign mig_p0_rd_clk   = 'b0;
+                           assign mig_p0_wr_en    = 'b0;
+                           assign mig_p0_wr_data  = 'b0; 
+                           assign mig_p0_wr_mask  = 'b0;
+                           assign p0_wr_count     = 'b0;
+                           assign p0_rd_count     = 'b0;
+
+                           
+                 end                           
+                           
+                           assign p0_cmd_empty       =      mig_p0_cmd_empty ;
+                           assign p0_cmd_full        =      mig_p0_cmd_full  ;
+                           
+                           
+                  if (C_PORT_ENABLE[1] == 1'b1)
+                  begin
+                           // command port signals
+
+                           assign mig_p1_arb_en      =      p1_arb_en ;
+                           assign mig_p1_cmd_clk     =      p1_cmd_clk  ;
+                           assign mig_p1_cmd_en      =      p1_cmd_en   ;
+                           assign mig_p1_cmd_ra      =      p1_cmd_ra  ;
+                           assign mig_p1_cmd_ba      =      p1_cmd_ba   ;
+                           assign mig_p1_cmd_ca      =      p1_cmd_ca  ;
+                           assign mig_p1_cmd_instr   =      p1_cmd_instr;
+                           assign mig_p1_cmd_bl      =      {(p1_cmd_instr[2] | p1_cmd_bl[5]),p1_cmd_bl[4:0]}  ;
+                           // Data port signals
+                 
+                            assign mig_p1_wr_en    = p1_wr_en;
+                            assign mig_p1_wr_clk   = p1_wr_clk;
+                            assign mig_p1_rd_en    = p1_rd_en;
+                            assign mig_p1_wr_data  = p1_wr_data[31:0];
+                            assign mig_p1_wr_mask  = p1_wr_mask[3:0];                
+                            assign mig_p1_rd_clk   = p1_rd_clk;
+                            assign p1_wr_count     = mig_p1_wr_count;
+                            assign p1_rd_count     = mig_p1_rd_count;
+                           
+                  end else
+                  begin
+
+                           assign mig_p1_arb_en      =       'b0;
+                           assign mig_p1_cmd_clk     =       'b0;
+                           assign mig_p1_cmd_en      =       'b0;
+                           assign mig_p1_cmd_ra      =       'b0;
+                           assign mig_p1_cmd_ba      =       'b0;
+                           assign mig_p1_cmd_ca      =       'b0;
+                           assign mig_p1_cmd_instr   =       'b0;
+                           assign mig_p1_cmd_bl      =       'b0;
+                           // Data port signals
+                           assign mig_p1_wr_en    = 'b0; 
+                           assign mig_p1_wr_clk   = 'b0;
+                           assign mig_p1_rd_en    = 'b0;
+                           assign mig_p1_wr_data  = 'b0;
+                           assign mig_p1_wr_mask  = 'b0;                
+                           assign mig_p1_rd_clk   = 'b0;
+                            assign p1_wr_count     = 'b0;
+                            assign p1_rd_count     = 'b0;
+                  
+                  end
+                           
+                           
+                           assign p1_cmd_empty       =      mig_p1_cmd_empty ;
+                           assign p1_cmd_full        =      mig_p1_cmd_full  ;
+ 
+                  if (C_PORT_ENABLE[2] == 1'b1)
+                  begin   //MCB Physical port               Logical Port
+                           assign mig_p2_arb_en      =      p2_arb_en ;
+                           assign mig_p2_cmd_clk     =      p2_cmd_clk  ;
+                           assign mig_p2_cmd_en      =      p2_cmd_en   ;
+                           assign mig_p2_cmd_ra      =      p2_cmd_ra  ;
+                           assign mig_p2_cmd_ba      =      p2_cmd_ba   ;
+                           assign mig_p2_cmd_ca      =      p2_cmd_ca  ;
+                           assign mig_p2_cmd_instr   =      p2_cmd_instr;
+                           assign mig_p2_cmd_bl      =      {(p2_cmd_instr[2] | p2_cmd_bl[5]),p2_cmd_bl[4:0]}   ;
+                           
+                            assign mig_p2_en       = p2_rd_en;
+                            assign mig_p2_clk      = p2_rd_clk;
+                            assign mig_p3_en       = p2_wr_en;
+                            assign mig_p3_clk      = p2_wr_clk;
+                            assign mig_p3_wr_data  = p2_wr_data[31:0];
+                            assign mig_p3_wr_mask  = p2_wr_mask[3:0];
+                            assign p2_wr_count     = mig_p3_count;
+                            assign p2_rd_count     = mig_p2_count;
+                           
+                  end else
+                  begin
+
+                           assign mig_p2_arb_en      =      'b0;
+                           assign mig_p2_cmd_clk     =      'b0;
+                           assign mig_p2_cmd_en      =      'b0;
+                           assign mig_p2_cmd_ra      =      'b0;
+                           assign mig_p2_cmd_ba      =      'b0;
+                           assign mig_p2_cmd_ca      =      'b0;
+                           assign mig_p2_cmd_instr   =      'b0;
+                           assign mig_p2_cmd_bl      =      'b0;
+
+                            assign mig_p2_en       = 'b0; 
+                            assign mig_p2_clk      = 'b0;
+                            assign mig_p3_en       = 'b0;
+                            assign mig_p3_clk      = 'b0;
+                            assign mig_p3_wr_data  = 'b0; 
+                            assign mig_p3_wr_mask  = 'b0;
+                            assign p2_rd_count     = 'b0;
+                            assign p2_wr_count     = 'b0;
+                           
+                 end                           
+                         
+                           assign p2_cmd_empty       =      mig_p2_cmd_empty ;
+                           assign p2_cmd_full        =      mig_p2_cmd_full  ;
+  
+                 if (C_PORT_ENABLE[3] == 1'b1)
+                  begin   //MCB Physical port               Logical Port
+                           assign mig_p4_arb_en      =      p3_arb_en ;
+                           assign mig_p4_cmd_clk     =      p3_cmd_clk  ;
+                           assign mig_p4_cmd_en      =      p3_cmd_en   ;
+                           assign mig_p4_cmd_ra      =      p3_cmd_ra  ;
+                           assign mig_p4_cmd_ba      =      p3_cmd_ba   ;
+                           assign mig_p4_cmd_ca      =      p3_cmd_ca  ;
+                           assign mig_p4_cmd_instr   =      p3_cmd_instr;
+                           assign mig_p4_cmd_bl      =      {(p3_cmd_instr[2] | p3_cmd_bl[5]),p3_cmd_bl[4:0]}  ;
+
+                           assign mig_p4_clk      = p3_rd_clk;
+                           assign mig_p4_en       = p3_rd_en;                            
+                           assign mig_p5_clk      = p3_wr_clk;
+                           assign mig_p5_en       = p3_wr_en; 
+                           assign mig_p5_wr_data  = p3_wr_data[31:0];
+                           assign mig_p5_wr_mask  = p3_wr_mask[3:0];
+                           assign p3_rd_count     = mig_p4_count;
+                           assign p3_wr_count     = mig_p5_count;
+                           
+                           
+                  end else
+                  begin
+                           assign mig_p4_arb_en      =     'b0;
+                           assign mig_p4_cmd_clk     =     'b0;
+                           assign mig_p4_cmd_en      =     'b0;
+                           assign mig_p4_cmd_ra      =     'b0;
+                           assign mig_p4_cmd_ba      =     'b0;
+                           assign mig_p4_cmd_ca      =     'b0;
+                           assign mig_p4_cmd_instr   =     'b0;
+                           assign mig_p4_cmd_bl      =     'b0;
+                           
+                            assign mig_p4_clk      = 'b0; 
+                            assign mig_p4_en       = 'b0;                   
+                            assign mig_p5_clk      = 'b0;
+                            assign mig_p5_en       = 'b0;
+                            assign mig_p5_wr_data  = 'b0; 
+                            assign mig_p5_wr_mask  = 'b0;
+                            assign p3_rd_count     = 'b0;
+                            assign p3_wr_count     = 'b0;
+                           
+                          
+                           
+                  end         
+                           
+                           assign p3_cmd_empty       =      mig_p4_cmd_empty ;
+                           assign p3_cmd_full        =      mig_p4_cmd_full  ;
+                           
+                           
+                            // outputs to Applications User Port
+                            assign p0_rd_data     = mig_p0_rd_data;
+                            assign p1_rd_data     = mig_p1_rd_data;
+                            assign p2_rd_data     = mig_p2_rd_data;
+                            assign p3_rd_data     = mig_p4_rd_data;
+
+                            assign p0_rd_empty    = mig_p0_rd_empty;
+                            assign p1_rd_empty    = mig_p1_rd_empty;
+                            assign p2_rd_empty    = mig_p2_empty;
+                            assign p3_rd_empty    = mig_p4_empty;
+
+                            assign p0_rd_full     = mig_p0_rd_full;
+                            assign p1_rd_full     = mig_p1_rd_full;
+                            assign p2_rd_full     = mig_p2_full;
+                            assign p3_rd_full     = mig_p4_full;
+
+                            assign p0_rd_error    = mig_p0_rd_error;
+                            assign p1_rd_error    = mig_p1_rd_error;
+                            assign p2_rd_error    = mig_p2_error;
+                            assign p3_rd_error    = mig_p4_error;
+                            
+                            assign p0_rd_overflow = mig_p0_rd_overflow;
+                            assign p1_rd_overflow = mig_p1_rd_overflow;
+                            assign p2_rd_overflow = mig_p2_overflow;
+                            assign p3_rd_overflow = mig_p4_overflow;
+
+                            assign p0_wr_underrun = mig_p0_wr_underrun;
+                            assign p1_wr_underrun = mig_p1_wr_underrun;
+                            assign p2_wr_underrun = mig_p3_underrun;
+                            assign p3_wr_underrun = mig_p5_underrun;
+                            
+                            assign p0_wr_empty    = mig_p0_wr_empty;
+                            assign p1_wr_empty    = mig_p1_wr_empty;
+                            assign p2_wr_empty    = mig_p3_empty; 
+                            assign p3_wr_empty    = mig_p5_empty; 
+ 
+                            assign p0_wr_full    = mig_p0_wr_full;
+                            assign p1_wr_full    = mig_p1_wr_full;
+                            assign p2_wr_full    = mig_p3_full;
+                            assign p3_wr_full    = mig_p5_full;
+
+                            assign p0_wr_error    = mig_p0_wr_error;
+                            assign p1_wr_error    = mig_p1_wr_error;
+                            assign p2_wr_error    = mig_p3_error;
+                            assign p3_wr_error    = mig_p5_error;
+
+     // unused ports signals
+                           assign p4_cmd_empty        =     1'b0;
+                           assign p4_cmd_full         =     1'b0;
+                           assign mig_p2_wr_mask  = 'b0;
+                           assign mig_p4_wr_mask  = 'b0;
+
+                           assign mig_p2_wr_data     = 'b0;
+                           assign mig_p4_wr_data     = 'b0;
+
+                           assign p5_cmd_empty        =     1'b0;
+                           assign p5_cmd_full         =     1'b0;
+     
+ 
+                            assign mig_p3_cmd_clk     =      1'b0;
+                            assign mig_p3_cmd_en      =      1'b0;
+                            assign mig_p3_cmd_ra      =      15'd0;
+                            assign mig_p3_cmd_ba      =      3'd0;
+                            assign mig_p3_cmd_ca      =      12'd0;
+                            assign mig_p3_cmd_instr   =      3'd0;
+                            assign mig_p3_cmd_bl      =      6'd0;
+                            assign mig_p3_arb_en      =      1'b0;  // physical cmd port 3 is not used in this config
+                            
+                            
+                            
+                            
+                            assign mig_p5_arb_en      =      1'b0;  // physical cmd port 3 is not used in this config
+                            assign mig_p5_cmd_clk     =      1'b0;
+                            assign mig_p5_cmd_en      =      1'b0;
+                            assign mig_p5_cmd_ra      =      15'd0;
+                            assign mig_p5_cmd_ba      =      3'd0;
+                            assign mig_p5_cmd_ca      =      12'd0;
+                            assign mig_p5_cmd_instr   =      3'd0;
+                            assign mig_p5_cmd_bl      =      6'd0;
+
+
+
+      ////////////////////////////////////////////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////
+      ////     
+      ////                         B64_B32_B32
+      ////     
+      /////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////////////////////////////////////////////////////
+
+     
+     
+  end else if(C_PORT_CONFIG == "B64_B32_B32" ) begin : u_config_3
+
+               // Inputs from Application CMD Port
+ 
+ 
+       if (C_PORT_ENABLE[0] == 1'b1)
+       begin
+               assign mig_p0_arb_en      =  p0_arb_en ;
+               assign mig_p0_cmd_clk     =  p0_cmd_clk  ;
+               assign mig_p0_cmd_en      =  p0_cmd_en   ;
+               assign mig_p0_cmd_ra      =  p0_cmd_ra  ;
+               assign mig_p0_cmd_ba      =  p0_cmd_ba   ;
+               assign mig_p0_cmd_ca      =  p0_cmd_ca  ;
+               assign mig_p0_cmd_instr   =  p0_cmd_instr;
+               assign mig_p0_cmd_bl      =   {(p0_cmd_instr[2] | p0_cmd_bl[5]),p0_cmd_bl[4:0]}   ;
+               assign p0_cmd_empty       =  mig_p0_cmd_empty ;
+               assign p0_cmd_full        =  mig_p0_cmd_full  ;
+
+               assign mig_p0_wr_clk   = p0_wr_clk;
+               assign mig_p0_rd_clk   = p0_rd_clk;
+               assign mig_p1_wr_clk   = p0_wr_clk;
+               assign mig_p1_rd_clk   = p0_rd_clk;
+
+               assign mig_p0_wr_en    = p0_wr_en & !p0_wr_full;
+               assign mig_p1_wr_en    = p0_wr_en & !p0_wr_full;
+               assign mig_p0_wr_data  = p0_wr_data[31:0];
+               assign mig_p0_wr_mask  = p0_wr_mask[3:0];
+               assign mig_p1_wr_data  = p0_wr_data[63 : 32];
+               assign mig_p1_wr_mask  = p0_wr_mask[7 : 4];     
+
+               assign p0_rd_empty       = mig_p1_rd_empty;
+               assign p0_rd_data        = {mig_p1_rd_data , mig_p0_rd_data}; 
+               assign mig_p0_rd_en    = p0_rd_en & !p0_rd_empty;
+               assign mig_p1_rd_en    = p0_rd_en & !p0_rd_empty;
+
+
+                assign p0_wr_count       = mig_p1_wr_count;  // B64 for port 0, map most significant port to output
+                assign p0_rd_count       = mig_p1_rd_count;
+                assign p0_wr_empty       = mig_p1_wr_empty;
+                assign p0_wr_error       = mig_p1_wr_error | mig_p0_wr_error;  
+                assign p0_wr_full        = mig_p1_wr_full;
+                assign p0_wr_underrun    = mig_p1_wr_underrun | mig_p0_wr_underrun; 
+                assign p0_rd_overflow    = mig_p1_rd_overflow | mig_p0_rd_overflow; 
+                assign p0_rd_error       = mig_p1_rd_error | mig_p0_rd_error; 
+                assign p0_rd_full        = mig_p1_rd_full;
+
+ 
+       end else
+       begin
+       
+               assign mig_p0_arb_en      = 'b0;
+               assign mig_p0_cmd_clk     = 'b0;
+               assign mig_p0_cmd_en      = 'b0;
+               assign mig_p0_cmd_ra      = 'b0;
+               assign mig_p0_cmd_ba      = 'b0;
+               assign mig_p0_cmd_ca      = 'b0;
+               assign mig_p0_cmd_instr   = 'b0;
+               assign mig_p0_cmd_bl      = 'b0;
+               assign p0_cmd_empty       =  'b0;
+               assign p0_cmd_full        =  'b0;
+
+
+               assign mig_p0_wr_clk   = 'b0;
+               assign mig_p0_rd_clk   = 'b0;
+               assign mig_p1_wr_clk   = 'b0;
+               assign mig_p1_rd_clk   = 'b0;
+               
+               assign mig_p0_wr_en    = 'b0;
+               assign mig_p1_wr_en    = 'b0;
+               assign mig_p0_wr_data  = 'b0;
+               assign mig_p0_wr_mask  = 'b0;
+               assign mig_p1_wr_data  = 'b0;
+               assign mig_p1_wr_mask  = 'b0; 
+
+               assign p0_rd_empty       = 'b0;
+               assign p0_rd_data        = 'b0;
+               assign mig_p0_rd_en      = 'b0;
+               assign mig_p1_rd_en      = 'b0;
+ 
+ 
+               assign p0_wr_count       =  'b0;
+               assign p0_rd_count       =  'b0;
+               assign p0_wr_empty       =  'b0;
+               assign p0_wr_error       =  'b0;
+               assign p0_wr_full        =  'b0;
+               assign p0_wr_underrun    =  'b0;
+               assign p0_rd_overflow    =  'b0;
+               assign p0_rd_error       =  'b0;
+               assign p0_rd_full        =  'b0;
+                                         
+
+       end       
+       
+        
+ 
+       if (C_PORT_ENABLE[1] == 1'b1)
+       begin
+
+               assign mig_p2_arb_en      =      p1_arb_en ;
+               assign mig_p2_cmd_clk     =      p1_cmd_clk  ;
+               assign mig_p2_cmd_en      =      p1_cmd_en   ;
+               assign mig_p2_cmd_ra      =      p1_cmd_ra  ;
+               assign mig_p2_cmd_ba      =      p1_cmd_ba   ;
+               assign mig_p2_cmd_ca      =      p1_cmd_ca  ;
+               assign mig_p2_cmd_instr   =      p1_cmd_instr;
+               assign mig_p2_cmd_bl      =      {(p1_cmd_instr[2] | p1_cmd_bl[5]),p1_cmd_bl[4:0]}  ;
+               assign p1_cmd_empty       =      mig_p2_cmd_empty;  
+               assign p1_cmd_full        =      mig_p2_cmd_full;   
+
+               assign mig_p2_clk         = p1_rd_clk;
+               assign mig_p3_clk         = p1_wr_clk;
+
+               assign mig_p3_en       = p1_wr_en;
+               assign mig_p3_wr_data  = p1_wr_data[31:0];
+               assign mig_p3_wr_mask  = p1_wr_mask[3:0];
+               assign mig_p2_en       = p1_rd_en;
+
+               assign p1_rd_data        = mig_p2_rd_data;
+               assign p1_wr_count       = mig_p3_count;
+               assign p1_rd_count       = mig_p2_count;
+               assign p1_wr_empty       = mig_p3_empty;
+               assign p1_wr_error       = mig_p3_error;                 
+               assign p1_wr_full        = mig_p3_full;
+               assign p1_wr_underrun    = mig_p3_underrun;
+               assign p1_rd_overflow    = mig_p2_overflow; 
+               assign p1_rd_error       = mig_p2_error;
+               assign p1_rd_full        = mig_p2_full;
+               assign p1_rd_empty       = mig_p2_empty;
+ 
+       end else
+       begin
+
+               assign mig_p2_arb_en      =     'b0; 
+               assign mig_p2_cmd_clk     =     'b0; 
+               assign mig_p2_cmd_en      =     'b0; 
+               assign mig_p2_cmd_ra      =     'b0; 
+               assign mig_p2_cmd_ba      =     'b0; 
+               assign mig_p2_cmd_ca      =     'b0; 
+               assign mig_p2_cmd_instr   =     'b0; 
+               assign mig_p2_cmd_bl      =     'b0; 
+               assign p1_cmd_empty       =     'b0; 
+               assign p1_cmd_full        =     'b0; 
+               assign mig_p3_en       = 'b0; 
+               assign mig_p3_wr_data  = 'b0; 
+               assign mig_p3_wr_mask  = 'b0; 
+               assign mig_p2_en       = 'b0; 
+
+               assign mig_p2_clk   = 'b0; 
+               assign mig_p3_clk   = 'b0; 
+               
+               assign p1_rd_data        = 'b0; 
+               assign p1_wr_count       = 'b0; 
+               assign p1_rd_count       = 'b0; 
+               assign p1_wr_empty       = 'b0; 
+               assign p1_wr_error       = 'b0;         
+               assign p1_wr_full        = 'b0; 
+               assign p1_wr_underrun    = 'b0; 
+               assign p1_rd_overflow    = 'b0; 
+               assign p1_rd_error       = 'b0; 
+               assign p1_rd_full        = 'b0; 
+               assign p1_rd_empty       = 'b0; 
+ 
+       end
+       
+       if (C_PORT_ENABLE[2] == 1'b1)
+       begin
+               assign mig_p4_arb_en      = p2_arb_en ;
+               assign mig_p4_cmd_clk     = p2_cmd_clk  ;
+               assign mig_p4_cmd_en      = p2_cmd_en   ;
+               assign mig_p4_cmd_ra      = p2_cmd_ra  ;
+               assign mig_p4_cmd_ba      = p2_cmd_ba   ;
+               assign mig_p4_cmd_ca      = p2_cmd_ca  ;
+               assign mig_p4_cmd_instr   = p2_cmd_instr;
+               assign mig_p4_cmd_bl      = {(p2_cmd_instr[2] | p2_cmd_bl[5]),p2_cmd_bl[4:0]}   ;
+               assign p2_cmd_empty       = mig_p4_cmd_empty ; 
+               assign p2_cmd_full        = mig_p4_cmd_full  ; 
+               assign mig_p5_en          = p2_wr_en;
+               assign mig_p5_wr_data     = p2_wr_data[31:0];
+               assign mig_p5_wr_mask     = p2_wr_mask[3:0];
+               assign mig_p4_en          = p2_rd_en;
+               
+                assign mig_p4_clk        = p2_rd_clk;
+                assign mig_p5_clk        = p2_wr_clk;
+
+                assign p2_rd_data        = mig_p4_rd_data;
+                assign p2_wr_count       = mig_p5_count;
+                assign p2_rd_count       = mig_p4_count;
+                assign p2_wr_empty       = mig_p5_empty;
+                assign p2_wr_full        = mig_p5_full;
+                assign p2_wr_error       = mig_p5_error;  
+                assign p2_wr_underrun    = mig_p5_underrun;
+                assign p2_rd_overflow    = mig_p4_overflow;    
+                assign p2_rd_error       = mig_p4_error;
+                assign p2_rd_full        = mig_p4_full;
+                assign p2_rd_empty       = mig_p4_empty;
+               
+       end else
+       begin
+               assign mig_p4_arb_en      = 'b0;   
+               assign mig_p4_cmd_clk     = 'b0;   
+               assign mig_p4_cmd_en      = 'b0;   
+               assign mig_p4_cmd_ra      = 'b0;   
+               assign mig_p4_cmd_ba      = 'b0;   
+               assign mig_p4_cmd_ca      = 'b0;   
+               assign mig_p4_cmd_instr   = 'b0;   
+               assign mig_p4_cmd_bl      = 'b0;   
+               assign p2_cmd_empty       = 'b0;   
+               assign p2_cmd_full        = 'b0;   
+               assign mig_p5_en          = 'b0; 
+               assign mig_p5_wr_data     = 'b0; 
+               assign mig_p5_wr_mask     = 'b0; 
+               assign mig_p4_en          = 'b0; 
+
+                assign mig_p4_clk        = 'b0; 
+                assign mig_p5_clk        = 'b0; 
+
+                assign p2_rd_data        =   'b0;   
+                assign p2_wr_count       =   'b0;   
+                assign p2_rd_count       =   'b0;   
+                assign p2_wr_empty       =   'b0;   
+                assign p2_wr_full        =   'b0;   
+                assign p2_wr_error       =   'b0;   
+                assign p2_wr_underrun    =   'b0;   
+                assign p2_rd_overflow    =   'b0;     
+                assign p2_rd_error       =   'b0;   
+                assign p2_rd_full        =   'b0;   
+                assign p2_rd_empty       =   'b0;   
+
+       end 
+ 
+
+              // MCB's port 1,3,5 is not used in this Config mode
+               assign mig_p1_arb_en      =      1'b0;
+               assign mig_p1_cmd_clk     =      1'b0;
+               assign mig_p1_cmd_en      =      1'b0;
+               assign mig_p1_cmd_ra      =      15'd0;
+               assign mig_p1_cmd_ba      =      3'd0;
+               assign mig_p1_cmd_ca      =      12'd0;
+               
+               assign mig_p1_cmd_instr   =      3'd0;
+               assign mig_p1_cmd_bl      =      6'd0;
+                
+               assign mig_p3_arb_en    =      1'b0;
+               assign mig_p3_cmd_clk     =      1'b0;
+               assign mig_p3_cmd_en      =      1'b0;
+               assign mig_p3_cmd_ra      =      15'd0;
+               assign mig_p3_cmd_ba      =      3'd0;
+               assign mig_p3_cmd_ca      =      12'd0;
+               
+               assign mig_p3_cmd_instr   =      3'd0;
+               assign mig_p3_cmd_bl      =      6'd0;
+
+               assign mig_p5_arb_en    =      1'b0;
+               assign mig_p5_cmd_clk     =      1'b0;
+               assign mig_p5_cmd_en      =      1'b0;
+               assign mig_p5_cmd_ra      =      15'd0;
+               assign mig_p5_cmd_ba      =      3'd0;
+               assign mig_p5_cmd_ca      =      12'd0;
+               
+               assign mig_p5_cmd_instr   =      3'd0;
+               assign mig_p5_cmd_bl      =      6'd0;
+ 
+
+
+end else if(C_PORT_CONFIG == "B64_B64" ) begin : u_config_4
+
+               // Inputs from Application CMD Port
+
+                 if (C_PORT_ENABLE[0] == 1'b1)
+                  begin
+               
+                       assign mig_p0_arb_en      =      p0_arb_en ;
+                       assign mig_p1_arb_en      =      p0_arb_en ;
+                       
+                       assign mig_p0_cmd_clk     =      p0_cmd_clk  ;
+                       assign mig_p0_cmd_en      =      p0_cmd_en   ;
+                       assign mig_p0_cmd_ra      =      p0_cmd_ra  ;
+                       assign mig_p0_cmd_ba      =      p0_cmd_ba   ;
+                       assign mig_p0_cmd_ca      =      p0_cmd_ca  ;
+                       assign mig_p0_cmd_instr   =      p0_cmd_instr;
+                       assign mig_p0_cmd_bl      =       {(p0_cmd_instr[2] | p0_cmd_bl[5]),p0_cmd_bl[4:0]}   ;
+
+
+                        assign mig_p0_wr_clk   = p0_wr_clk;
+                        assign mig_p0_rd_clk   = p0_rd_clk;
+                        assign mig_p1_wr_clk   = p0_wr_clk;
+                        assign mig_p1_rd_clk   = p0_rd_clk;
+                        assign mig_p0_wr_en    = p0_wr_en & !p0_wr_full;
+                        assign mig_p0_wr_data  = p0_wr_data[31:0];
+                        assign mig_p0_wr_mask  = p0_wr_mask[3:0];
+                        assign mig_p1_wr_data  = p0_wr_data[63 : 32];
+                        assign mig_p1_wr_mask  = p0_wr_mask[7 : 4];                
+                        assign mig_p1_wr_en    = p0_wr_en & !p0_wr_full;
+                        assign mig_p0_rd_en    = p0_rd_en & !p0_rd_empty;
+                        assign mig_p1_rd_en    = p0_rd_en & !p0_rd_empty;  
+                        assign p0_rd_data     = {mig_p1_rd_data , mig_p0_rd_data};
+                        
+                        assign p0_cmd_empty   =     mig_p0_cmd_empty ;
+                        assign p0_cmd_full    =     mig_p0_cmd_full  ;
+                        assign p0_wr_empty    = mig_p1_wr_empty;      
+                        assign p0_wr_full    = mig_p1_wr_full;
+                        assign p0_wr_error    = mig_p1_wr_error | mig_p0_wr_error; 
+                        assign p0_wr_count    = mig_p1_wr_count;
+                        assign p0_rd_count    = mig_p1_rd_count;
+                        assign p0_wr_underrun = mig_p1_wr_underrun | mig_p0_wr_underrun; 
+                        assign p0_rd_overflow = mig_p1_rd_overflow | mig_p0_rd_overflow; 
+                        assign p0_rd_error    = mig_p1_rd_error | mig_p0_rd_error; 
+                        assign p0_rd_full     = mig_p1_rd_full;
+                        assign p0_rd_empty    = mig_p1_rd_empty;
+                       
+                       
+                 end else
+                 begin
+                       assign mig_p0_arb_en      =      'b0;
+                       assign mig_p0_cmd_clk     =      'b0;
+                       assign mig_p0_cmd_en      =      'b0;
+                       assign mig_p0_cmd_ra      =      'b0;
+                       assign mig_p0_cmd_ba      =      'b0;
+                       assign mig_p0_cmd_ca      =      'b0;
+                       assign mig_p0_cmd_instr   =      'b0;
+                       assign mig_p0_cmd_bl      =      'b0;
+
+                        assign mig_p0_wr_clk   = 'b0;
+                        assign mig_p0_rd_clk   = 'b0;
+                        assign mig_p1_wr_clk   = 'b0;
+                        assign mig_p1_rd_clk   = 'b0;
+                        assign mig_p0_wr_en    = 'b0;
+                        assign mig_p1_wr_en    = 'b0;
+                        assign mig_p0_wr_data  = 'b0;
+                        assign mig_p0_wr_mask  = 'b0;
+                        assign mig_p1_wr_data  = 'b0;
+                        assign mig_p1_wr_mask  = 'b0;            
+                   //     assign mig_p1_wr_en    = 'b0;
+                        assign mig_p0_rd_en    = 'b0;
+                        assign mig_p1_rd_en    = 'b0;
+                        assign p0_rd_data     = 'b0;
+
+
+                        assign p0_cmd_empty   = 'b0;
+                        assign p0_cmd_full    = 'b0;
+                        assign p0_wr_empty    = 'b0;
+                        assign p0_wr_full     = 'b0;
+                        assign p0_wr_error    = 'b0;
+                        assign p0_wr_count    = 'b0;
+                        assign p0_rd_count    = 'b0;
+                        assign p0_wr_underrun = 'b0;  
+                        assign p0_rd_overflow = 'b0;
+                        assign p0_rd_error    = 'b0;
+                        assign p0_rd_full     = 'b0;
+                        assign p0_rd_empty    = 'b0;
+                 
+                 
+                 end
+
+      
+
+                 if (C_PORT_ENABLE[1] == 1'b1)
+                 begin
+
+                       assign mig_p2_arb_en      =      p1_arb_en ;
+                       
+                       assign mig_p2_cmd_clk     =      p1_cmd_clk  ;
+                       assign mig_p2_cmd_en      =      p1_cmd_en   ;
+                       assign mig_p2_cmd_ra      =      p1_cmd_ra  ;
+                       assign mig_p2_cmd_ba      =      p1_cmd_ba   ;
+                       assign mig_p2_cmd_ca      =      p1_cmd_ca  ;
+                       assign mig_p2_cmd_instr   =      p1_cmd_instr;
+                       assign mig_p2_cmd_bl      =      {(p1_cmd_instr[2] | p1_cmd_bl[5]),p1_cmd_bl[4:0]}  ;
+
+
+                        assign mig_p2_clk     = p1_rd_clk;
+                        assign mig_p3_clk     = p1_wr_clk;
+                        assign mig_p4_clk     = p1_rd_clk;
+                        assign mig_p5_clk     = p1_wr_clk;
+                        assign mig_p3_en      = p1_wr_en & !p1_wr_full;
+                        assign mig_p5_en      = p1_wr_en & !p1_wr_full;
+                        assign mig_p3_wr_data  = p1_wr_data[31:0];
+                        assign mig_p3_wr_mask  = p1_wr_mask[3:0];
+                        assign mig_p5_wr_data  = p1_wr_data[63 : 32];
+                        assign mig_p5_wr_mask  = p1_wr_mask[7 : 4];
+                        assign mig_p2_en       = p1_rd_en & !p1_rd_empty;
+                        assign mig_p4_en       = p1_rd_en & !p1_rd_empty;
+                        
+                        assign p1_cmd_empty       =      mig_p2_cmd_empty ;  
+                        assign p1_cmd_full        =      mig_p2_cmd_full  ;
+
+                        assign p1_wr_count    = mig_p5_count;
+                        assign p1_rd_count    = mig_p4_count;
+                        assign p1_wr_full    = mig_p5_full;
+                        assign p1_wr_error    = mig_p5_error | mig_p5_error;
+                        assign p1_wr_empty    = mig_p5_empty;
+                        assign p1_wr_underrun = mig_p3_underrun | mig_p5_underrun;
+                        assign p1_rd_overflow = mig_p4_overflow;
+                        assign p1_rd_error    = mig_p4_error;
+                        assign p1_rd_full     = mig_p4_full;
+                        assign p1_rd_empty    = mig_p4_empty;
+
+                        assign p1_rd_data     = {mig_p4_rd_data , mig_p2_rd_data};
+                       
+                       
+                 end else
+                 begin
+                       assign mig_p2_arb_en      = 'b0;
+                   //    assign mig_p3_arb_en      = 'b0;
+                  //     assign mig_p4_arb_en      = 'b0;
+                  //     assign mig_p5_arb_en      = 'b0;
+                       
+                       assign mig_p2_cmd_clk     = 'b0;
+                       assign mig_p2_cmd_en      = 'b0;
+                       assign mig_p2_cmd_ra      = 'b0;
+                       assign mig_p2_cmd_ba      = 'b0;
+                       assign mig_p2_cmd_ca      = 'b0;
+                       assign mig_p2_cmd_instr   = 'b0;
+                       assign mig_p2_cmd_bl      = 'b0;
+                       assign mig_p2_clk      = 'b0;
+                       assign mig_p3_clk      = 'b0;
+                       assign mig_p4_clk      = 'b0;
+                       assign mig_p5_clk      = 'b0;
+                       assign mig_p3_en       = 'b0;
+                       assign mig_p5_en       = 'b0;
+                       assign mig_p3_wr_data  = 'b0;
+                       assign mig_p3_wr_mask  = 'b0;
+                       assign mig_p5_wr_data  = 'b0;
+                       assign mig_p5_wr_mask  = 'b0; 
+                       assign mig_p2_en    = 'b0;
+                       assign mig_p4_en    = 'b0;
+                       assign p1_cmd_empty    = 'b0;  
+                       assign p1_cmd_full     = 'b0;  
+
+                       assign p1_wr_count    = 'b0;
+                       assign p1_rd_count    = 'b0;
+                       assign p1_wr_full     = 'b0;
+                       assign p1_wr_error    = 'b0;
+                       assign p1_wr_empty    = 'b0;
+                       assign p1_wr_underrun = 'b0;
+                       assign p1_rd_overflow = 'b0;
+                       assign p1_rd_error    = 'b0; 
+                       assign p1_rd_full     = 'b0; 
+                       assign p1_rd_empty    = 'b0; 
+                       assign p1_rd_data     = 'b0;
+                       
+                 end               
+                
+                  // unused MCB's signals in this configuration
+                       assign mig_p3_arb_en      =      1'b0;
+                       assign mig_p4_arb_en      =      1'b0;
+                       assign mig_p5_arb_en      =      1'b0;
+                       
+                       assign mig_p3_cmd_clk     =      1'b0;
+                       assign mig_p3_cmd_en      =      1'b0;
+                       assign mig_p3_cmd_ra      =      15'd0;
+                       assign mig_p3_cmd_ba      =      3'd0;
+                       assign mig_p3_cmd_ca      =      12'd0;
+                       assign mig_p3_cmd_instr   =      3'd0;
+
+                       assign mig_p4_cmd_clk     =      1'b0;
+                       assign mig_p4_cmd_en      =      1'b0;
+                       assign mig_p4_cmd_ra      =      15'd0;
+                       assign mig_p4_cmd_ba      =      3'd0;
+                       assign mig_p4_cmd_ca      =      12'd0;
+                       assign mig_p4_cmd_instr   =      3'd0;
+                       assign mig_p4_cmd_bl      =      6'd0;
+
+                       assign mig_p5_cmd_clk     =      1'b0;
+                       assign mig_p5_cmd_en      =      1'b0;
+                       assign mig_p5_cmd_ra      =      15'd0;
+                       assign mig_p5_cmd_ba      =      3'd0;
+                       assign mig_p5_cmd_ca      =      12'd0;                       
+                       assign mig_p5_cmd_instr   =      3'd0;
+                       assign mig_p5_cmd_bl      =      6'd0;
+
+                
+                
+
+  end else if(C_PORT_CONFIG == "B128" ) begin : u_config_5
+//*******************************BEGIN OF CONFIG 5 SIGNALS ********************************     
+
+               // Inputs from Application CMD Port
+               
+               assign mig_p0_arb_en      =  p0_arb_en ;
+               assign mig_p0_cmd_clk     =  p0_cmd_clk  ;
+               assign mig_p0_cmd_en      =  p0_cmd_en   ;
+               assign mig_p0_cmd_ra      =  p0_cmd_ra  ;
+               assign mig_p0_cmd_ba      =  p0_cmd_ba   ;
+               assign mig_p0_cmd_ca      =  p0_cmd_ca  ;
+               assign mig_p0_cmd_instr   =  p0_cmd_instr;
+               assign mig_p0_cmd_bl      =   {(p0_cmd_instr[2] | p0_cmd_bl[5]),p0_cmd_bl[4:0]}   ;
+               
+               assign p0_cmd_empty       =      mig_p0_cmd_empty ;
+               assign p0_cmd_full        =      mig_p0_cmd_full  ;
+               
+ 
+ 
+                // Inputs from Application User Port
+                
+                assign mig_p0_wr_clk   = p0_wr_clk;
+                assign mig_p0_rd_clk   = p0_rd_clk;
+                assign mig_p1_wr_clk   = p0_wr_clk;
+                assign mig_p1_rd_clk   = p0_rd_clk;
+                
+                assign mig_p2_clk   = p0_rd_clk;
+                assign mig_p3_clk   = p0_wr_clk;
+                assign mig_p4_clk   = p0_rd_clk;
+                assign mig_p5_clk   = p0_wr_clk;
+                
+                
+                
+                assign mig_p0_wr_en    = p0_wr_en & !p0_wr_full;
+                assign mig_p1_wr_en    = p0_wr_en & !p0_wr_full;
+                assign mig_p3_en       = p0_wr_en & !p0_wr_full;
+                assign mig_p5_en       = p0_wr_en & !p0_wr_full;
+                
+                
+                
+                assign mig_p0_wr_data = p0_wr_data[31:0];
+                assign mig_p0_wr_mask = p0_wr_mask[3:0];
+                assign mig_p1_wr_data = p0_wr_data[63 : 32];
+                assign mig_p1_wr_mask = p0_wr_mask[7 : 4];                
+                assign mig_p3_wr_data = p0_wr_data[95 : 64];
+                assign mig_p3_wr_mask = p0_wr_mask[11 : 8];
+                assign mig_p5_wr_data = p0_wr_data[127 : 96];
+                assign mig_p5_wr_mask = p0_wr_mask[15 : 12];
+                
+                assign mig_p0_rd_en    = p0_rd_en & !p0_rd_empty;
+                assign mig_p1_rd_en    = p0_rd_en & !p0_rd_empty;
+                assign mig_p2_en       = p0_rd_en & !p0_rd_empty;
+                assign mig_p4_en       = p0_rd_en & !p0_rd_empty;
+                
+                // outputs to Applications User Port
+                assign p0_rd_data     = {mig_p4_rd_data , mig_p2_rd_data , mig_p1_rd_data , mig_p0_rd_data};
+                assign p0_rd_empty    = mig_p4_empty;
+                assign p0_rd_full     = mig_p4_full;
+                assign p0_rd_error    = mig_p0_rd_error | mig_p1_rd_error | mig_p2_error | mig_p4_error;  
+                assign p0_rd_overflow    = mig_p0_rd_overflow | mig_p1_rd_overflow | mig_p2_overflow | mig_p4_overflow; 
+
+                assign p0_wr_underrun    = mig_p0_wr_underrun | mig_p1_wr_underrun | mig_p3_underrun | mig_p5_underrun;      
+                assign p0_wr_empty    = mig_p5_empty;
+                assign p0_wr_full     = mig_p5_full;
+                assign p0_wr_error    = mig_p0_wr_error | mig_p1_wr_error | mig_p3_error | mig_p5_error; 
+                
+                assign p0_wr_count    = mig_p5_count;
+                assign p0_rd_count    = mig_p4_count;
+
+
+               // unused MCB's siganls in this configuration
+               
+               assign mig_p1_arb_en      =      1'b0;
+               assign mig_p1_cmd_clk     =      1'b0;
+               assign mig_p1_cmd_en      =      1'b0;
+               assign mig_p1_cmd_ra      =      15'd0;
+               assign mig_p1_cmd_ba      =      3'd0;
+               assign mig_p1_cmd_ca      =      12'd0;
+               
+               assign mig_p1_cmd_instr   =      3'd0;
+               assign mig_p1_cmd_bl      =      6'd0;
+               
+               assign mig_p2_arb_en    =      1'b0;
+               assign mig_p2_cmd_clk     =      1'b0;
+               assign mig_p2_cmd_en      =      1'b0;
+               assign mig_p2_cmd_ra      =      15'd0;
+               assign mig_p2_cmd_ba      =      3'd0;
+               assign mig_p2_cmd_ca      =      12'd0;
+               
+               assign mig_p2_cmd_instr   =      3'd0;
+               assign mig_p2_cmd_bl      =      6'd0;
+               
+               assign mig_p3_arb_en    =      1'b0;
+               assign mig_p3_cmd_clk     =      1'b0;
+               assign mig_p3_cmd_en      =      1'b0;
+               assign mig_p3_cmd_ra      =      15'd0;
+               assign mig_p3_cmd_ba      =      3'd0;
+               assign mig_p3_cmd_ca      =      12'd0;
+               
+               assign mig_p3_cmd_instr   =      3'd0;
+               assign mig_p3_cmd_bl      =      6'd0;
+               
+               assign mig_p4_arb_en    =      1'b0;
+               assign mig_p4_cmd_clk     =      1'b0;
+               assign mig_p4_cmd_en      =      1'b0;
+               assign mig_p4_cmd_ra      =      15'd0;
+               assign mig_p4_cmd_ba      =      3'd0;
+               assign mig_p4_cmd_ca      =      12'd0;
+               
+               assign mig_p4_cmd_instr   =      3'd0;
+               assign mig_p4_cmd_bl      =      6'd0;
+               
+               assign mig_p5_arb_en    =      1'b0;
+               assign mig_p5_cmd_clk     =      1'b0;
+               assign mig_p5_cmd_en      =      1'b0;
+               assign mig_p5_cmd_ra      =      15'd0;
+               assign mig_p5_cmd_ba      =      3'd0;
+               assign mig_p5_cmd_ca      =      12'd0;
+               
+               assign mig_p5_cmd_instr   =      3'd0;
+               assign mig_p5_cmd_bl      =      6'd0;
+                             
+//*******************************END OF CONFIG 5 SIGNALS ********************************     
+                                
+end
+endgenerate
+                              
+   MCB 
+   # (         .PORT_CONFIG             (C_PORT_CONFIG),                                    
+               .MEM_WIDTH              (C_NUM_DQ_PINS    ),        
+               .MEM_TYPE                (C_MEM_TYPE       ), 
+               .MEM_BURST_LEN            (C_MEM_BURST_LEN  ),  
+               .MEM_ADDR_ORDER           (C_MEM_ADDR_ORDER),               
+               .MEM_CAS_LATENCY          (C_MEM_CAS_LATENCY),        
+               .MEM_DDR3_CAS_LATENCY      (C_MEM_DDR3_CAS_LATENCY   ),
+               .MEM_DDR2_WRT_RECOVERY     (C_MEM_DDR2_WRT_RECOVERY  ),
+               .MEM_DDR3_WRT_RECOVERY     (C_MEM_DDR3_WRT_RECOVERY  ),
+               .MEM_MOBILE_PA_SR          (C_MEM_MOBILE_PA_SR       ),
+               .MEM_DDR1_2_ODS              (C_MEM_DDR1_2_ODS         ),
+               .MEM_DDR3_ODS                (C_MEM_DDR3_ODS           ),
+               .MEM_DDR2_RTT                (C_MEM_DDR2_RTT           ),
+               .MEM_DDR3_RTT                (C_MEM_DDR3_RTT           ),
+               .MEM_DDR3_ADD_LATENCY        (C_MEM_DDR3_ADD_LATENCY   ),
+               .MEM_DDR2_ADD_LATENCY        (C_MEM_DDR2_ADD_LATENCY   ),
+               .MEM_MOBILE_TC_SR            (C_MEM_MOBILE_TC_SR       ),
+               .MEM_MDDR_ODS                (C_MEM_MDDR_ODS           ),
+               .MEM_DDR2_DIFF_DQS_EN        (C_MEM_DDR2_DIFF_DQS_EN   ),
+               .MEM_DDR2_3_PA_SR            (C_MEM_DDR2_3_PA_SR       ),
+               .MEM_DDR3_CAS_WR_LATENCY    (C_MEM_DDR3_CAS_WR_LATENCY),
+               .MEM_DDR3_AUTO_SR           (C_MEM_DDR3_AUTO_SR       ),
+               .MEM_DDR2_3_HIGH_TEMP_SR    (C_MEM_DDR2_3_HIGH_TEMP_SR),
+               .MEM_DDR3_DYN_WRT_ODT       (C_MEM_DDR3_DYN_WRT_ODT   ),
+               .MEM_RA_SIZE               (C_MEM_ADDR_WIDTH            ),
+               .MEM_BA_SIZE               (C_MEM_BANKADDR_WIDTH            ),
+               .MEM_CA_SIZE               (C_MEM_NUM_COL_BITS            ),
+               .MEM_RAS_VAL               (MEM_RAS_VAL            ),  
+               .MEM_RCD_VAL               (MEM_RCD_VAL            ),  
+               .MEM_REFI_VAL               (MEM_REFI_VAL           ),  
+               .MEM_RFC_VAL               (MEM_RFC_VAL            ),  
+               .MEM_RP_VAL                (MEM_RP_VAL             ),  
+               .MEM_WR_VAL                (MEM_WR_VAL             ),  
+               .MEM_RTP_VAL               (MEM_RTP_VAL            ),  
+               .MEM_WTR_VAL               (MEM_WTR_VAL            ),
+               .CAL_BYPASS        (C_MC_CALIB_BYPASS),      
+               .CAL_RA            (C_MC_CALIBRATION_RA),     
+               .CAL_BA            (C_MC_CALIBRATION_BA ),    
+               .CAL_CA            (C_MC_CALIBRATION_CA),  
+               .CAL_CLK_DIV        (C_MC_CALIBRATION_CLK_DIV),        
+               .CAL_DELAY         (C_MC_CALIBRATION_DELAY),
+               .ARB_NUM_TIME_SLOTS         (C_ARB_NUM_TIME_SLOTS),
+               .ARB_TIME_SLOT_0            (arbtimeslot0 )     ,    
+               .ARB_TIME_SLOT_1            (arbtimeslot1 )     ,    
+               .ARB_TIME_SLOT_2            (arbtimeslot2 )     ,    
+               .ARB_TIME_SLOT_3            (arbtimeslot3 )     ,    
+               .ARB_TIME_SLOT_4            (arbtimeslot4 )     ,    
+               .ARB_TIME_SLOT_5            (arbtimeslot5 )     ,    
+               .ARB_TIME_SLOT_6            (arbtimeslot6 )     ,    
+               .ARB_TIME_SLOT_7            (arbtimeslot7 )     ,    
+               .ARB_TIME_SLOT_8            (arbtimeslot8 )     ,    
+               .ARB_TIME_SLOT_9            (arbtimeslot9 )     ,    
+               .ARB_TIME_SLOT_10           (arbtimeslot10)   ,         
+               .ARB_TIME_SLOT_11           (arbtimeslot11)            
+             )  samc_0                                                
+     (                                                              
+                                                                    
+             // HIGH-SPEED PLL clock interface
+             
+             .PLLCLK            ({ioclk90,ioclk0}),
+             .PLLCE              ({pll_ce_90,pll_ce_0})       ,
+
+             .PLLLOCK       (1'b1),
+             
+             // DQS CLOCK NETWork interface
+             
+             .DQSIOIN           (idelay_dqs_ioi_s),
+             .DQSIOIP           (idelay_dqs_ioi_m),
+             .UDQSIOIN          (idelay_udqs_ioi_s),
+             .UDQSIOIP          (idelay_udqs_ioi_m),
+
+
+               //.DQSPIN    (in_pre_dqsp),
+               .DQI       (in_dq),
+             // RESETS - GLOBAl & local
+             .SYSRST         (MCB_SYSRST ), 
+   
+            // command port 0
+             .P0ARBEN            (mig_p0_arb_en),
+             .P0CMDCLK           (mig_p0_cmd_clk),
+             .P0CMDEN            (mig_p0_cmd_en),
+             .P0CMDRA            (mig_p0_cmd_ra),
+             .P0CMDBA            (mig_p0_cmd_ba),
+             .P0CMDCA            (mig_p0_cmd_ca),
+             
+             .P0CMDINSTR         (mig_p0_cmd_instr),
+             .P0CMDBL            (mig_p0_cmd_bl),
+             .P0CMDEMPTY         (mig_p0_cmd_empty),
+             .P0CMDFULL          (mig_p0_cmd_full),
+             
+             // command port 1 
+            
+             .P1ARBEN            (mig_p1_arb_en),
+             .P1CMDCLK           (mig_p1_cmd_clk),
+             .P1CMDEN            (mig_p1_cmd_en),
+             .P1CMDRA            (mig_p1_cmd_ra),
+             .P1CMDBA            (mig_p1_cmd_ba),
+             .P1CMDCA            (mig_p1_cmd_ca),
+             
+             .P1CMDINSTR         (mig_p1_cmd_instr),
+             .P1CMDBL            (mig_p1_cmd_bl),
+             .P1CMDEMPTY         (mig_p1_cmd_empty),
+             .P1CMDFULL          (mig_p1_cmd_full),
+
+             // command port 2
+             
+             .P2ARBEN            (mig_p2_arb_en),
+             .P2CMDCLK           (mig_p2_cmd_clk),
+             .P2CMDEN            (mig_p2_cmd_en),
+             .P2CMDRA            (mig_p2_cmd_ra),
+             .P2CMDBA            (mig_p2_cmd_ba),
+             .P2CMDCA            (mig_p2_cmd_ca),
+             
+             .P2CMDINSTR         (mig_p2_cmd_instr),
+             .P2CMDBL            (mig_p2_cmd_bl),
+             .P2CMDEMPTY         (mig_p2_cmd_empty),
+             .P2CMDFULL          (mig_p2_cmd_full),
+
+             // command port 3
+             
+             .P3ARBEN            (mig_p3_arb_en),
+             .P3CMDCLK           (mig_p3_cmd_clk),
+             .P3CMDEN            (mig_p3_cmd_en),
+             .P3CMDRA            (mig_p3_cmd_ra),
+             .P3CMDBA            (mig_p3_cmd_ba),
+             .P3CMDCA            (mig_p3_cmd_ca),
+                               
+             .P3CMDINSTR         (mig_p3_cmd_instr),
+             .P3CMDBL            (mig_p3_cmd_bl),
+             .P3CMDEMPTY         (mig_p3_cmd_empty),
+             .P3CMDFULL          (mig_p3_cmd_full),
+
+             // command port 4  // don't care in config 2
+             
+             .P4ARBEN            (mig_p4_arb_en),
+             .P4CMDCLK           (mig_p4_cmd_clk),
+             .P4CMDEN            (mig_p4_cmd_en),
+             .P4CMDRA            (mig_p4_cmd_ra),
+             .P4CMDBA            (mig_p4_cmd_ba),
+             .P4CMDCA            (mig_p4_cmd_ca),
+                               
+             .P4CMDINSTR         (mig_p4_cmd_instr),
+             .P4CMDBL            (mig_p4_cmd_bl),
+             .P4CMDEMPTY         (mig_p4_cmd_empty),
+             .P4CMDFULL          (mig_p4_cmd_full),
+
+             // command port 5 // don't care in config 2
+             
+             .P5ARBEN            (mig_p5_arb_en),
+             .P5CMDCLK           (mig_p5_cmd_clk),
+             .P5CMDEN            (mig_p5_cmd_en),
+             .P5CMDRA            (mig_p5_cmd_ra),
+             .P5CMDBA            (mig_p5_cmd_ba),
+             .P5CMDCA            (mig_p5_cmd_ca),
+                               
+             .P5CMDINSTR         (mig_p5_cmd_instr),
+             .P5CMDBL            (mig_p5_cmd_bl),
+             .P5CMDEMPTY         (mig_p5_cmd_empty),
+             .P5CMDFULL          (mig_p5_cmd_full),
+
+              
+             // IOI & IOB SIGNals/tristate interface
+             
+             .DQIOWEN0        (dqIO_w_en_0),
+             .DQSIOWEN90P     (dqsIO_w_en_90_p),
+             .DQSIOWEN90N     (dqsIO_w_en_90_n),
+             
+             
+             // IOB MEMORY INTerface signals
+             .ADDR         (address_90),  
+             .BA           (ba_90 ),      
+             .RAS         (ras_90 ),     
+             .CAS         (cas_90 ),     
+             .WE          (we_90  ),     
+             .CKE          (cke_90 ),     
+             .ODT          (odt_90 ),     
+             .RST          (rst_90 ),     
+             
+             // CALIBRATION DRP interface
+             .IOIDRPCLK           (ioi_drp_clk    ),
+             .IOIDRPADDR          (ioi_drp_addr   ),
+             .IOIDRPSDO           (ioi_drp_sdo    ), 
+             .IOIDRPSDI           (ioi_drp_sdi    ), 
+             .IOIDRPCS            (ioi_drp_cs     ),
+             .IOIDRPADD           (ioi_drp_add    ), 
+             .IOIDRPBROADCAST     (ioi_drp_broadcast  ),
+             .IOIDRPTRAIN         (ioi_drp_train    ),
+             .IOIDRPUPDATE         (ioi_drp_update) ,
+             
+             // CALIBRATION DAtacapture interface
+             //SPECIAL COMMANDs
+             .RECAL               (mcb_recal    ), 
+             .UIREAD               (mcb_ui_read),
+             .UIADD                (mcb_ui_add)    ,
+             .UICS                 (mcb_ui_cs)     ,
+             .UICLK                (mcb_ui_clk)    ,
+             .UISDI                (mcb_ui_sdi)    ,
+             .UIADDR               (mcb_ui_addr)   ,
+             .UIBROADCAST          (mcb_ui_broadcast) ,
+             .UIDRPUPDATE          (mcb_ui_drp_update) ,
+             .UIDONECAL            (mcb_ui_done_cal)   ,
+             .UICMD                (mcb_ui_cmd),
+             .UICMDIN              (mcb_ui_cmd_in)     ,
+             .UICMDEN              (mcb_ui_cmd_en)     ,
+             .UIDQCOUNT            (mcb_ui_dqcount)    ,
+             .UIDQLOWERDEC          (mcb_ui_dq_lower_dec),
+             .UIDQLOWERINC          (mcb_ui_dq_lower_inc),
+             .UIDQUPPERDEC          (mcb_ui_dq_upper_dec),
+             .UIDQUPPERINC          (mcb_ui_dq_upper_inc),
+             .UIUDQSDEC          (mcb_ui_udqs_dec),
+             .UIUDQSINC          (mcb_ui_udqs_inc),
+             .UILDQSDEC          (mcb_ui_ldqs_dec),
+             .UILDQSINC          (mcb_ui_ldqs_inc),
+             .UODATA             (uo_data),
+             .UODATAVALID          (uo_data_valid),
+             .UODONECAL            (hard_done_cal)  ,
+             .UOCMDREADYIN         (uo_cmd_ready_in),
+             .UOREFRSHFLAG         (uo_refrsh_flag),
+             .UOCALSTART           (uo_cal_start)   ,
+             .UOSDO                (uo_sdo),
+                                                   
+             //CONTROL SIGNALS
+              .STATUS                    (status),
+              .SELFREFRESHENTER          (selfrefresh_mcb_enter  ),
+              .SELFREFRESHMODE           (selfrefresh_mcb_mode ),  
+//////////////////////////////  //////////////////
+//MUIs
+////////////////////////////////////////////////
+            
+              .P0RDDATA         ( mig_p0_rd_data[31:0]    ), 
+              .P1RDDATA         ( mig_p1_rd_data[31:0]   ), 
+              .P2RDDATA         ( mig_p2_rd_data[31:0]  ), 
+              .P3RDDATA         ( mig_p3_rd_data[31:0]       ),
+              .P4RDDATA         ( mig_p4_rd_data[31:0] ), 
+              .P5RDDATA         ( mig_p5_rd_data[31:0]        ), 
+              .LDMN             ( dqnlm       ),
+              .UDMN             ( dqnum       ),
+              .DQON             ( dqo_n       ),
+              .DQOP             ( dqo_p       ),
+              .LDMP             ( dqplm       ),
+              .UDMP             ( dqpum       ),
+              
+              .P0RDCOUNT          ( mig_p0_rd_count ), 
+              .P0WRCOUNT          ( mig_p0_wr_count ),
+              .P1RDCOUNT          ( mig_p1_rd_count ), 
+              .P1WRCOUNT          ( mig_p1_wr_count ), 
+              .P2COUNT           ( mig_p2_count  ), 
+              .P3COUNT           ( mig_p3_count  ),
+              .P4COUNT           ( mig_p4_count  ),
+              .P5COUNT           ( mig_p5_count  ),
+              
+              // NEW ADDED FIFo status siganls
+              // MIG USER PORT 0
+              .P0RDEMPTY        ( mig_p0_rd_empty), 
+              .P0RDFULL         ( mig_p0_rd_full), 
+              .P0RDOVERFLOW     ( mig_p0_rd_overflow), 
+              .P0WREMPTY        ( mig_p0_wr_empty), 
+              .P0WRFULL         ( mig_p0_wr_full), 
+              .P0WRUNDERRUN     ( mig_p0_wr_underrun), 
+              // MIG USER PORT 1
+              .P1RDEMPTY        ( mig_p1_rd_empty), 
+              .P1RDFULL         ( mig_p1_rd_full), 
+              .P1RDOVERFLOW     ( mig_p1_rd_overflow),  
+              .P1WREMPTY        ( mig_p1_wr_empty), 
+              .P1WRFULL         ( mig_p1_wr_full), 
+              .P1WRUNDERRUN     ( mig_p1_wr_underrun),  
+              
+              // MIG USER PORT 2
+              .P2EMPTY          ( mig_p2_empty),
+              .P2FULL           ( mig_p2_full),
+              .P2RDOVERFLOW        ( mig_p2_overflow), 
+              .P2WRUNDERRUN       ( mig_p2_underrun), 
+              
+              .P3EMPTY          ( mig_p3_empty ),
+              .P3FULL           ( mig_p3_full ),
+              .P3RDOVERFLOW        ( mig_p3_overflow), 
+              .P3WRUNDERRUN       ( mig_p3_underrun ),
+              // MIG USER PORT 3
+              .P4EMPTY          ( mig_p4_empty),
+              .P4FULL           ( mig_p4_full),
+              .P4RDOVERFLOW        ( mig_p4_overflow), 
+              .P4WRUNDERRUN       ( mig_p4_underrun), 
+              
+              .P5EMPTY          ( mig_p5_empty ),
+              .P5FULL           ( mig_p5_full ),
+              .P5RDOVERFLOW        ( mig_p5_overflow), 
+              .P5WRUNDERRUN       ( mig_p5_underrun), 
+              
+              ////////////////////////////////////////////////////////-
+              .P0WREN        ( mig_p0_wr_en), 
+              .P0RDEN        ( mig_p0_rd_en),                         
+              .P1WREN        ( mig_p1_wr_en), 
+              .P1RDEN        ( mig_p1_rd_en), 
+              .P2EN          ( mig_p2_en),
+              .P3EN          ( mig_p3_en), 
+              .P4EN          ( mig_p4_en), 
+              .P5EN          ( mig_p5_en), 
+              // WRITE  MASK BIts connection
+              .P0RWRMASK        ( mig_p0_wr_mask[3:0]), 
+              .P1RWRMASK        ( mig_p1_wr_mask[3:0]),
+              .P2WRMASK        ( mig_p2_wr_mask[3:0]),
+              .P3WRMASK        ( mig_p3_wr_mask[3:0]), 
+              .P4WRMASK        ( mig_p4_wr_mask[3:0]),
+              .P5WRMASK        ( mig_p5_wr_mask[3:0]), 
+              // DATA WRITE COnnection
+              .P0WRDATA      ( mig_p0_wr_data[31:0]), 
+              .P1WRDATA      ( mig_p1_wr_data[31:0]),
+              .P2WRDATA      ( mig_p2_wr_data[31:0]),
+              .P3WRDATA      ( mig_p3_wr_data[31:0]), 
+              .P4WRDATA      ( mig_p4_wr_data[31:0]),
+              .P5WRDATA      ( mig_p5_wr_data[31:0]),  
+              
+              .P0WRERROR     (mig_p0_wr_error),
+              .P1WRERROR     (mig_p1_wr_error),
+              .P0RDERROR     (mig_p0_rd_error),
+              .P1RDERROR     (mig_p1_rd_error),
+              
+              .P2ERROR       (mig_p2_error),
+              .P3ERROR       (mig_p3_error),
+              .P4ERROR       (mig_p4_error),
+              .P5ERROR       (mig_p5_error),
+              
+              //  USER SIDE DAta ports clock
+              //  128 BITS CONnections
+              .P0WRCLK            ( mig_p0_wr_clk  ),
+              .P1WRCLK            ( mig_p1_wr_clk  ),
+              .P0RDCLK            ( mig_p0_rd_clk  ),
+              .P1RDCLK            ( mig_p1_rd_clk  ),
+              .P2CLK              ( mig_p2_clk  ),
+              .P3CLK              ( mig_p3_clk  ),
+              .P4CLK              ( mig_p4_clk  ),
+              .P5CLK              ( mig_p5_clk) 
+              ////////////////////////////////////////////////////////
+              // TST MODE PINS
+              
+                            
+            
+              );
+             
+
+//////////////////////////////////////////////////////
+// Input Termination Calibration
+//////////////////////////////////////////////////////
+wire                          DONE_SOFTANDHARD_CAL;
+
+assign uo_done_cal = (   C_CALIB_SOFT_IP == "TRUE") ? DONE_SOFTANDHARD_CAL : hard_done_cal;
+generate   
+if ( C_CALIB_SOFT_IP == "TRUE") begin: gen_term_calib
+
+
+  
+
+ 
+mcb_soft_calibration_top  # (
+
+    .C_MEM_TZQINIT_MAXCNT (C_MEM_TZQINIT_MAXCNT),
+    .C_MC_CALIBRATION_MODE(C_MC_CALIBRATION_MODE),
+    .SKIP_IN_TERM_CAL     (C_SKIP_IN_TERM_CAL),
+    .SKIP_DYNAMIC_CAL     (C_SKIP_DYNAMIC_CAL),
+    .SKIP_DYN_IN_TERM     (C_SKIP_DYN_IN_TERM),
+    .C_SIMULATION         (C_SIMULATION),
+    .C_MEM_TYPE           (C_MEM_TYPE)
+        )
+  mcb_soft_calibration_top_inst (
+    .UI_CLK               (ui_clk),               //Input - global clock to be used for input_term_tuner and IODRP clock
+    .RST                  (int_sys_rst),              //Input - reset for input_term_tuner - synchronous for input_term_tuner state machine, asynch for IODRP (sub)controller
+    .IOCLK                (ioclk0),               //Input - IOCLK input to the IODRP's
+    .DONE_SOFTANDHARD_CAL (DONE_SOFTANDHARD_CAL), // active high flag signals soft calibration of input delays is complete and MCB_UODONECAL is high (MCB hard calib complete)
+    .PLL_LOCK             (pll_lock),
+    
+    .SELFREFRESH_REQ      (selfrefresh_enter),    // from user app
+    .SELFREFRESH_MCB_MODE (selfrefresh_mcb_mode), // from MCB
+    .SELFREFRESH_MCB_REQ  (selfrefresh_mcb_enter),// to mcb
+    .SELFREFRESH_MODE     (selfrefresh_mode),     // to user app
+    
+    
+    
+    .MCB_UIADD            (mcb_ui_add),
+    .MCB_UISDI            (mcb_ui_sdi),
+    .MCB_UOSDO            (uo_sdo),               // from MCB's UOSDO port (User output SDO)
+    .MCB_UODONECAL        (hard_done_cal),        // input for when MCB hard calibration process is complete
+    .MCB_UOREFRSHFLAG     (uo_refrsh_flag),       //high during refresh cycle and time when MCB is innactive
+    .MCB_UICS             (mcb_ui_cs),            // to MCB's UICS port (User Input CS)
+    .MCB_UIDRPUPDATE      (mcb_ui_drp_update),    // MCB's UIDRPUPDATE port (gets passed to IODRP2_MCB's MEMUPDATE port: this controls shadow latch used during IODRP2_MCB writes).  Currently just trasnparent
+    .MCB_UIBROADCAST      (mcb_ui_broadcast),     // to MCB's UIBROADCAST port (User Input BROADCAST - gets passed to IODRP2_MCB's BKST port)
+    .MCB_UIADDR           (mcb_ui_addr),          //to MCB's UIADDR port (gets passed to IODRP2_MCB's AUXADDR port
+    .MCB_UICMDEN          (mcb_ui_cmd_en),        //set to take control of UI interface - removes control from internal calib block
+    .MCB_UIDONECAL        (mcb_ui_done_cal),      //
+    .MCB_UIDQLOWERDEC     (mcb_ui_dq_lower_dec),
+    .MCB_UIDQLOWERINC     (mcb_ui_dq_lower_inc),
+    .MCB_UIDQUPPERDEC     (mcb_ui_dq_upper_dec),
+    .MCB_UIDQUPPERINC     (mcb_ui_dq_upper_inc),
+    .MCB_UILDQSDEC        (mcb_ui_ldqs_dec),
+    .MCB_UILDQSINC        (mcb_ui_ldqs_inc),
+    .MCB_UIREAD           (mcb_ui_read),          //enables read w/o writing by turning on a SDO->SDI loopback inside the IODRP2_MCBs (doesn't exist in regular IODRP2).  IODRPCTRLR_R_WB becomes don't-care.
+    .MCB_UIUDQSDEC        (mcb_ui_udqs_dec),
+    .MCB_UIUDQSINC        (mcb_ui_udqs_inc),
+    .MCB_RECAL            (mcb_recal),
+    .MCB_SYSRST           (MCB_SYSRST),           //drives the MCB's SYSRST pin - the main reset for MCB
+    .MCB_UICMD            (mcb_ui_cmd),
+    .MCB_UICMDIN          (mcb_ui_cmd_in),
+    .MCB_UIDQCOUNT        (mcb_ui_dqcount),
+    .MCB_UODATA           (uo_data),
+    .MCB_UODATAVALID      (uo_data_valid),
+    .MCB_UOCMDREADY       (uo_cmd_ready_in),
+    .MCB_UO_CAL_START     (uo_cal_start),
+    .RZQ_Pin              (rzq),
+    .ZIO_Pin              (zio),
+    .CKE_Train            (cke_train)
+    
+     );
+
+
+
+
+
+
+        assign mcb_ui_clk = ui_clk;
+end
+endgenerate
+
+generate   
+if ( C_CALIB_SOFT_IP != "TRUE") begin: gen_no_term_calib   
+    assign DONE_SOFTANDHARD_CAL = 1'b0;
+    assign MCB_SYSRST = int_sys_rst | (~wait_200us_counter[15]);
+    assign mcb_recal = calib_recal;
+    assign mcb_ui_read = ui_read;
+    assign mcb_ui_add = ui_add;
+    assign mcb_ui_cs = ui_cs;  
+    assign mcb_ui_clk = ui_clk;
+    assign mcb_ui_sdi = ui_sdi;
+    assign mcb_ui_addr = ui_addr;
+    assign mcb_ui_broadcast = ui_broadcast;
+    assign mcb_ui_drp_update = ui_drp_update;
+    assign mcb_ui_done_cal = ui_done_cal;
+    assign mcb_ui_cmd = ui_cmd;
+    assign mcb_ui_cmd_in = ui_cmd_in;
+    assign mcb_ui_cmd_en = ui_cmd_en;
+    assign mcb_ui_dq_lower_dec = ui_dq_lower_dec;
+    assign mcb_ui_dq_lower_inc = ui_dq_lower_inc;
+    assign mcb_ui_dq_upper_dec = ui_dq_upper_dec;
+    assign mcb_ui_dq_upper_inc = ui_dq_upper_inc;
+    assign mcb_ui_udqs_inc = ui_udqs_inc;
+    assign mcb_ui_udqs_dec = ui_udqs_dec;
+    assign mcb_ui_ldqs_inc = ui_ldqs_inc;
+    assign mcb_ui_ldqs_dec = ui_ldqs_dec; 
+    assign selfrefresh_mode = 1'b0;
+ 
+    if (C_SIMULATION == "FALSE") begin: init_sequence
+        always @ (posedge ui_clk, posedge int_sys_rst)
+        begin
+            if (int_sys_rst)
+                wait_200us_counter <= 'b0;
+            else 
+               if (wait_200us_counter[15])  // UI_CLK maximum is up to 100 MHz.
+                   wait_200us_counter <= wait_200us_counter                        ;
+               else
+                   wait_200us_counter <= wait_200us_counter + 1'b1;
+        end 
+    end 
+    else begin: init_sequence_skip
+// synthesis translate_off	  
+        initial
+        begin
+           wait_200us_counter = 16'hFFFF;
+           $display("The 200 us wait period required before CKE goes active has been skipped in Simulation\n");
+        end	  
+// synthesis translate_on	  
+    end
+   
+    
+    if( C_MEM_TYPE == "DDR2") begin : gen_cketrain_a
+
+        always @ ( posedge ui_clk)
+        begin 
+          // When wait_200us_[13] and wait_200us_[14] are both asserted,
+          // 200 us wait should have been passed. 
+          if (wait_200us_counter[14] && wait_200us_counter[13])
+             wait_200us_done_r1 <= 1'b1;
+          else
+             wait_200us_done_r1 <= 1'b0;
+          
+
+          wait_200us_done_r2 <= wait_200us_done_r1;
+        end
+        
+        always @ ( posedge ui_clk, posedge int_sys_rst)
+        begin 
+        if (int_sys_rst)
+           cke_train_reg <= 1'b0;
+        else 
+           if ( wait_200us_done_r1 && ~wait_200us_done_r2 )
+               cke_train_reg <= 1'b1;
+           else if ( uo_done_cal)
+               cke_train_reg <= 1'b0;
+        end
+        
+        assign cke_train = cke_train_reg;
+    end
+
+    if( C_MEM_TYPE != "DDR2") begin : gen_cketrain_b
+    
+        assign cke_train = 1'b0;
+    end        
+        
+        
+end 
+endgenerate
+
+//////////////////////////////////////////////////////
+//ODDRDES2 instantiations
+//////////////////////////////////////////////////////
+
+////////
+//ADDR
+////////
+
+genvar addr_ioi;
+   generate 
+      for(addr_ioi = 0; addr_ioi < C_MEM_ADDR_WIDTH; addr_ioi = addr_ioi + 1) begin : gen_addr_oserdes2
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_MASTER),          // MASTER, SLAVE
+  .DATA_WIDTH    (2)           // {1..8} 
+) ioi_addr_0  
+(
+  .OQ(ioi_addr[addr_ioi]),
+  .SHIFTOUT1(),
+  .SHIFTOUT2(),
+  .SHIFTOUT3(),
+  .SHIFTOUT4(),
+  .TQ(t_addr[addr_ioi]),
+  .CLK0(ioclk0),
+  .CLK1(),
+  .CLKDIV(),
+  .D1(address_90[addr_ioi]),
+  .D2(address_90[addr_ioi]),
+  .D3(),
+  .D4(),
+  .IOCE(pll_ce_0),
+  .OCE(1'b1),
+  .RST(int_sys_rst),
+  .SHIFTIN1(),
+  .SHIFTIN2(),
+  .SHIFTIN3(),
+  .SHIFTIN4(),
+  .T1(1'b0),
+  .T2(1'b0),
+  .T3(),
+  .T4(),
+  .TCE(1'b1),
+  .TRAIN(1'b0)
+    );
+ end       
+   endgenerate
+
+////////
+//BA
+////////
+
+genvar ba_ioi;
+   generate 
+      for(ba_ioi = 0; ba_ioi < C_MEM_BANKADDR_WIDTH; ba_ioi = ba_ioi + 1) begin : gen_ba_oserdes2
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_MASTER),          // MASTER, SLAVE
+  .DATA_WIDTH    (2)           // {1..8} 
+) ioi_ba_0  
+(
+  .OQ       (ioi_ba[ba_ioi]),
+  .SHIFTOUT1 (),
+  .SHIFTOUT2 (),
+  .SHIFTOUT3 (),
+  .SHIFTOUT4 (),
+  .TQ       (t_ba[ba_ioi]),
+  .CLK0     (ioclk0),
+  .CLK1 (),
+  .CLKDIV (),
+  .D1       (ba_90[ba_ioi]),
+  .D2       (ba_90[ba_ioi]),
+  .D3 (),
+  .D4 (),
+  .IOCE     (pll_ce_0),
+  .OCE      (1'b1),
+  .RST      (int_sys_rst),
+  .SHIFTIN1 (),
+  .SHIFTIN2 (),
+  .SHIFTIN3 (),
+  .SHIFTIN4 (),
+  .T1(1'b0),
+  .T2(1'b0),
+  .T3(),
+  .T4(),
+  .TCE(1'b1),
+  .TRAIN    (1'b0)
+    );
+ end       
+   endgenerate
+
+////////
+//CAS
+////////
+
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_MASTER),          // MASTER, SLAVE
+  .DATA_WIDTH    (2)           // {1..8} 
+) ioi_cas_0 
+(
+  .OQ       (ioi_cas),
+  .SHIFTOUT1 (),
+  .SHIFTOUT2 (),
+  .SHIFTOUT3 (),
+  .SHIFTOUT4 (),
+  .TQ       (t_cas),
+  .CLK0     (ioclk0),
+  .CLK1 (),
+  .CLKDIV (),
+  .D1       (cas_90),
+  .D2       (cas_90),
+  .D3 (),
+  .D4 (),
+  .IOCE     (pll_ce_0),
+  .OCE      (1'b1),
+  .RST      (int_sys_rst),
+  .SHIFTIN1 (),
+  .SHIFTIN2 (),
+  .SHIFTIN3 (),
+  .SHIFTIN4 (),
+  .T1(1'b0),
+  .T2(1'b0),
+  .T3(),
+  .T4(),
+  .TCE(1'b1),
+  .TRAIN    (1'b0)
+    );
+
+////////
+//CKE
+////////
+
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_MASTER),          // MASTER, SLAVE
+  .DATA_WIDTH    (2)    ,       // {1..8} 
+  .TRAIN_PATTERN (15)
+) ioi_cke_0 
+(
+  .OQ       (ioi_cke),
+  .SHIFTOUT1 (),
+  .SHIFTOUT2 (),
+  .SHIFTOUT3 (),
+  .SHIFTOUT4 (),
+  .TQ       (t_cke),
+  .CLK0     (ioclk0),
+  .CLK1 (),
+  .CLKDIV (),
+  .D1       (cke_90),
+  .D2       (cke_90),
+  .D3 (),
+  .D4 (),
+  .IOCE     (pll_ce_0),
+  .OCE      (1'b1),
+  .RST      (1'b0),//int_sys_rst
+  .SHIFTIN1 (),
+  .SHIFTIN2 (),
+  .SHIFTIN3 (),
+  .SHIFTIN4 (),
+  .T1(1'b0),
+  .T2(1'b0),
+  .T3(),
+  .T4(),
+  .TCE(1'b1),
+  .TRAIN    (cke_train)
+    );
+
+////////
+//ODT
+////////
+generate
+if(C_MEM_TYPE == "DDR3" || C_MEM_TYPE == "DDR2" ) begin : gen_ioi_odt
+
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_MASTER),          // MASTER, SLAVE
+  .DATA_WIDTH    (2)           // {1..8} 
+) ioi_odt_0 
+(
+  .OQ       (ioi_odt),
+  .SHIFTOUT1 (),
+  .SHIFTOUT2 (),
+  .SHIFTOUT3 (),
+  .SHIFTOUT4 (),
+  .TQ       (t_odt),
+  .CLK0     (ioclk0),
+  .CLK1 (),
+  .CLKDIV (),
+  .D1       (odt_90),
+  .D2       (odt_90),
+  .D3 (),
+  .D4 (),
+  .IOCE     (pll_ce_0),
+  .OCE      (1'b1),
+  .RST      (int_sys_rst),
+  .SHIFTIN1 (),
+  .SHIFTIN2 (),
+  .SHIFTIN3 (),
+  .SHIFTIN4 (),
+  .T1(1'b0),
+  .T2(1'b0),
+  .T3(),
+  .T4(),
+  .TCE(1'b1),
+  .TRAIN    (1'b0)
+    );
+end
+endgenerate
+////////
+//RAS
+////////
+
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_MASTER),          // MASTER, SLAVE
+  .DATA_WIDTH    (2)           // {1..8} 
+) ioi_ras_0 
+(
+  .OQ       (ioi_ras),
+  .SHIFTOUT1 (),
+  .SHIFTOUT2 (),
+  .SHIFTOUT3 (),
+  .SHIFTOUT4 (),
+  .TQ       (t_ras),
+  .CLK0     (ioclk0),
+  .CLK1 (),
+  .CLKDIV (),
+  .D1       (ras_90),
+  .D2       (ras_90),
+  .D3 (),
+  .D4 (),
+  .IOCE     (pll_ce_0),
+  .OCE      (1'b1),
+  .RST      (int_sys_rst),
+  .SHIFTIN1 (),
+  .SHIFTIN2 (),
+  .SHIFTIN3 (),
+  .SHIFTIN4 (),
+  .T1 (1'b0),
+  .T2 (1'b0),
+  .T3 (),
+  .T4 (),
+  .TCE (1'b1),
+  .TRAIN    (1'b0)
+    );
+
+////////
+//RST
+////////
+generate 
+if (C_MEM_TYPE == "DDR3"  ) begin : gen_ioi_rst
+
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_MASTER),          // MASTER, SLAVE
+  .DATA_WIDTH    (2)           // {1..8} 
+) ioi_rst_0 
+(
+  .OQ       (ioi_rst),
+  .SHIFTOUT1 (),
+  .SHIFTOUT2 (),
+  .SHIFTOUT3 (),
+  .SHIFTOUT4 (),
+  .TQ       (t_rst),
+  .CLK0     (ioclk0),
+  .CLK1 (),
+  .CLKDIV (),
+  .D1       (rst_90),
+  .D2       (rst_90),
+  .D3 (),
+  .D4 (),
+  .IOCE     (pll_ce_0),
+  .OCE      (1'b1),
+  .RST      (int_sys_rst),
+  .SHIFTIN1 (),
+  .SHIFTIN2 (),
+  .SHIFTIN3 (),
+  .SHIFTIN4 (),
+  .T1(1'b0),
+  .T2(1'b0),
+  .T3(),
+  .T4(),
+  .TCE(1'b1),
+  .TRAIN    (1'b0)
+    );
+end
+endgenerate
+////////
+//WE
+////////
+
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_MASTER),          // MASTER, SLAVE
+  .DATA_WIDTH    (2)           // {1..8} 
+) ioi_we_0 
+(
+  .OQ       (ioi_we),
+  .TQ       (t_we),
+  .SHIFTOUT1 (),
+  .SHIFTOUT2 (),
+  .SHIFTOUT3 (),
+  .SHIFTOUT4 (),
+  .CLK0     (ioclk0),
+  .CLK1 (),
+  .CLKDIV (),
+  .D1       (we_90),
+  .D2       (we_90),
+  .D3 (),
+  .D4 (),
+  .IOCE     (pll_ce_0),
+  .OCE      (1'b1),
+  .RST      (int_sys_rst),
+  .SHIFTIN1 (),
+  .SHIFTIN2 (),
+  .SHIFTIN3 (),
+  .SHIFTIN4 (),
+  .T1(1'b0),
+  .T2(1'b0),
+  .T3(),
+  .T4(),
+  .TCE(1'b1),
+  .TRAIN    (1'b0)
+);
+
+////////
+//CK
+////////
+
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_MASTER),          // MASTER, SLAVE
+  .DATA_WIDTH    (2)           // {1..8} 
+) ioi_ck_0 
+(
+  .OQ       (ioi_ck),
+  .SHIFTOUT1(),
+  .SHIFTOUT2(),
+  .SHIFTOUT3(),
+  .SHIFTOUT4(),
+  .TQ       (t_ck),
+  .CLK0     (ioclk0),
+  .CLK1(),
+  .CLKDIV(),
+  .D1       (1'b0),
+  .D2       (1'b1),
+  .D3(),
+  .D4(),
+  .IOCE     (pll_ce_0),
+  .OCE      (1'b1),
+  .RST      (1'b0),//int_sys_rst
+  .SHIFTIN1(),
+  .SHIFTIN2(),
+  .SHIFTIN3 (),
+  .SHIFTIN4 (),
+  .T1(1'b0),
+  .T2(1'b0),
+  .T3(),
+  .T4(),
+  .TCE(1'b1),
+  .TRAIN    (1'b0)
+);
+
+////////
+//CKN
+////////
+/*
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_SLAVE),          // MASTER, SLAVE
+  .DATA_WIDTH    (2)           // {1..8} 
+) ioi_ckn_0 
+(
+  .OQ       (ioi_ckn),
+  .SHIFTOUT1(),
+  .SHIFTOUT2(),
+  .SHIFTOUT3(),
+  .SHIFTOUT4(),
+  .TQ       (t_ckn),
+  .CLK0     (ioclk0),
+  .CLK1(),
+  .CLKDIV(),
+  .D1       (1'b1),
+  .D2       (1'b0),
+  .D3(),
+  .D4(),
+  .IOCE     (pll_ce_0),
+  .OCE      (1'b1),
+  .RST      (1'b0),//int_sys_rst
+  .SHIFTIN1 (),
+  .SHIFTIN2 (),
+  .SHIFTIN3(),
+  .SHIFTIN4(),
+  .T1(1'b0),
+  .T2(1'b0),
+  .T3(),
+  .T4(),
+  .TCE(1'b1),
+  .TRAIN    (1'b0)
+);
+*/
+
+////////
+//UDM
+////////
+
+wire udm_oq;
+wire udm_t;
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_MASTER),          // MASTER, SLAVE
+  .DATA_WIDTH    (2)           // {1..8} 
+) ioi_udm_0 
+(
+  .OQ       (udm_oq),
+  .SHIFTOUT1 (),
+  .SHIFTOUT2 (),
+  .SHIFTOUT3 (),
+  .SHIFTOUT4 (),
+  .TQ       (udm_t),
+  .CLK0     (ioclk90),
+  .CLK1 (),
+  .CLKDIV (),
+  .D1       (dqpum),
+  .D2       (dqnum),
+  .D3 (),
+  .D4 (),
+  .IOCE     (pll_ce_90),
+  .OCE      (1'b1),
+  .RST      (int_sys_rst),
+  .SHIFTIN1 (),
+  .SHIFTIN2 (),
+  .SHIFTIN3 (),
+  .SHIFTIN4 (),
+  .T1       (dqIO_w_en_0),
+  .T2       (dqIO_w_en_0),
+  .T3 (),
+  .T4 (),
+  .TCE      (1'b1),
+  .TRAIN    (1'b0)
+);
+
+////////
+//LDM
+////////
+wire ldm_oq;
+wire ldm_t;
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_MASTER),          // MASTER, SLAVE
+  .DATA_WIDTH    (2)           // {1..8} 
+) ioi_ldm_0 
+(
+  .OQ       (ldm_oq),
+  .SHIFTOUT1 (),
+  .SHIFTOUT2 (),
+  .SHIFTOUT3 (),
+  .SHIFTOUT4 (),
+  .TQ       (ldm_t),
+  .CLK0     (ioclk90),
+  .CLK1 (),
+  .CLKDIV (),
+  .D1       (dqplm),
+  .D2       (dqnlm),
+  .D3 (),
+  .D4 (),
+  .IOCE     (pll_ce_90),
+  .OCE      (1'b1),
+  .RST      (int_sys_rst),
+  .SHIFTIN1 (),
+  .SHIFTIN2 (),
+  .SHIFTIN3 (),
+  .SHIFTIN4 (),
+  .T1       (dqIO_w_en_0),
+  .T2       (dqIO_w_en_0),
+  .T3 (),
+  .T4 (),
+  .TCE      (1'b1),
+  .TRAIN    (1'b0)
+);
+
+////////
+//DQ
+////////
+
+wire dq_oq [C_NUM_DQ_PINS-1:0];
+wire dq_tq [C_NUM_DQ_PINS-1:0];
+
+genvar dq;
+generate
+      for(dq = 0; dq < C_NUM_DQ_PINS; dq = dq + 1) begin : gen_dq
+
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_MASTER),          // MASTER, SLAVE
+  .DATA_WIDTH    (2),           // {1..8} 
+  .TRAIN_PATTERN (5)            // {0..15}             
+) oserdes2_dq_0 
+(
+  .OQ       (dq_oq[dq]),
+  .SHIFTOUT1 (),
+  .SHIFTOUT2 (),
+  .SHIFTOUT3 (),
+  .SHIFTOUT4 (),
+  .TQ       (dq_tq[dq]),
+  .CLK0     (ioclk90),
+  .CLK1 (),
+  .CLKDIV (),
+  .D1       (dqo_p[dq]),
+  .D2       (dqo_n[dq]),
+  .D3 (),
+  .D4 (),
+  .IOCE     (pll_ce_90),
+  .OCE      (1'b1),
+  .RST      (int_sys_rst),
+  .SHIFTIN1 (),
+  .SHIFTIN2 (),
+  .SHIFTIN3 (),
+  .SHIFTIN4 (),
+  .T1       (dqIO_w_en_0),
+  .T2       (dqIO_w_en_0),
+  .T3 (),
+  .T4 (),
+  .TCE      (1'b1),
+  .TRAIN    (ioi_drp_train)
+);
+
+end
+endgenerate
+
+////////
+//DQSP
+////////
+
+wire dqsp_oq ;
+wire dqsp_tq ;
+
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_MASTER),          // MASTER, SLAVE
+  .DATA_WIDTH    (2)           // {1..8} 
+) oserdes2_dqsp_0 
+(
+  .OQ       (dqsp_oq),
+  .SHIFTOUT1(),
+  .SHIFTOUT2(),
+  .SHIFTOUT3(),
+  .SHIFTOUT4(),
+  .TQ       (dqsp_tq),
+  .CLK0     (ioclk0),
+  .CLK1(),
+  .CLKDIV(),
+  .D1       (1'b0),
+  .D2       (1'b1),
+  .D3(),
+  .D4(),
+  .IOCE     (pll_ce_0),
+  .OCE      (1'b1),
+  .RST      (int_sys_rst),
+  .SHIFTIN1(),
+  .SHIFTIN2(),
+  .SHIFTIN3 (),
+  .SHIFTIN4 (),
+  .T1       (dqsIO_w_en_90_n),
+  .T2       (dqsIO_w_en_90_p),
+  .T3(),
+  .T4(),
+  .TCE      (1'b1),
+  .TRAIN    (1'b0)
+);
+
+////////
+//DQSN
+////////
+
+wire dqsn_oq ;
+wire dqsn_tq ;
+
+
+
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_SLAVE),          // MASTER, SLAVE
+  .DATA_WIDTH    (2)           // {1..8} 
+) oserdes2_dqsn_0 
+(
+  .OQ       (dqsn_oq),
+  .SHIFTOUT1(),
+  .SHIFTOUT2(),
+  .SHIFTOUT3(),
+  .SHIFTOUT4(),
+  .TQ       (dqsn_tq),
+  .CLK0     (ioclk0),
+  .CLK1(),
+  .CLKDIV(),
+  .D1       (1'b1),
+  .D2       (1'b0),
+  .D3(),
+  .D4(),
+  .IOCE     (pll_ce_0),
+  .OCE      (1'b1),
+  .RST      (int_sys_rst),
+  .SHIFTIN1 (),
+  .SHIFTIN2 (),
+  .SHIFTIN3(),
+  .SHIFTIN4(),
+  .T1       (dqsIO_w_en_90_n),
+  .T2       (dqsIO_w_en_90_p),
+  .T3(),
+  .T4(),
+  .TCE      (1'b1),
+  .TRAIN    (1'b0)
+);
+
+////////
+//UDQSP
+////////
+
+wire udqsp_oq ;
+wire udqsp_tq ;
+
+
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_MASTER),          // MASTER, SLAVE
+  .DATA_WIDTH    (2)           // {1..8} 
+) oserdes2_udqsp_0 
+(
+  .OQ       (udqsp_oq),
+  .SHIFTOUT1(),
+  .SHIFTOUT2(),
+  .SHIFTOUT3(),
+  .SHIFTOUT4(),
+  .TQ       (udqsp_tq),
+  .CLK0     (ioclk0),
+  .CLK1(),
+  .CLKDIV(),
+  .D1       (1'b0),
+  .D2       (1'b1),
+  .D3(),
+  .D4(),
+  .IOCE     (pll_ce_0),
+  .OCE      (1'b1),
+  .RST      (int_sys_rst),
+  .SHIFTIN1(),
+  .SHIFTIN2(),
+  .SHIFTIN3 (),
+  .SHIFTIN4 (),
+  .T1       (dqsIO_w_en_90_n),
+  .T2       (dqsIO_w_en_90_p),
+  .T3(),
+  .T4(),
+  .TCE      (1'b1),
+  .TRAIN    (1'b0)
+);
+
+////////
+//UDQSN
+////////
+
+wire udqsn_oq ;
+wire udqsn_tq ;
+
+OSERDES2 #(
+  .BYPASS_GCLK_FF ("TRUE"),
+  .DATA_RATE_OQ  (C_OSERDES2_DATA_RATE_OQ),         // SDR, DDR      | Data Rate setting
+  .DATA_RATE_OT  (C_OSERDES2_DATA_RATE_OT),         // SDR, DDR, BUF | Tristate Rate setting.
+  .OUTPUT_MODE   (C_OSERDES2_OUTPUT_MODE_SE),          // SINGLE_ENDED, DIFFERENTIAL
+  .SERDES_MODE   (C_OSERDES2_SERDES_MODE_SLAVE),          // MASTER, SLAVE
+  .DATA_WIDTH    (2)           // {1..8} 
+) oserdes2_udqsn_0 
+(
+  .OQ       (udqsn_oq),
+  .SHIFTOUT1(),
+  .SHIFTOUT2(),
+  .SHIFTOUT3(),
+  .SHIFTOUT4(),
+  .TQ       (udqsn_tq),
+  .CLK0     (ioclk0),
+  .CLK1(),
+  .CLKDIV(),
+  .D1       (1'b1),
+  .D2       (1'b0),
+  .D3(),
+  .D4(),
+  .IOCE     (pll_ce_0),
+  .OCE      (1'b1),
+  .RST      (int_sys_rst),
+  .SHIFTIN1 (),
+  .SHIFTIN2 (),
+  .SHIFTIN3(),
+  .SHIFTIN4(),
+  .T1       (dqsIO_w_en_90_n),
+  .T2       (dqsIO_w_en_90_p),
+  .T3(),
+  .T4(),
+  .TCE      (1'b1),
+  .TRAIN    (1'b0)
+);
+
+////////////////////////////////////////////////////////
+//OSDDRES2 instantiations end
+///////////////////////////////////////////////////////
+
+wire aux_sdi_out_udqsp;
+wire aux_sdi_out_10;
+wire aux_sdi_out_11;
+wire aux_sdi_out_12;
+wire aux_sdi_out_14;
+wire aux_sdi_out_15;
+
+////////////////////////////////////////////////
+//IODRP2 instantiations
+////////////////////////////////////////////////
+generate
+if(C_NUM_DQ_PINS == 16 ) begin : dq_15_0_data
+////////////////////////////////////////////////
+//IODRP2 instantiations
+////////////////////////////////////////////////
+
+wire aux_sdi_out_14;
+wire aux_sdi_out_15;
+////////////////////////////////////////////////
+//DQ14
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ14_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (7),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+)
+iodrp2_dq_14
+(
+  .AUXSDO             (aux_sdi_out_14),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[14]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[14]),
+  .SDO(),
+  .TOUT               (t_dq[14]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_15),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[14]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[14]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[14]) 
+);
+
+
+/////////////////////////////////////////////////
+//DQ15
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ15_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (7),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_15
+(
+  .AUXSDO             (aux_sdi_out_15),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[15]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[15]),
+  .SDO(),
+  .TOUT               (t_dq[15]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (1'b0),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[15]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[15]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[15]) 
+);
+
+
+
+wire aux_sdi_out_12;
+wire aux_sdi_out_13;
+/////////////////////////////////////////////////
+//DQ12
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ12_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (6),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_12
+(
+  .AUXSDO             (aux_sdi_out_12),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[12]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[12]),
+  .SDO(),
+  .TOUT               (t_dq[12]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_13),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[12]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[12]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[12]) 
+);
+
+
+
+/////////////////////////////////////////////////
+//DQ13
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ13_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (6),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_13
+(
+  .AUXSDO             (aux_sdi_out_13),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[13]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[13]),
+  .SDO(),
+  .TOUT               (t_dq[13]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_14),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[13]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[13]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[13]) 
+);
+
+
+wire aux_sdi_out_udqsp;
+wire aux_sdi_out_udqsn;
+/////////
+//UDQSP
+/////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQS_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (UDQSP_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (14),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQS_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_udqsp_0
+(
+  .AUXSDO             (aux_sdi_out_udqsp),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_udqs),
+  .DQSOUTN(),
+  .DQSOUTP            (idelay_udqs_ioi_m),
+  .SDO(),
+  .TOUT               (t_udqs),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_udqsn),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_udqsp),
+  .IOCLK0             (ioclk0),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (udqsp_oq),
+  .SDI                (ioi_drp_sdo),
+  .T                  (udqsp_tq) 
+);
+
+/////////
+//UDQSN
+/////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQS_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (UDQSN_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (14),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQS_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_udqsn_0
+(
+  .AUXSDO             (aux_sdi_out_udqsn),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_udqsn),
+  .DQSOUTN(),
+  .DQSOUTP            (idelay_udqs_ioi_s),
+  .SDO(),
+  .TOUT               (t_udqsn),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_12),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_udqsp),
+  .IOCLK0             (ioclk0),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (udqsn_oq),
+  .SDI                (ioi_drp_sdo),
+  .T                  (udqsn_tq) 
+);
+
+
+wire aux_sdi_out_10;
+wire aux_sdi_out_11;
+/////////////////////////////////////////////////
+//DQ10
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ10_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (5),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_10
+(
+  .AUXSDO             (aux_sdi_out_10),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[10]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[10]),
+  .SDO(),
+  .TOUT               (t_dq[10]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_11),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[10]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[10]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[10]) 
+);
+
+
+/////////////////////////////////////////////////
+//DQ11
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ11_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (5),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_11
+(
+  .AUXSDO             (aux_sdi_out_11),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[11]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[11]),
+  .SDO(),
+  .TOUT               (t_dq[11]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_udqsp),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[11]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[11]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[11])
+);
+
+
+
+wire aux_sdi_out_8;
+wire aux_sdi_out_9;
+/////////////////////////////////////////////////
+//DQ8
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ8_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (4),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_8
+(
+  .AUXSDO             (aux_sdi_out_8),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[8]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[8]),
+  .SDO(),
+  .TOUT               (t_dq[8]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_9),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[8]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[8]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[8]) 
+);
+
+
+/////////////////////////////////////////////////
+//DQ9
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ9_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (4),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_9
+(
+  .AUXSDO             (aux_sdi_out_9),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[9]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[9]),
+  .SDO(),
+  .TOUT               (t_dq[9]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_10),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[9]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[9]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[9]) 
+);
+
+
+wire aux_sdi_out_0;
+wire aux_sdi_out_1;
+/////////////////////////////////////////////////
+//DQ0
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ0_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (0),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_0
+(
+  .AUXSDO             (aux_sdi_out_0),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[0]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[0]),
+  .SDO(),
+  .TOUT               (t_dq[0]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_1),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[0]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[0]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[0]) 
+);
+
+
+/////////////////////////////////////////////////
+//DQ1
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ1_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (0),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_1
+(
+  .AUXSDO             (aux_sdi_out_1),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[1]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[1]),
+  .SDO(),
+  .TOUT               (t_dq[1]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_8),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[1]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[1]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[1]) 
+);
+
+
+wire aux_sdi_out_2;
+wire aux_sdi_out_3;
+/////////////////////////////////////////////////
+//DQ2
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ2_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (1),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_2
+(
+  .AUXSDO             (aux_sdi_out_2),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[2]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[2]),
+  .SDO(),
+  .TOUT               (t_dq[2]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_3),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[2]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[2]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[2]) 
+);
+
+
+/////////////////////////////////////////////////
+//DQ3
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ3_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (1),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_3
+(
+  .AUXSDO             (aux_sdi_out_3),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[3]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[3]),
+  .SDO(),
+  .TOUT               (t_dq[3]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_0),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[3]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[3]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[3]) 
+);
+
+
+wire aux_sdi_out_dqsp;
+wire aux_sdi_out_dqsn;
+/////////
+//DQSP
+/////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQS_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (LDQSP_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (15),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQS_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dqsp_0
+(
+  .AUXSDO             (aux_sdi_out_dqsp),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dqs),
+  .DQSOUTN(),
+  .DQSOUTP            (idelay_dqs_ioi_m),
+  .SDO(),
+  .TOUT               (t_dqs),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_dqsn),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dqsp),
+  .IOCLK0             (ioclk0),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dqsp_oq),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dqsp_tq) 
+);
+
+/////////
+//DQSN
+/////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQS_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (LDQSN_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (15),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQS_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dqsn_0
+(
+  .AUXSDO             (aux_sdi_out_dqsn),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dqsn),
+  .DQSOUTN(),
+  .DQSOUTP            (idelay_dqs_ioi_s),
+  .SDO(),
+  .TOUT               (t_dqsn),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_2),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dqsp),
+  .IOCLK0             (ioclk0),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dqsn_oq),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dqsn_tq) 
+);
+
+wire aux_sdi_out_6;
+wire aux_sdi_out_7;
+/////////////////////////////////////////////////
+//DQ6
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ6_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (3),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_6
+(
+  .AUXSDO             (aux_sdi_out_6),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[6]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[6]),
+  .SDO(),
+  .TOUT               (t_dq[6]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_7),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[6]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[6]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[6]) 
+);
+
+/////////////////////////////////////////////////
+//DQ7
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ7_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (3),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_7
+(
+  .AUXSDO             (aux_sdi_out_7),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[7]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[7]),
+  .SDO(),
+  .TOUT               (t_dq[7]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_dqsp),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[7]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[7]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[7]) 
+);
+
+
+
+wire aux_sdi_out_4;
+wire aux_sdi_out_5;
+/////////////////////////////////////////////////
+//DQ4
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ4_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (2),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_4
+(
+  .AUXSDO             (aux_sdi_out_4),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[4]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[4]),
+  .SDO(),
+  .TOUT               (t_dq[4]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_5),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[4]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[4]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[4]) 
+);
+
+/////////////////////////////////////////////////
+//DQ5
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ5_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (2),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_5
+(
+  .AUXSDO             (aux_sdi_out_5),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[5]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[5]),
+  .SDO(),
+  .TOUT               (t_dq[5]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_6),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[5]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[5]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[5]) 
+);
+
+
+//wire aux_sdi_out_udm;
+wire aux_sdi_out_ldm;
+/////////////////////////////////////////////////
+//UDM
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (0),  // 0 to 255 inclusive
+.MCB_ADDRESS          (8),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_udm
+(
+  .AUXSDO             (ioi_drp_sdi),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_udm),
+  .DQSOUTN(),
+  .DQSOUTP(),
+  .SDO(),
+  .TOUT               (t_udm),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_ldm),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN(),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (udm_oq),
+  .SDI                (ioi_drp_sdo),
+  .T                  (udm_t) 
+);
+
+
+/////////////////////////////////////////////////
+//LDM
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (0),  // 0 to 255 inclusive
+.MCB_ADDRESS          (8),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_ldm
+(
+  .AUXSDO             (aux_sdi_out_ldm),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_ldm),
+  .DQSOUTN(),
+  .DQSOUTP(),
+  .SDO(),
+  .TOUT               (t_ldm),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_4),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN(),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (ldm_oq),
+  .SDI                (ioi_drp_sdo),
+  .T                  (ldm_t) 
+);
+end
+endgenerate
+
+generate
+if(C_NUM_DQ_PINS == 8 ) begin : dq_7_0_data
+wire aux_sdi_out_0;
+wire aux_sdi_out_1;
+/////////////////////////////////////////////////
+//DQ0
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ0_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (0),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_0
+(
+  .AUXSDO             (aux_sdi_out_0),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[0]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[0]),
+  .SDO(),
+  .TOUT               (t_dq[0]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_1),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[0]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[0]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[0]) 
+);
+
+
+/////////////////////////////////////////////////
+//DQ1
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ1_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (0),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_1
+(
+  .AUXSDO             (aux_sdi_out_1),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[1]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[1]),
+  .SDO(),
+  .TOUT               (t_dq[1]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (1'b0),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[1]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[1]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[1]) 
+);
+
+
+wire aux_sdi_out_2;
+wire aux_sdi_out_3;
+/////////////////////////////////////////////////
+//DQ2
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ2_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (1),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_2
+(
+  .AUXSDO             (aux_sdi_out_2),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[2]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[2]),
+  .SDO(),
+  .TOUT               (t_dq[2]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_3),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[2]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[2]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[2]) 
+);
+
+
+/////////////////////////////////////////////////
+//DQ3
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ3_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (1),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_3
+(
+  .AUXSDO             (aux_sdi_out_3),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[3]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[3]),
+  .SDO(),
+  .TOUT               (t_dq[3]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_0),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[3]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[3]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[3]) 
+);
+
+
+wire aux_sdi_out_dqsp;
+wire aux_sdi_out_dqsn;
+/////////
+//DQSP
+/////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQS_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (LDQSP_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (15),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQS_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dqsp_0
+(
+  .AUXSDO             (aux_sdi_out_dqsp),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dqs),
+  .DQSOUTN(),
+  .DQSOUTP            (idelay_dqs_ioi_m),
+  .SDO(),
+  .TOUT               (t_dqs),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_dqsn),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dqsp),
+  .IOCLK0             (ioclk0),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dqsp_oq),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dqsp_tq) 
+);
+
+/////////
+//DQSN
+/////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQS_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (LDQSN_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (15),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQS_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dqsn_0
+(
+  .AUXSDO             (aux_sdi_out_dqsn),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dqsn),
+  .DQSOUTN(),
+  .DQSOUTP            (idelay_dqs_ioi_s),
+  .SDO(),
+  .TOUT               (t_dqsn),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_2),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dqsp),
+  .IOCLK0             (ioclk0),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dqsn_oq),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dqsn_tq) 
+);
+
+wire aux_sdi_out_6;
+wire aux_sdi_out_7;
+/////////////////////////////////////////////////
+//DQ6
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ6_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (3),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_6
+(
+  .AUXSDO             (aux_sdi_out_6),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[6]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[6]),
+  .SDO(),
+  .TOUT               (t_dq[6]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_7),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[6]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[6]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[6]) 
+);
+
+/////////////////////////////////////////////////
+//DQ7
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ7_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (3),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_7
+(
+  .AUXSDO             (aux_sdi_out_7),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[7]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[7]),
+  .SDO(),
+  .TOUT               (t_dq[7]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_dqsp),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[7]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[7]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[7]) 
+);
+
+
+
+wire aux_sdi_out_4;
+wire aux_sdi_out_5;
+/////////////////////////////////////////////////
+//DQ4
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ4_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (2),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_4
+(
+  .AUXSDO             (aux_sdi_out_4),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[4]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[4]),
+  .SDO(),
+  .TOUT               (t_dq[4]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_5),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[4]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[4]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[4]) 
+);
+
+/////////////////////////////////////////////////
+//DQ5
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ5_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (2),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_5
+(
+  .AUXSDO             (aux_sdi_out_5),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[5]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[5]),
+  .SDO(),
+  .TOUT               (t_dq[5]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_6),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[5]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[5]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[5]) 
+);
+
+//NEED TO GENERATE UDM so that user won't instantiate in this location
+//wire aux_sdi_out_udm;
+wire aux_sdi_out_ldm;
+/////////////////////////////////////////////////
+//UDM
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (0),  // 0 to 255 inclusive
+.MCB_ADDRESS          (8),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_udm
+(
+  .AUXSDO             (ioi_drp_sdi),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_udm),
+  .DQSOUTN(),
+  .DQSOUTP(),
+  .SDO(),
+  .TOUT               (t_udm),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_ldm),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN(),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (udm_oq),
+  .SDI                (ioi_drp_sdo),
+  .T                  (udm_t) 
+);
+
+
+/////////////////////////////////////////////////
+//LDM
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (0),  // 0 to 255 inclusive
+.MCB_ADDRESS          (8),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_ldm
+(
+  .AUXSDO             (aux_sdi_out_ldm),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_ldm),
+  .DQSOUTN(),
+  .DQSOUTP(),
+  .SDO(),
+  .TOUT               (t_ldm),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_4),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN(),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (ldm_oq),
+  .SDI                (ioi_drp_sdo),
+  .T                  (ldm_t) 
+);
+end
+endgenerate
+
+generate
+if(C_NUM_DQ_PINS == 4 ) begin : dq_3_0_data
+
+wire aux_sdi_out_0;
+wire aux_sdi_out_1;
+/////////////////////////////////////////////////
+//DQ0
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ0_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (0),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_0
+(
+  .AUXSDO             (aux_sdi_out_0),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[0]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[0]),
+  .SDO(),
+  .TOUT               (t_dq[0]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_1),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[0]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[0]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[0]) 
+);
+
+
+/////////////////////////////////////////////////
+//DQ1
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ1_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (0),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_1
+(
+  .AUXSDO             (aux_sdi_out_1),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[1]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[1]),
+  .SDO(),
+  .TOUT               (t_dq[1]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (1'b0),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[1]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[1]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[1]) 
+);
+
+
+wire aux_sdi_out_2;
+wire aux_sdi_out_3;
+/////////////////////////////////////////////////
+//DQ2
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ2_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (1),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_2
+(
+  .AUXSDO             (aux_sdi_out_2),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[2]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[2]),
+  .SDO(),
+  .TOUT               (t_dq[2]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_3),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[2]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[2]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[2]) 
+);
+
+
+/////////////////////////////////////////////////
+//DQ3
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (DQ3_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (1),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_3
+(
+  .AUXSDO             (aux_sdi_out_3),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dq[3]),
+  .DQSOUTN(),
+  .DQSOUTP            (in_dq[3]),
+  .SDO(),
+  .TOUT               (t_dq[3]),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_0),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dq[3]),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dq_oq[3]),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dq_tq[3]) 
+);
+
+
+wire aux_sdi_out_dqsp;
+wire aux_sdi_out_dqsn;
+/////////
+//DQSP
+/////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQS_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (LDQSP_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (15),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQS_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dqsp_0
+(
+  .AUXSDO             (aux_sdi_out_dqsp),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dqs),
+  .DQSOUTN(),
+  .DQSOUTP            (idelay_dqs_ioi_m),
+  .SDO(),
+  .TOUT               (t_dqs),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_dqsn),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dqsp),
+  .IOCLK0             (ioclk0),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dqsp_oq),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dqsp_tq) 
+);
+
+/////////
+//DQSN
+/////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQS_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (LDQSN_TAP_DELAY_VAL),  // 0 to 255 inclusive
+.MCB_ADDRESS          (15),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQS_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dqsn_0
+(
+  .AUXSDO             (aux_sdi_out_dqsn),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_dqsn),
+  .DQSOUTN(),
+  .DQSOUTP            (idelay_dqs_ioi_s),
+  .SDO(),
+  .TOUT               (t_dqsn),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_2),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN            (in_pre_dqsp),
+  .IOCLK0             (ioclk0),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (dqsn_oq),
+  .SDI                (ioi_drp_sdo),
+  .T                  (dqsn_tq) 
+);
+
+//NEED TO GENERATE UDM so that user won't instantiate in this location
+//wire aux_sdi_out_udm;
+wire aux_sdi_out_ldm;
+/////////////////////////////////////////////////
+//UDM
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (0),  // 0 to 255 inclusive
+.MCB_ADDRESS          (8),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_MASTER),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_udm
+(
+  .AUXSDO             (ioi_drp_sdi),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_udm),
+  .DQSOUTN(),
+  .DQSOUTP(),
+  .SDO(),
+  .TOUT               (t_udm),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_ldm),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN(),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (udm_oq),
+  .SDI                (ioi_drp_sdo),
+  .T                  (udm_t) 
+);
+
+
+/////////////////////////////////////////////////
+//LDM
+////////////////////////////////////////////////
+IODRP2_MCB #(
+.DATA_RATE            (C_DQ_IODRP2_DATA_RATE),   // "SDR", "DDR"
+.IDELAY_VALUE         (0),  // 0 to 255 inclusive
+.MCB_ADDRESS          (8),  // 0 to 15
+.ODELAY_VALUE         (0),  // 0 to 255 inclusive
+.SERDES_MODE          (C_DQ_IODRP2_SERDES_MODE_SLAVE),   // "NONE", "MASTER", "SLAVE"
+.SIM_TAPDELAY_VALUE   (10)  // 10 to 90 inclusive
+
+)
+iodrp2_dq_ldm
+(
+  .AUXSDO             (aux_sdi_out_ldm),
+  .DATAOUT(),
+  .DATAOUT2(),
+  .DOUT               (ioi_ldm),
+  .DQSOUTN(),
+  .DQSOUTP(),
+  .SDO(),
+  .TOUT               (t_ldm),
+  .ADD                (ioi_drp_add),
+  .AUXADDR            (ioi_drp_addr),
+  .AUXSDOIN           (aux_sdi_out_4),
+  .BKST               (ioi_drp_broadcast),
+  .CLK                (ioi_drp_clk),
+  .CS                 (ioi_drp_cs),
+  .IDATAIN(),
+  .IOCLK0             (ioclk90),
+  .IOCLK1(),
+  .MEMUPDATE          (ioi_drp_update),
+  .ODATAIN            (ldm_oq),
+  .SDI                (ioi_drp_sdo),
+  .T                  (ldm_t) 
+);
+
+end
+endgenerate
+
+ ////////////////////////////////////////////////
+ //IOBs instantiations
+ // this part need more inputs from design team 
+ // for now just use as listed in fpga.v
+ ////////////////////////////////////////////////
+
+
+//// Address
+
+genvar addr_i;
+   generate 
+      for(addr_i = 0; addr_i < C_MEM_ADDR_WIDTH; addr_i = addr_i + 1) begin : gen_addr_obuft
+        OBUFT iob_addr_inst
+        (.I  ( ioi_addr[addr_i]), 
+         .T   ( t_addr[addr_i]), 
+         .O ( mcbx_dram_addr[addr_i])
+        );
+      end       
+   endgenerate
+
+genvar ba_i;
+   generate 
+      for(ba_i = 0; ba_i < C_MEM_BANKADDR_WIDTH; ba_i = ba_i + 1) begin : gen_ba_obuft
+        OBUFT iob_ba_inst
+        (.I  ( ioi_ba[ba_i]), 
+         .T   ( t_ba[ba_i]), 
+         .O ( mcbx_dram_ba[ba_i])
+        );
+      end       
+   endgenerate
+
+
+
+// DRAM Control
+OBUFT iob_ras (.O(mcbx_dram_ras_n),.I(ioi_ras),.T(t_ras));
+OBUFT iob_cas (.O(mcbx_dram_cas_n),.I(ioi_cas),.T(t_cas));
+OBUFT iob_we  (.O(mcbx_dram_we_n ),.I(ioi_we ),.T(t_we ));
+OBUFT iob_cke (.O(mcbx_dram_cke),.I(ioi_cke),.T(t_cke));
+
+generate 
+if (C_MEM_TYPE == "DDR3") begin : gen_ddr3_rst
+OBUFT iob_rst (.O(mcbx_dram_ddr3_rst),.I(ioi_rst),.T(t_rst));
+end
+endgenerate
+generate
+if((C_MEM_TYPE == "DDR3"  && (C_MEM_DDR3_RTT != "OFF" || C_MEM_DDR3_DYN_WRT_ODT != "OFF"))
+ ||(C_MEM_TYPE == "DDR2" &&  C_MEM_DDR2_RTT != "OFF") ) begin : gen_dram_odt
+OBUFT iob_odt (.O(mcbx_dram_odt),.I(ioi_odt),.T(t_odt));
+end
+endgenerate
+
+// Clock
+OBUFTDS iob_clk  (.I(ioi_ck), .T(t_ck), .O(mcbx_dram_clk), .OB(mcbx_dram_clk_n)); 
+
+//DQ
+genvar dq_i;
+generate
+      for(dq_i = 0; dq_i < C_NUM_DQ_PINS; dq_i = dq_i + 1) begin : gen_dq_iobuft
+         IOBUF gen_iob_dq_inst (.IO(mcbx_dram_dq[dq_i]),.I(ioi_dq[dq_i]),.T(t_dq[dq_i]),.O(in_pre_dq[dq_i]));
+      end
+endgenerate
+
+
+// DQS
+generate 
+if(C_MEM_TYPE == "DDR" || C_MEM_TYPE =="MDDR" || (C_MEM_TYPE == "DDR2" && (C_MEM_DDR2_DIFF_DQS_EN == "NO"))) begin: gen_dqs_iobuf
+IOBUF iob_dqs  (.IO(mcbx_dram_dqs), .I(ioi_dqs),.T(t_dqs),.O(in_pre_dqsp));
+end else begin: gen_dqs_iobufds
+IOBUFDS iob_dqs  (.IO(mcbx_dram_dqs),.IOB(mcbx_dram_dqs_n), .I(ioi_dqs),.T(t_dqs),.O(in_pre_dqsp));
+
+end
+endgenerate
+
+generate
+if((C_MEM_TYPE == "DDR" || C_MEM_TYPE =="MDDR" || (C_MEM_TYPE == "DDR2" && (C_MEM_DDR2_DIFF_DQS_EN == "NO"))) && C_NUM_DQ_PINS == 16) begin: gen_udqs_iobuf
+IOBUF iob_udqs  (.IO(mcbx_dram_udqs), .I(ioi_udqs),.T(t_udqs),.O(in_pre_udqsp));
+end else if(C_NUM_DQ_PINS == 16) begin: gen_udqs_iobufds
+IOBUFDS iob_udqs  (.IO(mcbx_dram_udqs),.IOB(mcbx_dram_udqs_n), .I(ioi_udqs),.T(t_udqs),.O(in_pre_udqsp));
+
+end
+endgenerate
+
+// DQS PULLDWON
+generate 
+if(C_MEM_TYPE == "DDR" || C_MEM_TYPE =="MDDR" || (C_MEM_TYPE == "DDR2" && (C_MEM_DDR2_DIFF_DQS_EN == "NO"))) begin: gen_dqs_pullupdn
+PULLDOWN dqs_pulldown (.O(mcbx_dram_dqs));
+end else begin: gen_dqs_pullupdn_ds
+PULLDOWN dqs_pulldown (.O(mcbx_dram_dqs));
+PULLUP dqs_n_pullup (.O(mcbx_dram_dqs_n));
+
+end
+endgenerate
+
+// DQSN PULLUP
+generate
+if((C_MEM_TYPE == "DDR" || C_MEM_TYPE =="MDDR" || (C_MEM_TYPE == "DDR2" && (C_MEM_DDR2_DIFF_DQS_EN == "NO"))) && C_NUM_DQ_PINS == 16) begin: gen_udqs_pullupdn
+PULLDOWN udqs_pulldown (.O(mcbx_dram_udqs));
+end else if(C_NUM_DQ_PINS == 16) begin: gen_udqs_pullupdn_ds
+PULLDOWN udqs_pulldown (.O(mcbx_dram_udqs));
+PULLUP   udqs_n_pullup (.O(mcbx_dram_udqs_n));
+
+end
+endgenerate
+
+
+
+
+//DM
+//  datamask generation
+generate
+if( C_NUM_DQ_PINS == 16) begin : gen_udm
+OBUFT iob_udm (.I(ioi_udm), .T(t_udm), .O(mcbx_dram_udm)); 
+end
+endgenerate
+
+OBUFT iob_ldm (.I(ioi_ldm), .T(t_ldm), .O(mcbx_dram_ldm)); 
+
+endmodule
+

--- a/systems/atlys/rtl/verilog/xilinx_ddr2/mcb_soft_calibration.v
+++ b/systems/atlys/rtl/verilog/xilinx_ddr2/mcb_soft_calibration.v
@@ -1,0 +1,1268 @@
+//*****************************************************************************
+// (c) Copyright 2009 Xilinx, Inc. All rights reserved.
+//
+// This file contains confidential and proprietary information
+// of Xilinx, Inc. and is protected under U.S. and
+// international copyright and other intellectual property
+// laws.
+//
+// DISCLAIMER
+// This disclaimer is not a license and does not grant any
+// rights to the materials distributed herewith. Except as
+// otherwise provided in a valid license issued to you by
+// Xilinx, and to the maximum extent permitted by applicable
+// law: (1) THESE MATERIALS ARE MADE AVAILABLE "AS IS" AND
+// WITH ALL FAULTS, AND XILINX HEREBY DISCLAIMS ALL WARRANTIES
+// AND CONDITIONS, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING
+// BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, NON-
+// INFRINGEMENT, OR FITNESS FOR ANY PARTICULAR PURPOSE; and
+// (2) Xilinx shall not be liable (whether in contract or tort,
+// including negligence, or under any other theory of
+// liability) for any loss or damage of any kind or nature
+// related to, arising under or in connection with these
+// materials, including for any direct, or any indirect,
+// special, incidental, or consequential loss or damage
+// (including loss of data, profits, goodwill, or any type of
+// loss or damage suffered as a result of any action brought
+// by a third party) even if such damage or loss was
+// reasonably foreseeable or Xilinx had been advised of the
+// possibility of the same.
+//
+// CRITICAL APPLICATIONS
+// Xilinx products are not designed or intended to be fail-
+// safe, or for use in any application requiring fail-safe
+// performance, such as life-support or safety devices or
+// systems, Class III medical devices, nuclear facilities,
+// applications related to the deployment of airbags, or any
+// other applications that could lead to death, personal
+// injury, or severe property or environmental damage
+// (individually and collectively, "Critical
+// Applications"). Customer assumes the sole risk and
+// liability of any use of Xilinx products in Critical
+// Applications, subject only to applicable laws and
+// regulations governing limitations on product liability.
+//
+// THIS COPYRIGHT NOTICE AND DISCLAIMER MUST BE RETAINED AS
+// PART OF THIS FILE AT ALL TIMES.
+//
+//*****************************************************************************
+//   ____  ____
+//  /   /\/   /
+// /___/  \  /    Vendor: Xilinx
+// \   \   \/     Version: %version
+//  \   \         Application: MIG
+//  /   /         Filename: mcb_soft_calibration.v
+// /___/   /\     Date Last Modified: $Date: 2010/10/27 17:40:12 $
+// \   \  /  \    Date Created: Mon Feb 9 2009
+//  \___\/\___\
+//
+//Device: Spartan6
+//Design Name: DDR/DDR2/DDR3/LPDDR
+//Purpose:  Xilinx reference design for MCB Soft
+//           Calibration
+//Reference:
+//
+//  Revision:      Date:  Comment
+//       1.0:  2/06/09:   Initial version for MIG wrapper.
+//       1.1:  2/09/09:   moved Max_Value_Previous assignments to be completely inside CASE statement for next-state logic (needed to get it working correctly)
+//       1.2:  2/12/09:   Many other changes.
+//       1.3:  2/26/09:   Removed section with Max_Value_pre and DQS_COUNT_PREVIOUS_pre, and instead added PREVIOUS_STATE reg and moved assignment to within STATE
+//       1.4:  3/02/09:   Removed comments out of sensitivity list of always block to mux SDI, SDO, CS, and ADD.  Also added reg declaration for PREVIOUS_STATE
+//       1.5:  3/16/09:   Added pll_lock port, and using it to gate reset.  Changing RST (except input port) to RST_reg and gating it with pll_lock.
+//       1.6:  6/05/09:   Added START_DYN_CAL_PRE with pulse on SYSRST; removed MCB_UIDQCOUNT.
+//       1.7:  6/24/09:   Gave RZQ and ZIO each their own unique ADD and SDI nets
+//       2.0:  7/30/09:   Added dynamic Input Termination
+//       2.1:  8/02/09:   Added sampling of DQS input delays to make sure we never decrement below h00 (or increment above hEF).
+//       2.2:  8/04/09:   Added 2's compliment register "DQS_COUNT_VIRTUAL", and signficantly changed the increment/decrement algorythm - now will track a virtual
+//                        negative DQS_COUNT value if needed.  Got rid of DQS_COUNT_UP/DOWN registers
+//       2.3:  10/10/09:  Massive overhaul
+//       2.4:  10/14/09:  Fixed: from START, if SKIP_IN_TERM_CAL go to WRITE_CALIBRATE
+//       2.5:  10/15/09:  Changed OVERRIDE_DQS_CAL to CALMODE_EQ_CALIBRATION, and made it override SKIP_DYNAMIC_CAL (to 1) whenever C_MC_CALIBRATION_MODE="NOCALIBRATION"
+//       2.6:  12/15/09:  Changed STATE from 7-bit to 6-bit.  Dropped (* FSM_ENCODING="BINARY" *) for STATE. Moved MCB_UICMDEN = 0 from OFF_RZQ_PTERM to RST_DELAY. 
+//                        Changed the "reset" always block so that RST_reg is always set to 1 when the PLL loses lock, and is now held in reset for at least 16 clocks.  Added PNSKEW option.
+//       2.7:  12/23/09:  Added new states "SKEW" and "MULTIPLY_DIVIDE" to help with timing.
+//       2.8:  01/14/10:  Added functionality to allow for SUSPEND.  Changed MCB_SYSRST port from wire to reg.
+//       2.9:  02/01/10:  More changes to SUSPEND and Reset logic to handle SUSPEND properly.  Also - eliminated 2's comp DQS_COUNT_VIRTUAL, and replaced with 8bit TARGET_DQS_DELAY which
+//                        will track most recnet Max_Value.  Eliminated DQS_COUNT_PREVIOUS. Combined DQS_COUNT_INITIAL and DQS_Delay into DQS_DELAY_INITIAL.  Changed DQS_COUNT* to DQS_DELAY*.
+//                        Changed MCB_SYSRST port back to wire (from reg).
+//       3.0:  02/10/10:  Added count_inc and count_dec to add a few (4) UI_CLK cycles latency to the INC and DEC signals (to deal with latency on UOREFRSHFLAG)
+//       3.1:  02/23/10:  Registered the DONE_SOFTANDHARD_CAL for timing.   
+//       3.2:  02/28/10:  Corrected the   WAIT_SELFREFRESH_EXIT_DQS_CAL logic;
+//       3.3:  03/02/10:  Changed PNSKEW to default on (1'b1)
+//       3.4:  03/04/10:  Recoded the RST_Reg logic.
+//       3.5:  03/05/10:  Changed Result register to be 16-bits.  Changed DQS_NUMERATOR/DENOMINATOR values to 3/8 (from 6/16)
+//       3.6:  03/10/10:  Improvements to Reset logic    
+//       3.7:  04/12/10:  Added DDR2 Initialization fix to meet 400 ns wait as outlined in step d) of JEDEC DDR2 spec .
+//       3.8:  05/24/10:  Added 200us Wait logic to control CKE_Train. The 200us Wait counter assumes UI_CLK freq not higher than 100 MHz.
+// End Revision
+//**********************************************************************************
+
+
+`timescale 1ps/1ps
+
+module mcb_soft_calibration # (
+  parameter       C_MEM_TZQINIT_MAXCNT  = 10'd512,  // DDR3 Minimum delay between resets
+  parameter       C_MC_CALIBRATION_MODE = "CALIBRATION", // if set to CALIBRATION will reset DQS IDELAY to DQS_NUMERATOR/DQS_DENOMINATOR local_param values
+                                                         // if set to NOCALIBRATION then defaults to hard cal blocks setting of C_MC_CALBRATION_DELAY (Quarter, etc)
+  parameter       C_SIMULATION          = "FALSE",  // Tells us whether the design is being simulated or implemented
+  parameter       SKIP_IN_TERM_CAL      = 1'b0,     // provides option to skip the input termination calibration
+  parameter       SKIP_DYNAMIC_CAL      = 1'b0,     // provides option to skip the dynamic delay calibration
+  parameter       SKIP_DYN_IN_TERM      = 1'b1,      // provides option to skip the input termination calibration
+  parameter       C_MEM_TYPE = "DDR"            // provides the memory device used for the design
+  
+  )
+  (
+  input   wire            UI_CLK,                   // main clock input for logic and IODRP CLK pins.  At top level, this should also connect to IODRP2_MCB CLK pins
+  input   wire            RST,                      // main system reset for both this Soft Calibration block - also will act as a passthrough to MCB's SYSRST
+  (* IOB = "FALSE" *) output  reg            DONE_SOFTANDHARD_CAL,
+                                                    // active high flag signals soft calibration of input delays is complete and MCB_UODONECAL is high (MCB hard calib complete)
+  input   wire            PLL_LOCK,                 // Lock signal from PLL
+  input   wire            SELFREFRESH_REQ,     
+  input   wire            SELFREFRESH_MCB_MODE,
+  output  reg             SELFREFRESH_MCB_REQ ,
+  output  reg             SELFREFRESH_MODE,    
+  output  wire            IODRP_ADD,                // IODRP ADD port
+  output  wire            IODRP_SDI,                // IODRP SDI port
+  input   wire            RZQ_IN,                   // RZQ pin from board - expected to have a 2*R resistor to ground
+  input   wire            RZQ_IODRP_SDO,            // RZQ IODRP's SDO port
+  output  reg             RZQ_IODRP_CS      = 1'b0, // RZQ IODRP's CS port
+  input   wire            ZIO_IN,                   // Z-stated IO pin - garanteed not to be driven externally
+  input   wire            ZIO_IODRP_SDO,            // ZIO IODRP's SDO port
+  output  reg             ZIO_IODRP_CS      = 1'b0, // ZIO IODRP's CS port
+  output  wire            MCB_UIADD,                // to MCB's UIADD port
+  output  wire            MCB_UISDI,                // to MCB's UISDI port
+  input   wire            MCB_UOSDO,                // from MCB's UOSDO port (User output SDO)
+  input   wire            MCB_UODONECAL,            // indicates when MCB hard calibration process is complete
+  input   wire            MCB_UOREFRSHFLAG,         //  high during refresh cycle and time when MCB is innactive
+  output  wire            MCB_UICS,                 // to MCB's UICS port (User Input CS)
+  output  reg             MCB_UIDRPUPDATE   = 1'b1, // MCB's UIDRPUPDATE port (gets passed to IODRP2_MCB's MEMUPDATE port: this controls shadow latch used during IODRP2_MCB writes).  Currently just trasnparent
+  output  wire            MCB_UIBROADCAST,          // only to MCB's UIBROADCAST port (User Input BROADCAST - gets passed to IODRP2_MCB's BKST port)
+  output  reg   [4:0]     MCB_UIADDR        = 5'b0, //  to MCB's UIADDR port (gets passed to IODRP2_MCB's AUXADDR port
+  output  reg             MCB_UICMDEN       = 1'b1, //  set to 1 to take control of UI interface - removes control from internal calib block
+  output  reg             MCB_UIDONECAL     = 1'b0, //  set to 0 to "tell" controller that it's still in a calibrate state
+  output  reg             MCB_UIDQLOWERDEC  = 1'b0,
+  output  reg             MCB_UIDQLOWERINC  = 1'b0,
+  output  reg             MCB_UIDQUPPERDEC  = 1'b0,
+  output  reg             MCB_UIDQUPPERINC  = 1'b0,
+  output  reg             MCB_UILDQSDEC     = 1'b0,
+  output  reg             MCB_UILDQSINC     = 1'b0,
+  output  wire            MCB_UIREAD,               //  enables read w/o writing by turning on a SDO->SDI loopback inside the IODRP2_MCBs (doesn't exist in regular IODRP2).  IODRPCTRLR_R_WB becomes don't-care.
+  output  reg             MCB_UIUDQSDEC     = 1'b0,
+  output  reg             MCB_UIUDQSINC     = 1'b0,
+  output  reg             MCB_RECAL         = 1'b0, //  future hook to drive MCB's RECAL pin - initiates a hard re-calibration sequence when high
+  output  reg             MCB_UICMD,
+  output  reg             MCB_UICMDIN,
+  output  reg   [3:0]     MCB_UIDQCOUNT,
+  input   wire  [7:0]     MCB_UODATA,
+  input   wire            MCB_UODATAVALID,
+  input   wire            MCB_UOCMDREADY,
+  input   wire            MCB_UO_CAL_START,
+  
+  output  wire            MCB_SYSRST,               //  drives the MCB's SYSRST pin - the main reset for MCB
+  output  reg   [7:0]     Max_Value,
+  output  reg            CKE_Train
+  );
+
+
+localparam [4:0]
+          IOI_DQ0       = {4'h0, 1'b1},
+          IOI_DQ1       = {4'h0, 1'b0},
+          IOI_DQ2       = {4'h1, 1'b1},
+          IOI_DQ3       = {4'h1, 1'b0},
+          IOI_DQ4       = {4'h2, 1'b1},
+          IOI_DQ5       = {4'h2, 1'b0},
+          IOI_DQ6       = {4'h3, 1'b1},
+          IOI_DQ7       = {4'h3, 1'b0},
+          IOI_DQ8       = {4'h4, 1'b1},
+          IOI_DQ9       = {4'h4, 1'b0},
+          IOI_DQ10      = {4'h5, 1'b1},
+          IOI_DQ11      = {4'h5, 1'b0},
+          IOI_DQ12      = {4'h6, 1'b1},
+          IOI_DQ13      = {4'h6, 1'b0},
+          IOI_DQ14      = {4'h7, 1'b1},
+          IOI_DQ15      = {4'h7, 1'b0},
+          IOI_UDM       = {4'h8, 1'b1},
+          IOI_LDM       = {4'h8, 1'b0},
+          IOI_CK_P      = {4'h9, 1'b1},
+          IOI_CK_N      = {4'h9, 1'b0},
+          IOI_RESET     = {4'hA, 1'b1},
+          IOI_A11       = {4'hA, 1'b0},
+          IOI_WE        = {4'hB, 1'b1},
+          IOI_BA2       = {4'hB, 1'b0},
+          IOI_BA0       = {4'hC, 1'b1},
+          IOI_BA1       = {4'hC, 1'b0},
+          IOI_RASN      = {4'hD, 1'b1},
+          IOI_CASN      = {4'hD, 1'b0},
+          IOI_UDQS_CLK  = {4'hE, 1'b1},
+          IOI_UDQS_PIN  = {4'hE, 1'b0},
+          IOI_LDQS_CLK  = {4'hF, 1'b1},
+          IOI_LDQS_PIN  = {4'hF, 1'b0};
+
+localparam  [5:0]   START                     = 6'h00,
+                    LOAD_RZQ_NTERM            = 6'h01,
+                    WAIT1                     = 6'h02,
+                    LOAD_RZQ_PTERM            = 6'h03,
+                    WAIT2                     = 6'h04,
+                    INC_PTERM                 = 6'h05,
+                    MULTIPLY_DIVIDE           = 6'h06,
+                    LOAD_ZIO_PTERM            = 6'h07,
+                    WAIT3                     = 6'h08,
+                    LOAD_ZIO_NTERM            = 6'h09,
+                    WAIT4                     = 6'h0A,
+                    INC_NTERM                 = 6'h0B,
+                    SKEW                      = 6'h0C,
+                    WAIT_FOR_START_BROADCAST  = 6'h0D,
+                    BROADCAST_PTERM           = 6'h0E,
+                    WAIT5                     = 6'h0F,
+                    BROADCAST_NTERM           = 6'h10,
+                    WAIT6                     = 6'h11,
+                    OFF_RZQ_PTERM             = 6'h12,
+                    WAIT7                     = 6'h13,
+                    OFF_ZIO_NTERM             = 6'h14,
+                    WAIT8                     = 6'h15,
+                    RST_DELAY                 = 6'h16,
+                    START_DYN_CAL_PRE         = 6'h17,
+                    WAIT_FOR_UODONE           = 6'h18,
+                    LDQS_WRITE_POS_INDELAY    = 6'h19,
+                    LDQS_WAIT1                = 6'h1A,
+                    LDQS_WRITE_NEG_INDELAY    = 6'h1B,
+                    LDQS_WAIT2                = 6'h1C,
+                    UDQS_WRITE_POS_INDELAY    = 6'h1D,
+                    UDQS_WAIT1                = 6'h1E,
+                    UDQS_WRITE_NEG_INDELAY    = 6'h1F,
+                    UDQS_WAIT2                = 6'h20,
+                    START_DYN_CAL             = 6'h21,
+                    WRITE_CALIBRATE           = 6'h22,
+                    WAIT9                     = 6'h23,
+                    READ_MAX_VALUE            = 6'h24,
+                    WAIT10                    = 6'h25,
+                    ANALYZE_MAX_VALUE         = 6'h26,
+                    FIRST_DYN_CAL             = 6'h27,
+                    INCREMENT                 = 6'h28,
+                    DECREMENT                 = 6'h29,
+                    DONE                      = 6'h2A;
+
+localparam  [1:0]   RZQ           = 2'b00,
+                    ZIO           = 2'b01,
+                    MCB_PORT      = 2'b11;
+localparam          WRITE_MODE    = 1'b0;
+localparam          READ_MODE     = 1'b1;
+
+// IOI Registers
+localparam  [7:0]   NoOp          = 8'h00,
+                    DelayControl  = 8'h01,
+                    PosEdgeInDly  = 8'h02,
+                    NegEdgeInDly  = 8'h03,
+                    PosEdgeOutDly = 8'h04,
+                    NegEdgeOutDly = 8'h05,
+                    MiscCtl1      = 8'h06,
+                    MiscCtl2      = 8'h07,
+                    MaxValue      = 8'h08;
+
+// IOB Registers
+localparam  [7:0]   PDrive        = 8'h80,
+                    PTerm         = 8'h81,
+                    NDrive        = 8'h82,
+                    NTerm         = 8'h83,
+                    SlewRateCtl   = 8'h84,
+                    LVDSControl   = 8'h85,
+                    MiscControl   = 8'h86,
+                    InputControl  = 8'h87,
+                    TestReadback  = 8'h88;
+
+// No multi/divide is required when a 55 ohm resister is used on RZQ
+//localparam          MULT          = 1;
+//localparam          DIV           = 1;
+// use 7/4 scaling factor when the 100 ohm RZQ is used
+localparam          MULT          = 7;
+localparam          DIV           = 4;
+
+localparam          PNSKEW        = 1'b1; //Default is 1'b1. Change to 1'b0 if PSKEW and NSKEW are not required
+localparam          PSKEW_MULT    = 9;
+localparam          PSKEW_DIV     = 8;
+localparam          NSKEW_MULT    = 7;
+localparam          NSKEW_DIV     = 8;
+
+localparam          DQS_NUMERATOR   = 3;
+localparam          DQS_DENOMINATOR = 8;
+localparam          INCDEC_THRESHOLD= 8'h03; // parameter for the threshold which triggers an inc/dec to occur.  2 for half, 4 for quarter, 3 for three eighths
+
+reg   [5:0]   P_Term       /* synthesis syn_preserve = 1 */;
+reg   [6:0]   N_Term       /* synthesis syn_preserve = 1 */;
+reg   [5:0]   P_Term_Prev  /* synthesis syn_preserve = 1 */;
+reg   [6:0]   N_Term_Prev  /* synthesis syn_preserve = 1 */;
+//(* FSM_ENCODING="USER" *) reg [5:0] STATE = START;   //XST does not pick up "BINARY" - use COMPACT instead if binary is desired
+reg [5:0] STATE = START;
+reg   [7:0]   IODRPCTRLR_MEMCELL_ADDR /* synthesis syn_preserve = 1 */;
+reg   [7:0]   IODRPCTRLR_WRITE_DATA /* synthesis syn_preserve = 1 */;
+reg   [1:0]   Active_IODRP /* synthesis syn_maxfan = 1 */;
+// synthesis attribute max_fanout of Active_IODRP is 1
+reg           IODRPCTRLR_R_WB = 1'b0;
+reg           IODRPCTRLR_CMD_VALID = 1'b0;
+reg           IODRPCTRLR_USE_BKST = 1'b0;
+reg           MCB_CMD_VALID = 1'b0;
+reg           MCB_USE_BKST = 1'b0;
+reg           Pre_SYSRST = 1'b1 /* synthesis syn_maxfan = 5 */; //internally generated reset which will OR with RST input to drive MCB's SYSRST pin (MCB_SYSRST)
+// synthesis attribute max_fanout of Pre_SYSRST is 5
+reg           IODRP_SDO;
+reg   [7:0]   Max_Value_Previous  = 8'b0 /* synthesis syn_preserve = 1 */;
+reg   [5:0]   count = 6'd0;               //counter for adding 18 extra clock cycles after setting Calibrate bit
+reg           counter_en  = 1'b0;         //counter enable for "count"
+reg           First_Dyn_Cal_Done = 1'b0;  //flag - high after the very first dynamic calibration is done
+reg           START_BROADCAST = 1'b1;     // Trigger to start Broadcast to IODRP2_MCBs to set Input Impedance - state machine will wait for this to be high
+reg   [7:0]   DQS_DELAY_INITIAL   = 8'b0 /* synthesis syn_preserve = 1 */;
+reg   [7:0]   DQS_DELAY ;        // contains the latest values written to LDQS and UDQS Input Delays
+reg   [7:0]   TARGET_DQS_DELAY;  // used to track the target for DQS input delays - only gets updated if the Max Value changes by more than the threshold
+reg   [7:0]   counter_inc;       // used to delay Inc signal by several ui_clk cycles (to deal with latency on UOREFRSHFLAG)
+reg   [7:0]   counter_dec;       // used to delay Dec signal by several ui_clk cycles (to deal with latency on UOREFRSHFLAG)
+
+wire  [7:0]   IODRPCTRLR_READ_DATA;
+wire          IODRPCTRLR_RDY_BUSY_N;
+wire          IODRP_CS;
+wire  [7:0]   MCB_READ_DATA;
+
+reg           RST_reg;
+reg           Block_Reset;
+
+reg           MCB_UODATAVALID_U;
+
+wire  [2:0]   Inc_Dec_REFRSH_Flag;  // 3-bit flag to show:Inc is needed, Dec needed, refresh cycle taking place
+wire  [7:0]   Max_Value_Delta_Up;   // tracks amount latest Max Value has gone up from previous Max Value read
+wire  [7:0]   Half_MV_DU;           // half of Max_Value_Delta_Up
+wire  [7:0]   Max_Value_Delta_Dn;   // tracks amount latest Max Value has gone down from previous Max Value read
+wire  [7:0]   Half_MV_DD;           // half of Max_Value_Delta_Dn
+
+reg   [9:0]   RstCounter = 10'h0;
+wire          rst_tmp;
+reg           LastPass_DynCal;
+reg           First_In_Term_Done;
+wire          Inc_Flag;               // flag to increment Dynamic Delay
+wire          Dec_Flag;               // flag to decrement Dynamic Delay
+
+wire          CALMODE_EQ_CALIBRATION; // will calculate and set the DQS input delays if C_MC_CALIBRATION_MODE parameter = "CALIBRATION"
+wire  [7:0]   DQS_DELAY_LOWER_LIMIT;  // Lower limit for DQS input delays 
+wire  [7:0]   DQS_DELAY_UPPER_LIMIT;  // Upper limit for DQS input delays
+wire          SKIP_DYN_IN_TERMINATION;//wire to allow skipping dynamic input termination if either the one-time or dynamic parameters are 1
+wire          SKIP_DYNAMIC_DQS_CAL;   //wire allowing skipping dynamic DQS delay calibration if either SKIP_DYNIMIC_CAL=1, or if C_MC_CALIBRATION_MODE=NOCALIBRATION
+wire  [7:0]   Quarter_Max_Value;
+wire  [7:0]   Half_Max_Value;
+reg           PLL_LOCK_R1;
+reg           PLL_LOCK_R2;
+
+reg           SELFREFRESH_REQ_R1;
+reg           SELFREFRESH_REQ_R2;
+reg           SELFREFRESH_REQ_R3;
+reg           SELFREFRESH_MCB_MODE_R1;
+reg           SELFREFRESH_MCB_MODE_R2;
+reg           SELFREFRESH_MCB_MODE_R3;
+
+reg           WAIT_SELFREFRESH_EXIT_DQS_CAL;
+reg           PERFORM_START_DYN_CAL_AFTER_SELFREFRESH;
+reg           START_DYN_CAL_STATE_R1;
+reg           PERFORM_START_DYN_CAL_AFTER_SELFREFRESH_R1;
+reg           Rst_condition1, Rst_condition2;
+wire          non_violating_rst;
+reg [15:0]    WAIT_200us_COUNTER;
+
+// 'defines for which pass of the interleaved dynamic algorythm is taking place
+`define IN_TERM_PASS  1'b0
+`define DYN_CAL_PASS  1'b1
+
+assign  Inc_Dec_REFRSH_Flag     = {Inc_Flag,Dec_Flag,MCB_UOREFRSHFLAG};
+assign  Max_Value_Delta_Up      = Max_Value - Max_Value_Previous;
+assign  Half_MV_DU              = {1'b0,Max_Value_Delta_Up[7:1]};
+assign  Max_Value_Delta_Dn      = Max_Value_Previous - Max_Value;
+assign  Half_MV_DD              = {1'b0,Max_Value_Delta_Dn[7:1]};
+assign  CALMODE_EQ_CALIBRATION  = (C_MC_CALIBRATION_MODE == "CALIBRATION") ? 1'b1 : 1'b0; // will calculate and set the DQS input delays if = 1'b1
+assign  Half_Max_Value          = Max_Value >> 1;
+assign  Quarter_Max_Value       = Max_Value >> 2;
+assign  DQS_DELAY_LOWER_LIMIT   = Quarter_Max_Value;  // limit for DQS_DELAY for decrements; could optionally be assigned to any 8-bit hex value here
+assign  DQS_DELAY_UPPER_LIMIT   = Half_Max_Value;     // limit for DQS_DELAY for increments; could optionally be assigned to any 8-bit hex value here
+assign  SKIP_DYN_IN_TERMINATION = SKIP_DYN_IN_TERM || SKIP_IN_TERM_CAL; //skip dynamic input termination if either the one-time or dynamic parameters are 1
+assign  SKIP_DYNAMIC_DQS_CAL    = ~CALMODE_EQ_CALIBRATION || SKIP_DYNAMIC_CAL; //skip dynamic DQS delay calibration if either SKIP_DYNAMIC_CAL=1, or if C_MC_CALIBRATION_MODE=NOCALIBRATION
+
+always @ (posedge UI_CLK)
+     DONE_SOFTANDHARD_CAL    <= ((DQS_DELAY_INITIAL != 8'h00) || (STATE == DONE)) && MCB_UODONECAL;  //high when either DQS input delays initialized, or STATE=DONE and UODONECAL high
+
+
+iodrp_controller iodrp_controller(
+  .memcell_address  (IODRPCTRLR_MEMCELL_ADDR),
+  .write_data       (IODRPCTRLR_WRITE_DATA),
+  .read_data        (IODRPCTRLR_READ_DATA),
+  .rd_not_write     (IODRPCTRLR_R_WB),
+  .cmd_valid        (IODRPCTRLR_CMD_VALID),
+  .rdy_busy_n       (IODRPCTRLR_RDY_BUSY_N),
+  .use_broadcast    (1'b0),
+  .sync_rst         (RST_reg),
+  .DRP_CLK          (UI_CLK),
+  .DRP_CS           (IODRP_CS),
+  .DRP_SDI          (IODRP_SDI),
+  .DRP_ADD          (IODRP_ADD),
+  .DRP_SDO          (IODRP_SDO),
+  .DRP_BKST         ()
+  );
+
+iodrp_mcb_controller iodrp_mcb_controller(
+  .memcell_address  (IODRPCTRLR_MEMCELL_ADDR),
+  .write_data       (IODRPCTRLR_WRITE_DATA),
+  .read_data        (MCB_READ_DATA),
+  .rd_not_write     (IODRPCTRLR_R_WB),
+  .cmd_valid        (MCB_CMD_VALID),
+  .rdy_busy_n       (MCB_RDY_BUSY_N),
+  .use_broadcast    (MCB_USE_BKST),
+  .drp_ioi_addr     (MCB_UIADDR),
+  .sync_rst         (RST_reg),
+  .DRP_CLK          (UI_CLK),
+  .DRP_CS           (MCB_UICS),
+  .DRP_SDI          (MCB_UISDI),
+  .DRP_ADD          (MCB_UIADD),
+  .DRP_BKST         (MCB_UIBROADCAST),
+  .DRP_SDO          (MCB_UOSDO),
+  .MCB_UIREAD       (MCB_UIREAD)
+  );
+
+
+//******************************************************************************************
+// Mult_Divide Function - multiplies by a constant MULT and then divides by the DIV constant
+//******************************************************************************************
+function [7:0] Mult_Divide;
+input   [7:0]   Input;
+input   [7:0]   Mult;
+input   [7:0]   Div;
+reg     [3:0]   count;
+reg     [15:0]   Result;
+begin
+  Result  = 0;
+  for (count = 0; count < Mult; count = count+1) begin
+    Result    = Result + Input;
+  end
+  Result      = Result / Div;
+  Mult_Divide = Result[7:0];
+end
+endfunction
+
+
+generate
+if (C_SIMULATION == "FALSE") begin: init_sequence
+   always @ (posedge UI_CLK, posedge RST)
+   begin
+   if (RST)
+       WAIT_200us_COUNTER <= 'b0;
+   else 
+      if (WAIT_200us_COUNTER[15])  // UI_CLK maximum is up to 100 MHz.
+           WAIT_200us_COUNTER <= WAIT_200us_COUNTER                        ;
+      else
+           WAIT_200us_COUNTER <= WAIT_200us_COUNTER + 1'b1;
+   end 
+end 
+else begin: init_sequence_skip
+// synthesis translate_off	  
+   initial
+   begin
+      WAIT_200us_COUNTER = 16'hFFFF;
+      $display("The 200 us wait period required before CKE goes active has been skipped in Simulation\n");
+   end	  
+// synthesis translate_on	  
+end
+endgenerate
+    
+    
+generate
+if( C_MEM_TYPE == "DDR2") begin : gen_cketrain_a
+
+
+always @ ( posedge UI_CLK, posedge RST)
+begin 
+if (RST)
+   CKE_Train <= 1'b0;
+else 
+  if (STATE == WAIT_FOR_UODONE && MCB_UODONECAL)
+   CKE_Train <= 1'b0;
+  else if (WAIT_200us_COUNTER[15] && ~MCB_UODONECAL)
+   CKE_Train <= 1'b1;
+  
+end
+end
+endgenerate
+
+
+generate
+if( C_MEM_TYPE != "DDR2") begin : gen_cketrain_b
+always @ ( posedge UI_CLK)
+   CKE_Train <= 1'b0;
+end 
+endgenerate
+
+//********************************************
+//PLL_LOCK and Reset signals
+//********************************************
+localparam  RST_CNT         = 10'h010;          //defines pulse-width for reset
+localparam  TZQINIT_MAXCNT  = C_MEM_TZQINIT_MAXCNT + RST_CNT;  
+assign MCB_SYSRST = Pre_SYSRST | RST_reg ;            //Pre_SYSRST is generated from the STATE state machine, and is OR'd with RST_reg input to drive MCB's SYSRST pin (MCB_SYSRST)
+assign rst_tmp    = (~PLL_LOCK_R2 && ~SELFREFRESH_MODE); //rst_tmp becomes 1 if you lose PLL lock (registered twice for metastblty) and the device is not in SUSPEND
+assign non_violating_rst = RST && Rst_condition1;         //non_violating_rst is when the user-reset RST occurs and TZQINIT (min time between resets for DDR3) is not being violated
+
+
+
+
+always @ (posedge UI_CLK or posedge RST ) begin  
+  if (RST) begin         
+    Block_Reset <= 1'b0;
+    RstCounter  <= 10'b0;
+end
+  else if (rst_tmp) begin    //this is to deal with not allowing the user-reset "RST" to violate TZQINIT_MAXCNT (min time between resets to DDR3)
+    Block_Reset <= 1'b0;
+    RstCounter  <= 10'b0;
+  end
+  else begin
+    Block_Reset <= 1'b0;                   //default to allow STATE to move out of RST_DELAY state
+    if (Pre_SYSRST)
+      RstCounter  <= RST_CNT;              //whenever STATE wants to reset the MCB, set RstCounter to h10
+    else begin
+      if (RstCounter < TZQINIT_MAXCNT) begin //if RstCounter is less than d512 than this will execute
+        Block_Reset <= 1'b1;               //STATE won't exit RST_DELAY state
+        RstCounter  <= RstCounter + 1'b1;  //and Rst_Counter increments
+      end
+    end
+  end
+end
+
+
+
+always @ (posedge UI_CLK ) begin  
+if (RstCounter >= TZQINIT_MAXCNT) 
+    Rst_condition1 <= 1'b1;
+else
+    Rst_condition1 <= 1'b0;
+
+end
+
+always @ (posedge UI_CLK ) begin  
+if (RstCounter < RST_CNT)
+    Rst_condition2 <= 1'b1;
+  else 
+    Rst_condition2 <= 1'b0;
+
+end
+always @ (posedge UI_CLK or posedge non_violating_rst ) begin  
+  if (non_violating_rst)          
+    RST_reg <= 1'b1;                                       
+  else if (~WAIT_200us_COUNTER[15])
+    RST_reg <= 1'b1;         
+  else 
+    RST_reg     <= Rst_condition2 | rst_tmp ; 
+    
+end
+
+
+//********************************************
+// SUSPEND Logic
+//********************************************
+
+always @ ( posedge UI_CLK) begin
+  //SELFREFRESH_MCB_MODE is clocked by sysclk_2x_180
+  SELFREFRESH_MCB_MODE_R1 <= SELFREFRESH_MCB_MODE;
+  SELFREFRESH_MCB_MODE_R2 <= SELFREFRESH_MCB_MODE_R1;
+  SELFREFRESH_MCB_MODE_R3 <= SELFREFRESH_MCB_MODE_R2;
+  
+  //SELFREFRESH_REQ is clocked by user's application clock
+  SELFREFRESH_REQ_R1      <= SELFREFRESH_REQ;
+  SELFREFRESH_REQ_R2      <= SELFREFRESH_REQ_R1;
+  SELFREFRESH_REQ_R3      <= SELFREFRESH_REQ_R2;
+
+  PLL_LOCK_R1             <= PLL_LOCK;
+  PLL_LOCK_R2             <= PLL_LOCK_R1;
+
+
+end
+
+// SELFREFRESH should only be deasserted after PLL_LOCK is asserted.
+// This is to make sure MCB get a locked sys_2x_clk before exiting
+// SELFREFRESH mode.
+
+always @ ( posedge UI_CLK) begin
+  if (RST)
+    SELFREFRESH_MCB_REQ <= 1'b0;
+  else if (PLL_LOCK_R2 && ~SELFREFRESH_REQ_R1 && STATE == START_DYN_CAL)
+    SELFREFRESH_MCB_REQ <=  1'b0;
+  else if (STATE == START_DYN_CAL && SELFREFRESH_REQ_R1)  
+    SELFREFRESH_MCB_REQ <= 1'b1;
+end
+
+
+
+always @ (posedge UI_CLK) begin
+  if (RST)
+    WAIT_SELFREFRESH_EXIT_DQS_CAL <= 1'b0;
+  else if (~SELFREFRESH_MCB_MODE_R3 && SELFREFRESH_MCB_MODE_R2)  
+
+    WAIT_SELFREFRESH_EXIT_DQS_CAL <= 1'b1;
+  else if (WAIT_SELFREFRESH_EXIT_DQS_CAL && ~SELFREFRESH_REQ_R3 && PERFORM_START_DYN_CAL_AFTER_SELFREFRESH) // START_DYN_CAL is next state
+    WAIT_SELFREFRESH_EXIT_DQS_CAL <= 1'b0;
+end   
+
+//Need to detect when SM entering START_DYN_CAL
+always @ (posedge UI_CLK) begin
+  if (RST) begin
+    PERFORM_START_DYN_CAL_AFTER_SELFREFRESH  <= 1'b0;
+    START_DYN_CAL_STATE_R1 <= 1'b0;
+  end 
+  else begin
+    // register PERFORM_START_DYN_CAL_AFTER_SELFREFRESH to detect end of cycle
+    PERFORM_START_DYN_CAL_AFTER_SELFREFRESH_R1 <= PERFORM_START_DYN_CAL_AFTER_SELFREFRESH;
+    if (STATE == START_DYN_CAL)
+      START_DYN_CAL_STATE_R1 <= 1'b1;
+    else
+      START_DYN_CAL_STATE_R1 <= 1'b0;
+      if (WAIT_SELFREFRESH_EXIT_DQS_CAL && STATE != START_DYN_CAL && START_DYN_CAL_STATE_R1 )
+        PERFORM_START_DYN_CAL_AFTER_SELFREFRESH <= 1'b1;
+      else if (STATE == START_DYN_CAL && ~SELFREFRESH_MCB_MODE_R3)
+        PERFORM_START_DYN_CAL_AFTER_SELFREFRESH <= 1'b0;
+      end
+  end
+
+
+// SELFREFRESH_MCB_MODE deasserted status is hold off
+// until Soft_Calib has at least done one loop of DQS update.
+always @ (posedge UI_CLK) begin
+  if (RST)
+    SELFREFRESH_MODE <= 1'b0;
+  else if (SELFREFRESH_MCB_MODE_R2)  
+    SELFREFRESH_MODE <= 1'b1;
+  else if (!PERFORM_START_DYN_CAL_AFTER_SELFREFRESH && PERFORM_START_DYN_CAL_AFTER_SELFREFRESH_R1)
+    SELFREFRESH_MODE <= 1'b0;
+end
+
+//********************************************
+//Comparitors for Dynamic Calibration circuit
+//********************************************
+assign Dec_Flag = (TARGET_DQS_DELAY < DQS_DELAY);
+assign Inc_Flag = (TARGET_DQS_DELAY > DQS_DELAY);
+
+
+//*********************************************************************************************
+//Counter for extra clock cycles injected after setting Calibrate bit in IODRP2 for Dynamic Cal
+//*********************************************************************************************
+ always @(posedge UI_CLK)
+  begin
+    if (RST_reg)
+        count <= 6'd0;
+    else if (counter_en)
+        count <= count + 1'b1;
+    else
+        count <= 6'd0;
+  end
+
+//*********************************************************************************************
+// Capture narrow MCB_UODATAVALID pulse - only one sysclk90 cycle wide
+//*********************************************************************************************
+ always @(posedge UI_CLK or posedge MCB_UODATAVALID)
+  begin
+    if (MCB_UODATAVALID)
+        MCB_UODATAVALID_U <= 1'b1;
+    else
+        MCB_UODATAVALID_U <= MCB_UODATAVALID;
+  end
+
+  //**************************************************************************************************************
+  //Always block to mux SDI, SDO, CS, and ADD depending on which IODRP is active: RZQ, ZIO or MCB's UI port (to IODRP2_MCBs)
+  //**************************************************************************************************************
+  always @(*) begin: ACTIVE_IODRP
+    case (Active_IODRP)
+      RZQ:      begin
+        RZQ_IODRP_CS  = IODRP_CS;
+        ZIO_IODRP_CS  = 1'b0;
+        IODRP_SDO     = RZQ_IODRP_SDO;
+      end
+      ZIO:      begin
+        RZQ_IODRP_CS  = 1'b0;
+        ZIO_IODRP_CS  = IODRP_CS;
+        IODRP_SDO     = ZIO_IODRP_SDO;
+      end
+      MCB_PORT: begin
+        RZQ_IODRP_CS  = 1'b0;
+        ZIO_IODRP_CS  = 1'b0;
+        IODRP_SDO     = 1'b0;
+      end
+      default:  begin
+        RZQ_IODRP_CS  = 1'b0;
+        ZIO_IODRP_CS  = 1'b0;
+        IODRP_SDO     = 1'b0;
+      end
+    endcase
+  end
+
+//******************************************************************
+//State Machine's Always block / Case statement for Next State Logic
+//
+//The WAIT1,2,etc states were required after every state where the
+//DRP controller was used to do a write to the IODRPs - this is because
+//there's a clock cycle latency on IODRPCTRLR_RDY_BUSY_N whenever the DRP controller
+//sees IODRPCTRLR_CMD_VALID go high.  OFF_RZQ_PTERM and OFF_ZIO_NTERM were added
+//soley for the purpose of reducing power, particularly on RZQ as
+//that pin is expected to have a permanent external resistor to gnd.
+//******************************************************************
+  always @(posedge UI_CLK) begin: NEXT_STATE_LOGIC
+    if (RST_reg) begin                      // Synchronous reset
+      MCB_CMD_VALID           <= 1'b0;
+      MCB_UIADDR              <= 5'b0;
+      MCB_UICMDEN             <= 1'b1;      // take control of UI/UO port
+      MCB_UIDONECAL           <= 1'b0;      // tells MCB that it is in Soft Cal.
+      MCB_USE_BKST            <= 1'b0;
+      MCB_UIDRPUPDATE         <= 1'b1;
+      Pre_SYSRST              <= 1'b1;      // keeps MCB in reset
+      IODRPCTRLR_CMD_VALID    <= 1'b0;
+      IODRPCTRLR_MEMCELL_ADDR <= NoOp;
+      IODRPCTRLR_WRITE_DATA   <= 1'b0;
+      IODRPCTRLR_R_WB         <= WRITE_MODE;
+      IODRPCTRLR_USE_BKST     <= 1'b0;
+      P_Term                  <= 6'b0;
+      N_Term                  <= 7'b0;
+      P_Term_Prev             <= 6'b0;
+      N_Term_Prev             <= 7'b0;
+      Active_IODRP            <= RZQ;
+      MCB_UILDQSINC           <= 1'b0;      //no inc or dec
+      MCB_UIUDQSINC           <= 1'b0;      //no inc or dec
+      MCB_UILDQSDEC           <= 1'b0;      //no inc or dec
+      MCB_UIUDQSDEC           <= 1'b0;      //no inc or dec
+      counter_en              <= 1'b0;
+      First_Dyn_Cal_Done      <= 1'b0;      //flag that the First Dynamic Calibration completed
+      Max_Value               <= 8'b0;
+      Max_Value_Previous      <= 8'b0;
+      STATE                   <= START;
+      DQS_DELAY               <= 8'h0; //tracks the cumulative incrementing/decrementing that has been done
+      DQS_DELAY_INITIAL       <= 8'h0;
+      TARGET_DQS_DELAY        <= 8'h0;
+      LastPass_DynCal         <= `IN_TERM_PASS;
+      First_In_Term_Done      <= 1'b0;
+      MCB_UICMD               <= 1'b0;
+      MCB_UICMDIN             <= 1'b0;
+      MCB_UIDQCOUNT           <= 4'h0;
+      counter_inc             <= 8'h0;
+      counter_dec             <= 8'h0;
+    end
+    else begin
+      counter_en              <= 1'b0;
+      IODRPCTRLR_CMD_VALID    <= 1'b0;
+      IODRPCTRLR_MEMCELL_ADDR <= NoOp;
+      IODRPCTRLR_R_WB         <= READ_MODE;
+      IODRPCTRLR_USE_BKST     <= 1'b0;
+      MCB_CMD_VALID           <= 1'b0;
+      MCB_UILDQSINC           <= 1'b0;            //no inc or dec
+      MCB_UIUDQSINC           <= 1'b0;            //no inc or dec
+      MCB_UILDQSDEC           <= 1'b0;            //no inc or dec
+      MCB_UIUDQSDEC           <= 1'b0;            //no inc or dec
+      MCB_USE_BKST            <= 1'b0;
+      MCB_UICMDIN             <= 1'b0;
+      DQS_DELAY               <= DQS_DELAY;
+      TARGET_DQS_DELAY        <= TARGET_DQS_DELAY;
+      case (STATE)
+        START:  begin   //h00
+          MCB_UICMDEN     <= 1'b1;        // take control of UI/UO port
+          MCB_UIDONECAL   <= 1'b0;        // tells MCB that it is in Soft Cal.
+          P_Term          <= 6'b0;
+          N_Term          <= 7'b0;
+          Pre_SYSRST      <= 1'b1;        // keeps MCB in reset
+          LastPass_DynCal <= `IN_TERM_PASS;
+          if (SKIP_IN_TERM_CAL)
+            STATE <= WRITE_CALIBRATE;
+          else if (IODRPCTRLR_RDY_BUSY_N)
+            STATE  <= LOAD_RZQ_NTERM;
+          else
+            STATE  <= START;
+        end
+//***************************
+// IOB INPUT TERMINATION CAL
+//***************************
+        LOAD_RZQ_NTERM: begin   //h01
+          Active_IODRP            <= RZQ;
+          IODRPCTRLR_CMD_VALID    <= 1'b1;
+          IODRPCTRLR_MEMCELL_ADDR <= NTerm;
+          IODRPCTRLR_WRITE_DATA   <= {1'b0,N_Term};
+          IODRPCTRLR_R_WB         <= WRITE_MODE;
+          if (IODRPCTRLR_RDY_BUSY_N)
+            STATE <= LOAD_RZQ_NTERM;
+          else
+            STATE <= WAIT1;
+        end
+        WAIT1:  begin   //h02
+          if (!IODRPCTRLR_RDY_BUSY_N)
+            STATE <= WAIT1;
+          else
+            STATE <= LOAD_RZQ_PTERM;
+        end
+        LOAD_RZQ_PTERM: begin //h03
+          IODRPCTRLR_CMD_VALID    <= 1'b1;
+          IODRPCTRLR_MEMCELL_ADDR <= PTerm;
+          IODRPCTRLR_WRITE_DATA   <= {2'b00,P_Term};
+          IODRPCTRLR_R_WB         <= WRITE_MODE;
+          if (IODRPCTRLR_RDY_BUSY_N)
+            STATE <= LOAD_RZQ_PTERM;
+          else
+            STATE <= WAIT2;
+        end
+        WAIT2:  begin   //h04
+          if (!IODRPCTRLR_RDY_BUSY_N)
+            STATE <= WAIT2;
+          else if ((RZQ_IN)||(P_Term == 6'b111111)) begin
+            STATE <= MULTIPLY_DIVIDE;//LOAD_ZIO_PTERM;
+          end
+          else
+            STATE <= INC_PTERM;
+        end
+        INC_PTERM: begin    //h05
+          P_Term  <= P_Term + 1;
+          STATE   <= LOAD_RZQ_PTERM;
+        end
+        MULTIPLY_DIVIDE: begin //06
+           P_Term  <= Mult_Divide(P_Term, MULT, DIV);
+           STATE <= LOAD_ZIO_PTERM;
+        end
+        LOAD_ZIO_PTERM: begin   //h07
+          Active_IODRP            <= ZIO;
+          IODRPCTRLR_CMD_VALID    <= 1'b1;
+          IODRPCTRLR_MEMCELL_ADDR <= PTerm;
+          IODRPCTRLR_WRITE_DATA   <= {2'b00,P_Term};
+          IODRPCTRLR_R_WB         <= WRITE_MODE;
+          if (IODRPCTRLR_RDY_BUSY_N)
+            STATE <= LOAD_ZIO_PTERM;
+          else
+            STATE <= WAIT3;
+        end
+        WAIT3:  begin   //h08
+          if (!IODRPCTRLR_RDY_BUSY_N)
+            STATE <= WAIT3;
+          else begin
+            STATE   <= LOAD_ZIO_NTERM;
+          end
+        end
+        LOAD_ZIO_NTERM: begin   //h09
+          Active_IODRP            <= ZIO;
+          IODRPCTRLR_CMD_VALID    <= 1'b1;
+          IODRPCTRLR_MEMCELL_ADDR <= NTerm;
+          IODRPCTRLR_WRITE_DATA   <= {1'b0,N_Term};
+          IODRPCTRLR_R_WB         <= WRITE_MODE;
+          if (IODRPCTRLR_RDY_BUSY_N)
+            STATE <= LOAD_ZIO_NTERM;
+          else
+            STATE <= WAIT4;
+        end
+        WAIT4:  begin   //h0A
+          if (!IODRPCTRLR_RDY_BUSY_N)
+            STATE <= WAIT4;
+          else if ((!ZIO_IN)||(N_Term == 7'b1111111)) begin
+            if (PNSKEW) begin
+              STATE    <= SKEW;
+            end
+            else 
+            STATE <= WAIT_FOR_START_BROADCAST;
+          end
+          else
+            STATE <= INC_NTERM;
+        end
+        INC_NTERM: begin    //h0B
+          N_Term  <= N_Term + 1;
+          STATE   <= LOAD_ZIO_NTERM;
+        end
+        SKEW : begin //0C
+            P_Term <= Mult_Divide(P_Term, PSKEW_MULT, PSKEW_DIV);
+            N_Term <= Mult_Divide(N_Term, NSKEW_MULT, NSKEW_DIV);
+            STATE  <= WAIT_FOR_START_BROADCAST;
+        end
+        WAIT_FOR_START_BROADCAST: begin   //h0D
+          Pre_SYSRST    <= 1'b0;      //release SYSRST, but keep UICMDEN=1 and UIDONECAL=0. This is needed to do Broadcast through UI interface, while keeping the MCB in calibration mode
+          Active_IODRP  <= MCB_PORT;
+          if (START_BROADCAST && IODRPCTRLR_RDY_BUSY_N) begin
+            if (P_Term != P_Term_Prev) begin
+              STATE       <= BROADCAST_PTERM;
+              P_Term_Prev <= P_Term;
+            end
+            else if (N_Term != N_Term_Prev) begin
+              N_Term_Prev <= N_Term;
+              STATE       <= BROADCAST_NTERM;
+            end
+            else
+              STATE <= OFF_RZQ_PTERM;
+          end
+          else
+            STATE   <= WAIT_FOR_START_BROADCAST;
+        end
+        BROADCAST_PTERM:  begin    //h0E
+//SBS redundant?          MCB_UICMDEN             <= 1'b1;        // take control of UI/UO port for reentrant use of dynamic In Term tuning
+          IODRPCTRLR_MEMCELL_ADDR <= PTerm;
+          IODRPCTRLR_WRITE_DATA   <= {2'b00,P_Term};
+          IODRPCTRLR_R_WB         <= WRITE_MODE;
+          MCB_CMD_VALID           <= 1'b1;
+          MCB_UIDRPUPDATE         <= ~First_In_Term_Done; // Set the update flag if this is the first time through
+          MCB_USE_BKST            <= 1'b1;
+          if (MCB_RDY_BUSY_N)
+            STATE <= BROADCAST_PTERM;
+          else
+            STATE <= WAIT5;
+        end
+        WAIT5:  begin   //h0F
+          if (!MCB_RDY_BUSY_N)
+            STATE <= WAIT5;
+          else if (First_In_Term_Done) begin  // If first time through is already set, then this must be dynamic in term
+            if (MCB_UOREFRSHFLAG) begin
+              MCB_UIDRPUPDATE <= 1'b1;
+              if (N_Term != N_Term_Prev) begin
+                N_Term_Prev <= N_Term;
+                STATE       <= BROADCAST_NTERM;
+              end
+              else
+                STATE <= OFF_RZQ_PTERM;
+            end
+            else
+              STATE <= WAIT5;   // wait for a Refresh cycle
+          end
+          else begin
+            N_Term_Prev <= N_Term;
+            STATE <= BROADCAST_NTERM;
+          end
+        end
+        BROADCAST_NTERM:  begin    //h10
+          IODRPCTRLR_MEMCELL_ADDR <= NTerm;
+          IODRPCTRLR_WRITE_DATA   <= {2'b00,N_Term};
+          IODRPCTRLR_R_WB         <= WRITE_MODE;
+          MCB_CMD_VALID           <= 1'b1;
+          MCB_USE_BKST            <= 1'b1;
+          MCB_UIDRPUPDATE         <= ~First_In_Term_Done; // Set the update flag if this is the first time through
+          if (MCB_RDY_BUSY_N)
+            STATE <= BROADCAST_NTERM;
+          else
+            STATE <= WAIT6;
+        end
+        WAIT6:  begin             // 7'h11
+          if (!MCB_RDY_BUSY_N)
+            STATE <= WAIT6;
+          else if (First_In_Term_Done) begin  // If first time through is already set, then this must be dynamic in term
+            if (MCB_UOREFRSHFLAG) begin
+              MCB_UIDRPUPDATE <= 1'b1;
+              STATE           <= OFF_RZQ_PTERM;
+            end
+            else
+              STATE <= WAIT6;   // wait for a Refresh cycle
+          end
+          else
+            STATE <= OFF_RZQ_PTERM;
+        end
+        OFF_RZQ_PTERM:  begin     // 7'h12
+          Active_IODRP            <= RZQ;
+          IODRPCTRLR_CMD_VALID    <= 1'b1;
+          IODRPCTRLR_MEMCELL_ADDR <= PTerm;
+          IODRPCTRLR_WRITE_DATA   <= 8'b00;
+          IODRPCTRLR_R_WB         <= WRITE_MODE;
+          P_Term                  <= 6'b0;
+          N_Term                  <= 5'b0;
+          MCB_UIDRPUPDATE         <= ~First_In_Term_Done; // Set the update flag if this is the first time through
+          if (IODRPCTRLR_RDY_BUSY_N)
+            STATE <= OFF_RZQ_PTERM;
+          else
+            STATE <= WAIT7;
+        end
+        WAIT7:  begin             // 7'h13
+          if (!IODRPCTRLR_RDY_BUSY_N)
+            STATE <= WAIT7;
+          else
+            STATE <= OFF_ZIO_NTERM;
+        end
+        OFF_ZIO_NTERM:  begin     // 7'h14
+          Active_IODRP            <= ZIO;
+          IODRPCTRLR_CMD_VALID    <= 1'b1;
+          IODRPCTRLR_MEMCELL_ADDR <= NTerm;
+          IODRPCTRLR_WRITE_DATA   <= 8'b00;
+          IODRPCTRLR_R_WB         <= WRITE_MODE;
+          if (IODRPCTRLR_RDY_BUSY_N)
+            STATE <= OFF_ZIO_NTERM;
+          else
+            STATE <= WAIT8;
+        end
+        WAIT8:  begin             // 7'h15
+          if (!IODRPCTRLR_RDY_BUSY_N)
+            STATE <= WAIT8;
+          else begin
+            if (First_In_Term_Done) begin
+              STATE               <= START_DYN_CAL; // No need to reset the MCB if we are in InTerm tuning
+            end
+            else begin
+              STATE               <= WRITE_CALIBRATE; // go read the first Max_Value from RZQ
+            end
+          end
+        end
+        RST_DELAY:  begin     // 7'h16
+          MCB_UICMDEN             <= 1'b0;  // release control of UI/UO port
+          if (Block_Reset) begin  // this ensures that more than 512 clock cycles occur since the last reset after MCB_WRITE_CALIBRATE ???
+            STATE       <= RST_DELAY;
+          end
+          else begin
+            STATE <= START_DYN_CAL_PRE;
+          end
+        end
+//****************************
+// DYNAMIC CALIBRATION PORTION
+//****************************
+        START_DYN_CAL_PRE:  begin   // 7'h17
+          LastPass_DynCal <= `IN_TERM_PASS;
+          MCB_UICMDEN     <= 1'b0;    // release UICMDEN
+          MCB_UIDONECAL   <= 1'b1;    // release UIDONECAL - MCB will now initialize.
+          Pre_SYSRST      <= 1'b1;    // SYSRST pulse
+          if (~CALMODE_EQ_CALIBRATION)      // if C_MC_CALIBRATION_MODE is set to NOCALIBRATION
+            STATE       <= START_DYN_CAL;  // we'll skip setting the DQS delays manually
+          else
+            STATE       <= WAIT_FOR_UODONE;
+          end
+        WAIT_FOR_UODONE:  begin  //7'h18
+          Pre_SYSRST      <= 1'b0;    // SYSRST pulse
+          if (IODRPCTRLR_RDY_BUSY_N && MCB_UODONECAL) begin //IODRP Controller needs to be ready, & MCB needs to be done with hard calibration
+            MCB_UICMDEN <= 1'b1;    // grab UICMDEN
+            DQS_DELAY_INITIAL <= Mult_Divide(Max_Value, DQS_NUMERATOR, DQS_DENOMINATOR);
+            STATE       <= LDQS_WRITE_POS_INDELAY;
+          end
+          else
+            STATE       <= WAIT_FOR_UODONE;
+        end
+        LDQS_WRITE_POS_INDELAY:  begin// 7'h19
+          IODRPCTRLR_MEMCELL_ADDR <= PosEdgeInDly;
+          IODRPCTRLR_R_WB         <= WRITE_MODE;
+          IODRPCTRLR_WRITE_DATA   <= DQS_DELAY_INITIAL;
+          MCB_UIADDR              <= IOI_LDQS_CLK;
+          MCB_CMD_VALID           <= 1'b1;
+          if (MCB_RDY_BUSY_N)
+            STATE <= LDQS_WRITE_POS_INDELAY;
+          else
+            STATE <= LDQS_WAIT1;
+        end
+        LDQS_WAIT1:  begin           // 7'h1A
+          if (!MCB_RDY_BUSY_N)
+            STATE <= LDQS_WAIT1;
+          else begin
+            STATE           <= LDQS_WRITE_NEG_INDELAY;
+          end
+        end
+        LDQS_WRITE_NEG_INDELAY:  begin// 7'h1B
+          IODRPCTRLR_MEMCELL_ADDR <= NegEdgeInDly;
+          IODRPCTRLR_R_WB         <= WRITE_MODE;
+          IODRPCTRLR_WRITE_DATA   <= DQS_DELAY_INITIAL;
+          MCB_UIADDR              <= IOI_LDQS_CLK;
+          MCB_CMD_VALID           <= 1'b1;
+          if (MCB_RDY_BUSY_N)
+            STATE <= LDQS_WRITE_NEG_INDELAY;
+          else
+            STATE <= LDQS_WAIT2;
+        end
+        LDQS_WAIT2:  begin           // 7'h1C
+          if (!MCB_RDY_BUSY_N)
+            STATE <= LDQS_WAIT2;
+          else begin
+            STATE <= UDQS_WRITE_POS_INDELAY;
+          end
+        end
+        UDQS_WRITE_POS_INDELAY:  begin// 7'h1D
+          IODRPCTRLR_MEMCELL_ADDR <= PosEdgeInDly;
+          IODRPCTRLR_R_WB         <= WRITE_MODE;
+          IODRPCTRLR_WRITE_DATA   <= DQS_DELAY_INITIAL;
+          MCB_UIADDR              <= IOI_UDQS_CLK;
+          MCB_CMD_VALID           <= 1'b1;
+          if (MCB_RDY_BUSY_N)
+            STATE <= UDQS_WRITE_POS_INDELAY;
+          else
+            STATE <= UDQS_WAIT1;
+        end
+        UDQS_WAIT1:  begin           // 7'h1E
+          if (!MCB_RDY_BUSY_N)
+            STATE <= UDQS_WAIT1;
+          else begin
+            STATE           <= UDQS_WRITE_NEG_INDELAY;
+          end
+        end
+        UDQS_WRITE_NEG_INDELAY:  begin// 7'h1F
+          IODRPCTRLR_MEMCELL_ADDR <= NegEdgeInDly;
+          IODRPCTRLR_R_WB         <= WRITE_MODE;
+          IODRPCTRLR_WRITE_DATA   <= DQS_DELAY_INITIAL;
+          MCB_UIADDR              <= IOI_UDQS_CLK;
+          MCB_CMD_VALID           <= 1'b1;
+          if (MCB_RDY_BUSY_N)
+            STATE <= UDQS_WRITE_NEG_INDELAY;
+          else
+            STATE <= UDQS_WAIT2;
+        end
+        UDQS_WAIT2:  begin           // 7'h20
+          if (!MCB_RDY_BUSY_N)
+            STATE <= UDQS_WAIT2;
+          else begin
+            DQS_DELAY         <= DQS_DELAY_INITIAL;
+            TARGET_DQS_DELAY  <= DQS_DELAY_INITIAL;
+            STATE             <= START_DYN_CAL;
+          end
+        end
+//**************************************************************************************
+        START_DYN_CAL:  begin       // 7'h21
+          Pre_SYSRST        <= 1'b0;      // SYSRST not driven
+          counter_inc       <= 8'b0;
+          counter_dec       <= 8'b0;
+          if (SKIP_DYNAMIC_DQS_CAL & SKIP_DYN_IN_TERMINATION)
+            STATE <= DONE;  //if we're skipping both dynamic algorythms, go directly to DONE
+          else
+          if (IODRPCTRLR_RDY_BUSY_N && MCB_UODONECAL && ~SELFREFRESH_REQ_R1 ) begin  //IODRP Controller needs to be ready, & MCB needs to be done with hard calibration
+
+            // Alternate between Dynamic Input Termination and Dynamic Tuning routines
+            if (~SKIP_DYN_IN_TERMINATION & (LastPass_DynCal == `DYN_CAL_PASS)) begin
+              LastPass_DynCal <= `IN_TERM_PASS;
+              STATE           <= LOAD_RZQ_NTERM;
+            end
+            else begin
+              LastPass_DynCal <= `DYN_CAL_PASS;
+              STATE           <= WRITE_CALIBRATE;
+            end
+          end
+          else
+            STATE     <= START_DYN_CAL;
+        end
+        WRITE_CALIBRATE:  begin   // 7'h22
+          Pre_SYSRST              <= 1'b0; // SYSRST not driven
+          IODRPCTRLR_CMD_VALID    <= 1'b1;
+          IODRPCTRLR_MEMCELL_ADDR <= DelayControl;
+          IODRPCTRLR_WRITE_DATA   <= 8'h20; // Set calibrate bit
+          IODRPCTRLR_R_WB         <= WRITE_MODE;
+          Active_IODRP            <= RZQ;
+          if (IODRPCTRLR_RDY_BUSY_N)
+            STATE <= WRITE_CALIBRATE;
+          else
+            STATE <= WAIT9;
+        end
+        WAIT9:  begin     // 7'h23
+          counter_en  <= 1'b1;
+          if (count < 6'd38)  //this adds approximately 22 extra clock cycles after WRITE_CALIBRATE
+            STATE     <= WAIT9;
+          else
+            STATE     <= READ_MAX_VALUE;
+        end
+        READ_MAX_VALUE: begin     // 7'h24
+          IODRPCTRLR_CMD_VALID    <= 1'b1;
+          IODRPCTRLR_MEMCELL_ADDR <= MaxValue;
+          IODRPCTRLR_R_WB         <= READ_MODE;
+          Max_Value_Previous      <= Max_Value;
+          if (IODRPCTRLR_RDY_BUSY_N)
+            STATE <= READ_MAX_VALUE;
+          else
+            STATE <= WAIT10;
+        end
+        WAIT10:  begin    // 7'h25
+          if (!IODRPCTRLR_RDY_BUSY_N)
+            STATE <= WAIT10;
+          else begin
+            Max_Value           <= IODRPCTRLR_READ_DATA;  //record the Max_Value from the IODRP controller
+            if (~First_In_Term_Done) begin
+              STATE               <= RST_DELAY;
+              First_In_Term_Done  <= 1'b1;
+            end
+            else
+              STATE               <= ANALYZE_MAX_VALUE;
+          end
+        end
+        ANALYZE_MAX_VALUE:  begin // 7'h26   only do a Inc or Dec during a REFRESH cycle.
+          if (!First_Dyn_Cal_Done)
+            STATE <= FIRST_DYN_CAL;
+          else
+            if ((Max_Value<Max_Value_Previous)&&(Max_Value_Delta_Dn>=INCDEC_THRESHOLD)) begin
+              STATE <= DECREMENT;         //May need to Decrement
+              TARGET_DQS_DELAY   <= Mult_Divide(Max_Value, DQS_NUMERATOR, DQS_DENOMINATOR);
+            end
+          else
+            if ((Max_Value>Max_Value_Previous)&&(Max_Value_Delta_Up>=INCDEC_THRESHOLD)) begin
+              STATE <= INCREMENT;         //May need to Increment
+              TARGET_DQS_DELAY   <= Mult_Divide(Max_Value, DQS_NUMERATOR, DQS_DENOMINATOR);
+            end
+          else begin
+            Max_Value           <= Max_Value_Previous;
+            STATE <= START_DYN_CAL;
+          end
+        end
+        FIRST_DYN_CAL:  begin // 7'h27
+          First_Dyn_Cal_Done  <= 1'b1;          //set flag that the First Dynamic Calibration has been completed
+          STATE               <= START_DYN_CAL;
+        end
+        INCREMENT: begin      // 7'h28
+          STATE               <= START_DYN_CAL; // Default case: Inc is not high or no longer in REFRSH
+          MCB_UILDQSINC       <= 1'b0;          // Default case: no inc or dec
+          MCB_UIUDQSINC       <= 1'b0;          // Default case: no inc or dec
+          MCB_UILDQSDEC       <= 1'b0;          // Default case: no inc or dec
+          MCB_UIUDQSDEC       <= 1'b0;          // Default case: no inc or dec
+          case (Inc_Dec_REFRSH_Flag)            // {Increment_Flag,Decrement_Flag,MCB_UOREFRSHFLAG},
+            3'b101: begin
+              counter_inc <= counter_inc + 1'b1;
+                STATE               <= INCREMENT; //Increment is still high, still in REFRSH cycle
+              if (DQS_DELAY < DQS_DELAY_UPPER_LIMIT && counter_inc >= 8'h04) begin //if not at the upper limit yet, and you've waited 4 clks, increment
+                MCB_UILDQSINC       <= 1'b1;      //increment
+                MCB_UIUDQSINC       <= 1'b1;      //increment
+                DQS_DELAY           <= DQS_DELAY + 1'b1;
+              end
+            end
+            3'b100: begin
+              if (DQS_DELAY < DQS_DELAY_UPPER_LIMIT)
+                STATE                <= INCREMENT; //Increment is still high, REFRESH ended - wait for next REFRESH
+              end
+            default:  
+                STATE               <= START_DYN_CAL; // Default case
+          endcase
+        end
+        DECREMENT: begin      // 7'h29
+          STATE               <= START_DYN_CAL; // Default case: Dec is not high or no longer in REFRSH
+          MCB_UILDQSINC       <= 1'b0;          // Default case: no inc or dec
+          MCB_UIUDQSINC       <= 1'b0;          // Default case: no inc or dec
+          MCB_UILDQSDEC       <= 1'b0;          // Default case: no inc or dec
+          MCB_UIUDQSDEC       <= 1'b0;          // Default case: no inc or dec
+          if (DQS_DELAY != 8'h00) begin
+            case (Inc_Dec_REFRSH_Flag)            // {Increment_Flag,Decrement_Flag,MCB_UOREFRSHFLAG},
+              3'b011: begin
+                counter_dec <= counter_dec + 1'b1;
+                  STATE               <= DECREMENT; // Decrement is still high, still in REFRESH cycle
+                if (DQS_DELAY > DQS_DELAY_LOWER_LIMIT  && counter_dec >= 8'h04) begin //if not at the lower limit, and you've waited 4 clks, decrement
+                  MCB_UILDQSDEC       <= 1'b1;      // decrement
+                  MCB_UIUDQSDEC       <= 1'b1;      // decrement
+                  DQS_DELAY           <= DQS_DELAY - 1'b1; //SBS
+                end
+              end
+              3'b010: begin
+                if (DQS_DELAY > DQS_DELAY_LOWER_LIMIT) //if not at the lower limit, decrement
+                  STATE                 <= DECREMENT; //Decrement is still high, REFRESH ended - wait for next REFRESH
+                end
+              default: begin
+                  STATE               <= START_DYN_CAL; // Default case
+              end
+            endcase
+          end
+        end
+        DONE: begin           // 7'h2A
+          Pre_SYSRST              <= 1'b0;    // SYSRST cleared
+          MCB_UICMDEN             <= 1'b0;  // release UICMDEN
+          STATE <= DONE;
+        end
+        default:        begin
+          MCB_UICMDEN             <= 1'b0;  // release UICMDEN
+          MCB_UIDONECAL           <= 1'b1;  // release UIDONECAL - MCB will now initialize.
+          Pre_SYSRST              <= 1'b0;  // SYSRST not driven
+          IODRPCTRLR_CMD_VALID    <= 1'b0;
+          IODRPCTRLR_MEMCELL_ADDR <= 8'h00;
+          IODRPCTRLR_WRITE_DATA   <= 8'h00;
+          IODRPCTRLR_R_WB         <= 1'b0;
+          IODRPCTRLR_USE_BKST     <= 1'b0;
+          P_Term                  <= 6'b0;
+          N_Term                  <= 5'b0;
+          Active_IODRP            <= ZIO;
+          Max_Value_Previous      <= 8'b0;
+          MCB_UILDQSINC           <= 1'b0;  // no inc or dec
+          MCB_UIUDQSINC           <= 1'b0;  // no inc or dec
+          MCB_UILDQSDEC           <= 1'b0;  // no inc or dec
+          MCB_UIUDQSDEC           <= 1'b0;  // no inc or dec
+          counter_en              <= 1'b0;
+          First_Dyn_Cal_Done      <= 1'b0;  // flag that the First Dynamic Calibration completed
+          Max_Value               <= Max_Value;
+          STATE                   <= START;
+        end
+      endcase
+    end
+  end
+
+endmodule

--- a/systems/atlys/rtl/verilog/xilinx_ddr2/mcb_soft_calibration_top.v
+++ b/systems/atlys/rtl/verilog/xilinx_ddr2/mcb_soft_calibration_top.v
@@ -1,0 +1,283 @@
+//*****************************************************************************
+// (c) Copyright 2009 Xilinx, Inc. All rights reserved.
+//
+// This file contains confidential and proprietary information
+// of Xilinx, Inc. and is protected under U.S. and
+// international copyright and other intellectual property
+// laws.
+//
+// DISCLAIMER
+// This disclaimer is not a license and does not grant any
+// rights to the materials distributed herewith. Except as
+// otherwise provided in a valid license issued to you by
+// Xilinx, and to the maximum extent permitted by applicable
+// law: (1) THESE MATERIALS ARE MADE AVAILABLE "AS IS" AND
+// WITH ALL FAULTS, AND XILINX HEREBY DISCLAIMS ALL WARRANTIES
+// AND CONDITIONS, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING
+// BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, NON-
+// INFRINGEMENT, OR FITNESS FOR ANY PARTICULAR PURPOSE; and
+// (2) Xilinx shall not be liable (whether in contract or tort,
+// including negligence, or under any other theory of
+// liability) for any loss or damage of any kind or nature
+// related to, arising under or in connection with these
+// materials, including for any direct, or any indirect,
+// special, incidental, or consequential loss or damage
+// (including loss of data, profits, goodwill, or any type of
+// loss or damage suffered as a result of any action brought
+// by a third party) even if such damage or loss was
+// reasonably foreseeable or Xilinx had been advised of the
+// possibility of the same.
+//
+// CRITICAL APPLICATIONS
+// Xilinx products are not designed or intended to be fail-
+// safe, or for use in any application requiring fail-safe
+// performance, such as life-support or safety devices or
+// systems, Class III medical devices, nuclear facilities,
+// applications related to the deployment of airbags, or any
+// other applications that could lead to death, personal
+// injury, or severe property or environmental damage
+// (individually and collectively, "Critical
+// Applications"). Customer assumes the sole risk and
+// liability of any use of Xilinx products in Critical
+// Applications, subject only to applicable laws and
+// regulations governing limitations on product liability.
+//
+// THIS COPYRIGHT NOTICE AND DISCLAIMER MUST BE RETAINED AS
+// PART OF THIS FILE AT ALL TIMES.
+//
+//*****************************************************************************
+//   ____  ____
+//  /   /\/   /
+// /___/  \  /    Vendor: Xilinx
+// \   \   \/     Version: %version
+//  \   \         Application: MIG
+//  /   /         Filename: mcb_soft_calibration_top.v
+// /___/   /\     Date Last Modified: $Date: 2010/10/27 17:40:12 $
+// \   \  /  \    Date Created: Mon Feb 9 2009
+//  \___\/\___\
+//
+//Device: Spartan6
+//Design Name: DDR/DDR2/DDR3/LPDDR
+//Purpose:  Xilinx reference design top-level simulation
+//           wrapper file for input termination calibration
+//Reference:
+//
+//  Revision:      Date:  Comment
+//     1.0:  2/06/09:  Initial version for MIG wrapper.
+//     1.1:  3/16/09: Added pll_lock port, for using it to gate reset
+//     1.2: 6/06/09:  Removed MCB_UIDQCOUNT.
+//     1.3: 6/18/09:  corrected/changed MCB_SYSRST to be an output port
+//     1.4: 6/24/09:  gave RZQ and ZIO each their own unique ADD and SDI nets
+//     1.5: 10/08/09: removed INCDEC_TRESHOLD parameter - making it a localparam inside mcb_soft_calibration
+//     1.6: 02/04/09: Added condition generate statmenet for ZIO pin.	   
+//     1.7: 04/12/10: Added CKE_Train signal to fix DDR2 init wait .
+//
+// End Revision
+//**********************************************************************************
+
+`timescale 1ps/1ps
+
+module mcb_soft_calibration_top  # (
+  parameter       C_MEM_TZQINIT_MAXCNT  = 10'h512,  // DDR3 Minimum delay between resets
+  parameter       C_MC_CALIBRATION_MODE = "CALIBRATION", // if set to CALIBRATION will reset DQS IDELAY to DQS_NUMERATOR/DQS_DENOMINATOR local_param values, and does dynamic recal,
+                                                         // if set to NOCALIBRATION then defaults to hard cal blocks setting of C_MC_CALBRATION_DELAY *and* no dynamic recal will be done 
+  parameter       SKIP_IN_TERM_CAL  = 1'b0,     // provides option to skip the input termination calibration
+  parameter       SKIP_DYNAMIC_CAL  = 1'b0,     // provides option to skip the dynamic delay calibration
+  parameter       SKIP_DYN_IN_TERM  = 1'b0,     // provides option to skip the input termination calibration
+  parameter       C_SIMULATION      = "FALSE",  // Tells us whether the design is being simulated or implemented
+  parameter       C_MEM_TYPE        = "DDR"	// provides the memory device used for the design
+  )
+  (
+  input   wire        UI_CLK,                 // Input - global clock to be used for input_term_tuner and IODRP clock
+  input   wire        RST,                    // Input - reset for input_term_tuner - synchronous for input_term_tuner state machine, asynch for IODRP (sub)controller
+  input   wire        IOCLK,                  // Input - IOCLK input to the IODRP's
+  output  wire        DONE_SOFTANDHARD_CAL,   // active high flag signals soft calibration of input delays is complete and MCB_UODONECAL is high (MCB hard calib complete)
+  input   wire        PLL_LOCK,               // Lock signal from PLL
+  input   wire        SELFREFRESH_REQ,     
+  input   wire        SELFREFRESH_MCB_MODE,
+  output  wire         SELFREFRESH_MCB_REQ ,
+  output  wire         SELFREFRESH_MODE,    
+  
+  
+  
+  
+  output  wire        MCB_UIADD,              // to MCB's UIADD port
+  output  wire        MCB_UISDI,              // to MCB's UISDI port
+  input   wire        MCB_UOSDO,
+  input   wire        MCB_UODONECAL,
+  input   wire        MCB_UOREFRSHFLAG,
+  output  wire        MCB_UICS,
+  output  wire        MCB_UIDRPUPDATE,
+  output  wire        MCB_UIBROADCAST,
+  output  wire  [4:0] MCB_UIADDR,
+  output  wire        MCB_UICMDEN,
+  output  wire        MCB_UIDONECAL,
+  output  wire        MCB_UIDQLOWERDEC,
+  output  wire        MCB_UIDQLOWERINC,
+  output  wire        MCB_UIDQUPPERDEC,
+  output  wire        MCB_UIDQUPPERINC,
+  output  wire        MCB_UILDQSDEC,
+  output  wire        MCB_UILDQSINC,
+  output  wire        MCB_UIREAD,
+  output  wire        MCB_UIUDQSDEC,
+  output  wire        MCB_UIUDQSINC,
+  output  wire        MCB_RECAL,
+  output  wire        MCB_SYSRST,
+  output  wire        MCB_UICMD,
+  output  wire        MCB_UICMDIN,
+  output  wire  [3:0] MCB_UIDQCOUNT,
+  input   wire  [7:0] MCB_UODATA,
+  input   wire        MCB_UODATAVALID,
+  input   wire        MCB_UOCMDREADY,
+  input   wire        MCB_UO_CAL_START,
+  
+  inout   wire        RZQ_Pin,
+  inout   wire        ZIO_Pin,
+  output  wire            CKE_Train
+  
+  );
+
+  wire IODRP_ADD;
+  wire IODRP_SDI;
+  wire RZQ_IODRP_SDO;
+  wire RZQ_IODRP_CS;
+  wire ZIO_IODRP_SDO;
+  wire ZIO_IODRP_CS;
+  wire IODRP_SDO;
+  wire IODRP_CS;
+  wire IODRP_BKST;
+  wire RZQ_ZIO_ODATAIN;
+  wire RZQ_ZIO_TRISTATE;
+  wire RZQ_TOUT;
+  wire ZIO_TOUT;
+  wire [7:0] Max_Value;
+  
+  assign RZQ_ZIO_ODATAIN  = ~RST;
+  assign RZQ_ZIO_TRISTATE = ~RST;
+  assign IODRP_BKST       = 1'b0;  //future hook for possible BKST to ZIO and RZQ
+
+
+mcb_soft_calibration #(
+  .C_MEM_TZQINIT_MAXCNT (C_MEM_TZQINIT_MAXCNT),
+  .C_MC_CALIBRATION_MODE(C_MC_CALIBRATION_MODE),
+  .SKIP_IN_TERM_CAL     (SKIP_IN_TERM_CAL),
+  .SKIP_DYNAMIC_CAL     (SKIP_DYNAMIC_CAL),
+  .SKIP_DYN_IN_TERM     (SKIP_DYN_IN_TERM),
+  .C_SIMULATION         (C_SIMULATION),
+  .C_MEM_TYPE           (C_MEM_TYPE)
+  ) 
+mcb_soft_calibration_inst (
+  .UI_CLK               (UI_CLK),  // main clock input for logic and IODRP CLK pins.  At top level, this should also connect to IODRP2_MCB CLK pins
+  .RST                  (RST),             // main system reset for both this Soft Calibration block - also will act as a passthrough to MCB's SYSRST
+  .PLL_LOCK             (PLL_LOCK), //lock signal from PLL
+  .SELFREFRESH_REQ      (SELFREFRESH_REQ),    
+  .SELFREFRESH_MCB_MODE  (SELFREFRESH_MCB_MODE),
+  .SELFREFRESH_MCB_REQ   (SELFREFRESH_MCB_REQ ),
+  .SELFREFRESH_MODE     (SELFREFRESH_MODE),   
+  
+  .DONE_SOFTANDHARD_CAL (DONE_SOFTANDHARD_CAL),// active high flag signals soft calibration of input delays is complete and MCB_UODONECAL is high (MCB hard calib complete)        .IODRP_ADD(IODRP_ADD),       // RZQ and ZIO IODRP ADD port, and MCB's UIADD port
+  .IODRP_ADD            (IODRP_ADD),       // RZQ and ZIO IODRP ADD port
+  .IODRP_SDI            (IODRP_SDI),       // RZQ and ZIO IODRP SDI port, and MCB's UISDI port
+  .RZQ_IN               (RZQ_IN),         // RZQ pin from board - expected to have a 2*R resistor to ground
+  .RZQ_IODRP_SDO        (RZQ_IODRP_SDO),   // RZQ IODRP's SDO port
+  .RZQ_IODRP_CS         (RZQ_IODRP_CS),   // RZQ IODRP's CS port
+  .ZIO_IN               (ZIO_IN),         // Z-stated IO pin - garanteed not to be driven externally
+  .ZIO_IODRP_SDO        (ZIO_IODRP_SDO),   // ZIO IODRP's SDO port
+  .ZIO_IODRP_CS         (ZIO_IODRP_CS),   // ZIO IODRP's CS port
+  .MCB_UIADD            (MCB_UIADD),      // to MCB's UIADD port
+  .MCB_UISDI            (MCB_UISDI),      // to MCB's UISDI port
+  .MCB_UOSDO            (MCB_UOSDO),      // from MCB's UOSDO port (User output SDO)
+  .MCB_UODONECAL        (MCB_UODONECAL), // indicates when MCB hard calibration process is complete
+  .MCB_UOREFRSHFLAG     (MCB_UOREFRSHFLAG), //high during refresh cycle and time when MCB is innactive
+  .MCB_UICS             (MCB_UICS),         // to MCB's UICS port (User Input CS)
+  .MCB_UIDRPUPDATE      (MCB_UIDRPUPDATE),  // MCB's UIDRPUPDATE port (gets passed to IODRP2_MCB's MEMUPDATE port: this controls shadow latch used during IODRP2_MCB writes).  Currently just trasnparent
+  .MCB_UIBROADCAST      (MCB_UIBROADCAST),  // to MCB's UIBROADCAST port (User Input BROADCAST - gets passed to IODRP2_MCB's BKST port)
+  .MCB_UIADDR           (MCB_UIADDR),        //to MCB's UIADDR port (gets passed to IODRP2_MCB's AUXADDR port
+  .MCB_UICMDEN          (MCB_UICMDEN),       //set to take control of UI interface - removes control from internal calib block
+  .MCB_UIDONECAL        (MCB_UIDONECAL),
+  .MCB_UIDQLOWERDEC     (MCB_UIDQLOWERDEC),
+  .MCB_UIDQLOWERINC     (MCB_UIDQLOWERINC),
+  .MCB_UIDQUPPERDEC     (MCB_UIDQUPPERDEC),
+  .MCB_UIDQUPPERINC     (MCB_UIDQUPPERINC),
+  .MCB_UILDQSDEC        (MCB_UILDQSDEC),
+  .MCB_UILDQSINC        (MCB_UILDQSINC),
+  .MCB_UIREAD           (MCB_UIREAD),        //enables read w/o writing by turning on a SDO->SDI loopback inside the IODRP2_MCBs (doesn't exist in regular IODRP2).  IODRPCTRLR_R_WB becomes don't-care.
+  .MCB_UIUDQSDEC        (MCB_UIUDQSDEC),
+  .MCB_UIUDQSINC        (MCB_UIUDQSINC),
+  .MCB_RECAL            (MCB_RECAL),         //when high initiates a hard re-calibration sequence
+  .MCB_UICMD            (MCB_UICMD        ),
+  .MCB_UICMDIN          (MCB_UICMDIN      ),
+  .MCB_UIDQCOUNT        (MCB_UIDQCOUNT    ),
+  .MCB_UODATA           (MCB_UODATA       ),
+  .MCB_UODATAVALID      (MCB_UODATAVALID  ),
+  .MCB_UOCMDREADY       (MCB_UOCMDREADY   ),
+  .MCB_UO_CAL_START     (MCB_UO_CAL_START),
+  .MCB_SYSRST           (MCB_SYSRST       ), //drives the MCB's SYSRST pin - the main reset for MCB
+  .Max_Value            (Max_Value        ),  // Maximum Tap Value from calibrated IOI
+  .CKE_Train            (CKE_Train)
+);
+
+
+IOBUF IOBUF_RZQ (
+    .O  (RZQ_IN),
+    .IO (RZQ_Pin),
+    .I  (RZQ_OUT),
+    .T  (RZQ_TOUT)
+    );
+
+IODRP2 IODRP2_RZQ       (
+      .DATAOUT(),
+      .DATAOUT2(),
+      .DOUT(RZQ_OUT),
+      .SDO(RZQ_IODRP_SDO),
+      .TOUT(RZQ_TOUT),
+      .ADD(IODRP_ADD),
+      .BKST(IODRP_BKST),
+      .CLK(UI_CLK),
+      .CS(RZQ_IODRP_CS),
+      .IDATAIN(RZQ_IN),
+      .IOCLK0(IOCLK),
+      .IOCLK1(1'b1),
+      .ODATAIN(RZQ_ZIO_ODATAIN),
+      .SDI(IODRP_SDI),
+      .T(RZQ_ZIO_TRISTATE)
+      );
+
+
+generate 
+if ((C_MEM_TYPE == "DDR" || C_MEM_TYPE == "DDR2" || C_MEM_TYPE == "DDR3") &&
+     (SKIP_IN_TERM_CAL == 1'b0)
+     ) begin : gen_zio
+
+IOBUF IOBUF_ZIO (
+    .O  (ZIO_IN),
+    .IO (ZIO_Pin),
+    .I  (ZIO_OUT),
+    .T  (ZIO_TOUT)
+    );
+
+
+IODRP2 IODRP2_ZIO       (
+      .DATAOUT(),
+      .DATAOUT2(),
+      .DOUT(ZIO_OUT),
+      .SDO(ZIO_IODRP_SDO),
+      .TOUT(ZIO_TOUT),
+      .ADD(IODRP_ADD),
+      .BKST(IODRP_BKST),
+      .CLK(UI_CLK),
+      .CS(ZIO_IODRP_CS),
+      .IDATAIN(ZIO_IN),
+      .IOCLK0(IOCLK),
+      .IOCLK1(1'b1),
+      .ODATAIN(RZQ_ZIO_ODATAIN),
+      .SDI(IODRP_SDI),
+      .T(RZQ_ZIO_TRISTATE)
+      );
+
+
+end 
+endgenerate
+      
+
+endmodule

--- a/systems/atlys/rtl/verilog/xilinx_ddr2/mcb_ui_top.v
+++ b/systems/atlys/rtl/verilog/xilinx_ddr2/mcb_ui_top.v
@@ -1,0 +1,2162 @@
+//*****************************************************************************
+// (c) Copyright 2009 Xilinx, Inc. All rights reserved.
+//
+// This file contains confidential and proprietary information
+// of Xilinx, Inc. and is protected under U.S. and
+// international copyright and other intellectual property
+// laws.
+//
+// DISCLAIMER
+// This disclaimer is not a license and does not grant any
+// rights to the materials distributed herewith. Except as
+// otherwise provided in a valid license issued to you by
+// Xilinx, and to the maximum extent permitted by applicable
+// law: (1) THESE MATERIALS ARE MADE AVAILABLE "AS IS" AND
+// WITH ALL FAULTS, AND XILINX HEREBY DISCLAIMS ALL WARRANTIES
+// AND CONDITIONS, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING
+// BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, NON-
+// INFRINGEMENT, OR FITNESS FOR ANY PARTICULAR PURPOSE; and
+// (2) Xilinx shall not be liable (whether in contract or tort,
+// including negligence, or under any other theory of
+// liability) for any loss or damage of any kind or nature
+// related to, arising under or in connection with these
+// materials, including for any direct, or any indirect,
+// special, incidental, or consequential loss or damage
+// (including loss of data, profits, goodwill, or any type of
+// loss or damage suffered as a result of any action brought
+// by a third party) even if such damage or loss was
+// reasonably foreseeable or Xilinx had been advised of the
+// possibility of the same.
+//
+// CRITICAL APPLICATIONS
+// Xilinx products are not designed or intended to be fail-
+// safe, or for use in any application requiring fail-safe
+// performance, such as life-support or safety devices or
+// systems, Class III medical devices, nuclear facilities,
+// applications related to the deployment of airbags, or any
+// other applications that could lead to death, personal
+// injury, or severe property or environmental damage
+// (individually and collectively, "Critical
+// Applications"). Customer assumes the sole risk and
+// liability of any use of Xilinx products in Critical
+// Applications, subject only to applicable laws and
+// regulations governing limitations on product liability.
+//
+// THIS COPYRIGHT NOTICE AND DISCLAIMER MUST BE RETAINED AS
+// PART OF THIS FILE AT ALL TIMES.
+//
+//*****************************************************************************
+//Device: Spartan6
+//Design Name: DDR/DDR2/DDR3/LPDDR
+//Purpose:
+//Reference:
+//   This module instantiates the AXI bridges
+//
+//*****************************************************************************
+`timescale 1ps / 1ps
+
+module mcb_ui_top #
+   (
+///////////////////////////////////////////////////////////////////////////////
+// Parameter Definitions
+///////////////////////////////////////////////////////////////////////////////
+   // Raw Wrapper Parameters
+   parameter         C_MEMCLK_PERIOD           = 2500,
+   parameter         C_PORT_ENABLE             = 6'b111111,
+   parameter         C_MEM_ADDR_ORDER          = "BANK_ROW_COLUMN",
+   parameter         C_ARB_ALGORITHM           = 0,
+   parameter         C_ARB_NUM_TIME_SLOTS      = 12,
+   parameter         C_ARB_TIME_SLOT_0         = 18'o012345,
+   parameter         C_ARB_TIME_SLOT_1         = 18'o123450,
+   parameter         C_ARB_TIME_SLOT_2         = 18'o234501,
+   parameter         C_ARB_TIME_SLOT_3         = 18'o345012,
+   parameter         C_ARB_TIME_SLOT_4         = 18'o450123,
+   parameter         C_ARB_TIME_SLOT_5         = 18'o501234,
+   parameter         C_ARB_TIME_SLOT_6         = 18'o012345,
+   parameter         C_ARB_TIME_SLOT_7         = 18'o123450,
+   parameter         C_ARB_TIME_SLOT_8         = 18'o234501,
+   parameter         C_ARB_TIME_SLOT_9         = 18'o345012,
+   parameter         C_ARB_TIME_SLOT_10        = 18'o450123,
+   parameter         C_ARB_TIME_SLOT_11        = 18'o501234,
+   parameter         C_PORT_CONFIG             = "B128",
+   parameter         C_MEM_TRAS                = 45000,
+   parameter         C_MEM_TRCD                = 12500,
+   parameter         C_MEM_TREFI               = 7800,
+   parameter         C_MEM_TRFC                = 127500,
+   parameter         C_MEM_TRP                 = 12500,
+   parameter         C_MEM_TWR                 = 15000,
+   parameter         C_MEM_TRTP                = 7500,
+   parameter         C_MEM_TWTR                = 7500,
+   parameter         C_NUM_DQ_PINS             = 8,
+   parameter         C_MEM_TYPE                = "DDR3",
+   parameter         C_MEM_DENSITY             = "512M",
+   parameter         C_MEM_BURST_LEN           = 8,
+   parameter         C_MEM_CAS_LATENCY         = 4,
+   parameter         C_MEM_ADDR_WIDTH          = 13,
+   parameter         C_MEM_BANKADDR_WIDTH      = 3,
+   parameter         C_MEM_NUM_COL_BITS        = 11,
+   parameter         C_MEM_DDR3_CAS_LATENCY    = 7,
+   parameter         C_MEM_MOBILE_PA_SR        = "FULL",
+   parameter         C_MEM_DDR1_2_ODS          = "FULL",
+   parameter         C_MEM_DDR3_ODS            = "DIV6",
+   parameter         C_MEM_DDR2_RTT            = "50OHMS",
+   parameter         C_MEM_DDR3_RTT            = "DIV2",
+   parameter         C_MEM_MDDR_ODS            = "FULL",
+   parameter         C_MEM_DDR2_DIFF_DQS_EN    = "YES",
+   parameter         C_MEM_DDR2_3_PA_SR        = "OFF",
+   parameter         C_MEM_DDR3_CAS_WR_LATENCY = 5,
+   parameter         C_MEM_DDR3_AUTO_SR        = "ENABLED",
+   parameter         C_MEM_DDR2_3_HIGH_TEMP_SR = "NORMAL",
+   parameter         C_MEM_DDR3_DYN_WRT_ODT    = "OFF",
+   parameter         C_MEM_TZQINIT_MAXCNT      = 10'd512,
+   parameter         C_MC_CALIB_BYPASS         = "NO",
+   parameter         C_MC_CALIBRATION_RA       = 15'h0000,
+   parameter         C_MC_CALIBRATION_BA       = 3'h0,
+   parameter         C_CALIB_SOFT_IP           = "TRUE",
+   parameter         C_SKIP_IN_TERM_CAL        = 1'b0,
+   parameter         C_SKIP_DYNAMIC_CAL        = 1'b0,
+   parameter         C_SKIP_DYN_IN_TERM        = 1'b1,
+   parameter         LDQSP_TAP_DELAY_VAL       = 0,
+   parameter         UDQSP_TAP_DELAY_VAL       = 0,
+   parameter         LDQSN_TAP_DELAY_VAL       = 0,
+   parameter         UDQSN_TAP_DELAY_VAL       = 0,
+   parameter         DQ0_TAP_DELAY_VAL         = 0,
+   parameter         DQ1_TAP_DELAY_VAL         = 0,
+   parameter         DQ2_TAP_DELAY_VAL         = 0,
+   parameter         DQ3_TAP_DELAY_VAL         = 0,
+   parameter         DQ4_TAP_DELAY_VAL         = 0,
+   parameter         DQ5_TAP_DELAY_VAL         = 0,
+   parameter         DQ6_TAP_DELAY_VAL         = 0,
+   parameter         DQ7_TAP_DELAY_VAL         = 0,
+   parameter         DQ8_TAP_DELAY_VAL         = 0,
+   parameter         DQ9_TAP_DELAY_VAL         = 0,
+   parameter         DQ10_TAP_DELAY_VAL        = 0,
+   parameter         DQ11_TAP_DELAY_VAL        = 0,
+   parameter         DQ12_TAP_DELAY_VAL        = 0,
+   parameter         DQ13_TAP_DELAY_VAL        = 0,
+   parameter         DQ14_TAP_DELAY_VAL        = 0,
+   parameter         DQ15_TAP_DELAY_VAL        = 0,
+   parameter         C_MC_CALIBRATION_CA       = 12'h000,
+   parameter         C_MC_CALIBRATION_CLK_DIV  = 1,
+   parameter         C_MC_CALIBRATION_MODE     = "CALIBRATION",
+   parameter         C_MC_CALIBRATION_DELAY    = "HALF",
+   parameter         C_SIMULATION              = "FALSE",
+   parameter         C_P0_MASK_SIZE            = 4,
+   parameter         C_P0_DATA_PORT_SIZE       = 32,
+   parameter         C_P1_MASK_SIZE            = 4,
+   parameter         C_P1_DATA_PORT_SIZE       = 32,
+   parameter integer C_MCB_USE_EXTERNAL_BUFPLL = 1,
+   // AXI Parameters
+   parameter         C_S0_AXI_BASEADDR         = 32'h00000000,
+   parameter         C_S0_AXI_HIGHADDR         = 32'h00000000,
+   parameter integer C_S0_AXI_ENABLE           = 0,
+   parameter integer C_S0_AXI_ID_WIDTH         = 4,
+   parameter integer C_S0_AXI_ADDR_WIDTH       = 64,
+   parameter integer C_S0_AXI_DATA_WIDTH       = 32,
+   parameter integer C_S0_AXI_SUPPORTS_READ    = 1,
+   parameter integer C_S0_AXI_SUPPORTS_WRITE   = 1,
+   parameter integer C_S0_AXI_SUPPORTS_NARROW_BURST  = 1,
+   parameter         C_S0_AXI_REG_EN0          = 20'h00000,
+   parameter         C_S0_AXI_REG_EN1          = 20'h01000,
+   parameter integer C_S0_AXI_STRICT_COHERENCY = 1,
+   parameter integer C_S0_AXI_ENABLE_AP        = 0,
+   parameter         C_S1_AXI_BASEADDR         = 32'h00000000,
+   parameter         C_S1_AXI_HIGHADDR         = 32'h00000000,
+   parameter integer C_S1_AXI_ENABLE           = 0,
+   parameter integer C_S1_AXI_ID_WIDTH         = 4,
+   parameter integer C_S1_AXI_ADDR_WIDTH       = 64,
+   parameter integer C_S1_AXI_DATA_WIDTH       = 32,
+   parameter integer C_S1_AXI_SUPPORTS_READ    = 1,
+   parameter integer C_S1_AXI_SUPPORTS_WRITE   = 1,
+   parameter integer C_S1_AXI_SUPPORTS_NARROW_BURST  = 1,
+   parameter         C_S1_AXI_REG_EN0          = 20'h00000,
+   parameter         C_S1_AXI_REG_EN1          = 20'h01000,
+   parameter integer C_S1_AXI_STRICT_COHERENCY = 1,
+   parameter integer C_S1_AXI_ENABLE_AP        = 0,
+   parameter         C_S2_AXI_BASEADDR         = 32'h00000000,
+   parameter         C_S2_AXI_HIGHADDR         = 32'h00000000,
+   parameter integer C_S2_AXI_ENABLE           = 0,
+   parameter integer C_S2_AXI_ID_WIDTH         = 4,
+   parameter integer C_S2_AXI_ADDR_WIDTH       = 64,
+   parameter integer C_S2_AXI_DATA_WIDTH       = 32,
+   parameter integer C_S2_AXI_SUPPORTS_READ    = 1,
+   parameter integer C_S2_AXI_SUPPORTS_WRITE   = 1,
+   parameter integer C_S2_AXI_SUPPORTS_NARROW_BURST  = 1,
+   parameter         C_S2_AXI_REG_EN0          = 20'h00000,
+   parameter         C_S2_AXI_REG_EN1          = 20'h01000,
+   parameter integer C_S2_AXI_STRICT_COHERENCY = 1,
+   parameter integer C_S2_AXI_ENABLE_AP        = 0,
+   parameter         C_S3_AXI_BASEADDR         = 32'h00000000,
+   parameter         C_S3_AXI_HIGHADDR         = 32'h00000000,
+   parameter integer C_S3_AXI_ENABLE           = 0,
+   parameter integer C_S3_AXI_ID_WIDTH         = 4,
+   parameter integer C_S3_AXI_ADDR_WIDTH       = 64,
+   parameter integer C_S3_AXI_DATA_WIDTH       = 32,
+   parameter integer C_S3_AXI_SUPPORTS_READ    = 1,
+   parameter integer C_S3_AXI_SUPPORTS_WRITE   = 1,
+   parameter integer C_S3_AXI_SUPPORTS_NARROW_BURST  = 1,
+   parameter         C_S3_AXI_REG_EN0          = 20'h00000,
+   parameter         C_S3_AXI_REG_EN1          = 20'h01000,
+   parameter integer C_S3_AXI_STRICT_COHERENCY = 1,
+   parameter integer C_S3_AXI_ENABLE_AP        = 0,
+   parameter         C_S4_AXI_BASEADDR         = 32'h00000000,
+   parameter         C_S4_AXI_HIGHADDR         = 32'h00000000,
+   parameter integer C_S4_AXI_ENABLE           = 0,
+   parameter integer C_S4_AXI_ID_WIDTH         = 4,
+   parameter integer C_S4_AXI_ADDR_WIDTH       = 64,
+   parameter integer C_S4_AXI_DATA_WIDTH       = 32,
+   parameter integer C_S4_AXI_SUPPORTS_READ    = 1,
+   parameter integer C_S4_AXI_SUPPORTS_WRITE   = 1,
+   parameter integer C_S4_AXI_SUPPORTS_NARROW_BURST  = 1,
+   parameter         C_S4_AXI_REG_EN0          = 20'h00000,
+   parameter         C_S4_AXI_REG_EN1          = 20'h01000,
+   parameter integer C_S4_AXI_STRICT_COHERENCY = 1,
+   parameter integer C_S4_AXI_ENABLE_AP        = 0,
+   parameter         C_S5_AXI_BASEADDR         = 32'h00000000,
+   parameter         C_S5_AXI_HIGHADDR         = 32'h00000000,
+   parameter integer C_S5_AXI_ENABLE           = 0,
+   parameter integer C_S5_AXI_ID_WIDTH         = 4,
+   parameter integer C_S5_AXI_ADDR_WIDTH       = 64,
+   parameter integer C_S5_AXI_DATA_WIDTH       = 32,
+   parameter integer C_S5_AXI_SUPPORTS_READ    = 1,
+   parameter integer C_S5_AXI_SUPPORTS_WRITE   = 1,
+   parameter integer C_S5_AXI_SUPPORTS_NARROW_BURST  = 1,
+   parameter         C_S5_AXI_REG_EN0          = 20'h00000,
+   parameter         C_S5_AXI_REG_EN1          = 20'h01000,
+   parameter integer C_S5_AXI_STRICT_COHERENCY = 1,
+   parameter integer C_S5_AXI_ENABLE_AP        = 0
+   )
+   (
+///////////////////////////////////////////////////////////////////////////////
+// Port Declarations
+///////////////////////////////////////////////////////////////////////////////
+   // Raw Wrapper Signals
+   input                                     sysclk_2x          ,
+   input                                     sysclk_2x_180      ,
+   input                                     pll_ce_0           ,
+   input                                     pll_ce_90          ,
+   output                                    sysclk_2x_bufpll_o ,
+   output                                    sysclk_2x_180_bufpll_o,
+   output                                    pll_ce_0_bufpll_o  ,
+   output                                    pll_ce_90_bufpll_o ,
+   output                                    pll_lock_bufpll_o  ,
+   input                                     pll_lock           ,
+   input                                     sys_rst            ,
+   input                                     p0_arb_en          ,
+   input                                     p0_cmd_clk         ,
+   input                                     p0_cmd_en          ,
+   input       [2:0]                         p0_cmd_instr       ,
+   input       [5:0]                         p0_cmd_bl          ,
+   input       [29:0]                        p0_cmd_byte_addr   ,
+   output                                    p0_cmd_empty       ,
+   output                                    p0_cmd_full        ,
+   input                                     p0_wr_clk          ,
+   input                                     p0_wr_en           ,
+   input       [C_P0_MASK_SIZE-1:0]          p0_wr_mask         ,
+   input       [C_P0_DATA_PORT_SIZE-1:0]     p0_wr_data         ,
+   output                                    p0_wr_full         ,
+   output                                    p0_wr_empty        ,
+   output      [6:0]                         p0_wr_count        ,
+   output                                    p0_wr_underrun     ,
+   output                                    p0_wr_error        ,
+   input                                     p0_rd_clk          ,
+   input                                     p0_rd_en           ,
+   output      [C_P0_DATA_PORT_SIZE-1:0]     p0_rd_data         ,
+   output                                    p0_rd_full         ,
+   output                                    p0_rd_empty        ,
+   output      [6:0]                         p0_rd_count        ,
+   output                                    p0_rd_overflow     ,
+   output                                    p0_rd_error        ,
+   input                                     p1_arb_en          ,
+   input                                     p1_cmd_clk         ,
+   input                                     p1_cmd_en          ,
+   input       [2:0]                         p1_cmd_instr       ,
+   input       [5:0]                         p1_cmd_bl          ,
+   input       [29:0]                        p1_cmd_byte_addr   ,
+   output                                    p1_cmd_empty       ,
+   output                                    p1_cmd_full        ,
+   input                                     p1_wr_clk          ,
+   input                                     p1_wr_en           ,
+   input       [C_P1_MASK_SIZE-1:0]          p1_wr_mask         ,
+   input       [C_P1_DATA_PORT_SIZE-1:0]     p1_wr_data         ,
+   output                                    p1_wr_full         ,
+   output                                    p1_wr_empty        ,
+   output      [6:0]                         p1_wr_count        ,
+   output                                    p1_wr_underrun     ,
+   output                                    p1_wr_error        ,
+   input                                     p1_rd_clk          ,
+   input                                     p1_rd_en           ,
+   output      [C_P1_DATA_PORT_SIZE-1:0]     p1_rd_data         ,
+   output                                    p1_rd_full         ,
+   output                                    p1_rd_empty        ,
+   output      [6:0]                         p1_rd_count        ,
+   output                                    p1_rd_overflow     ,
+   output                                    p1_rd_error        ,
+   input                                     p2_arb_en          ,
+   input                                     p2_cmd_clk         ,
+   input                                     p2_cmd_en          ,
+   input       [2:0]                         p2_cmd_instr       ,
+   input       [5:0]                         p2_cmd_bl          ,
+   input       [29:0]                        p2_cmd_byte_addr   ,
+   output                                    p2_cmd_empty       ,
+   output                                    p2_cmd_full        ,
+   input                                     p2_wr_clk          ,
+   input                                     p2_wr_en           ,
+   input       [3:0]                         p2_wr_mask         ,
+   input       [31:0]                        p2_wr_data         ,
+   output                                    p2_wr_full         ,
+   output                                    p2_wr_empty        ,
+   output      [6:0]                         p2_wr_count        ,
+   output                                    p2_wr_underrun     ,
+   output                                    p2_wr_error        ,
+   input                                     p2_rd_clk          ,
+   input                                     p2_rd_en           ,
+   output      [31:0]                        p2_rd_data         ,
+   output                                    p2_rd_full         ,
+   output                                    p2_rd_empty        ,
+   output      [6:0]                         p2_rd_count        ,
+   output                                    p2_rd_overflow     ,
+   output                                    p2_rd_error        ,
+   input                                     p3_arb_en          ,
+   input                                     p3_cmd_clk         ,
+   input                                     p3_cmd_en          ,
+   input       [2:0]                         p3_cmd_instr       ,
+   input       [5:0]                         p3_cmd_bl          ,
+   input       [29:0]                        p3_cmd_byte_addr   ,
+   output                                    p3_cmd_empty       ,
+   output                                    p3_cmd_full        ,
+   input                                     p3_wr_clk          ,
+   input                                     p3_wr_en           ,
+   input       [3:0]                         p3_wr_mask         ,
+   input       [31:0]                        p3_wr_data         ,
+   output                                    p3_wr_full         ,
+   output                                    p3_wr_empty        ,
+   output      [6:0]                         p3_wr_count        ,
+   output                                    p3_wr_underrun     ,
+   output                                    p3_wr_error        ,
+   input                                     p3_rd_clk          ,
+   input                                     p3_rd_en           ,
+   output      [31:0]                        p3_rd_data         ,
+   output                                    p3_rd_full         ,
+   output                                    p3_rd_empty        ,
+   output      [6:0]                         p3_rd_count        ,
+   output                                    p3_rd_overflow     ,
+   output                                    p3_rd_error        ,
+   input                                     p4_arb_en          ,
+   input                                     p4_cmd_clk         ,
+   input                                     p4_cmd_en          ,
+   input       [2:0]                         p4_cmd_instr       ,
+   input       [5:0]                         p4_cmd_bl          ,
+   input       [29:0]                        p4_cmd_byte_addr   ,
+   output                                    p4_cmd_empty       ,
+   output                                    p4_cmd_full        ,
+   input                                     p4_wr_clk          ,
+   input                                     p4_wr_en           ,
+   input       [3:0]                         p4_wr_mask         ,
+   input       [31:0]                        p4_wr_data         ,
+   output                                    p4_wr_full         ,
+   output                                    p4_wr_empty        ,
+   output      [6:0]                         p4_wr_count        ,
+   output                                    p4_wr_underrun     ,
+   output                                    p4_wr_error        ,
+   input                                     p4_rd_clk          ,
+   input                                     p4_rd_en           ,
+   output      [31:0]                        p4_rd_data         ,
+   output                                    p4_rd_full         ,
+   output                                    p4_rd_empty        ,
+   output      [6:0]                         p4_rd_count        ,
+   output                                    p4_rd_overflow     ,
+   output                                    p4_rd_error        ,
+   input                                     p5_arb_en          ,
+   input                                     p5_cmd_clk         ,
+   input                                     p5_cmd_en          ,
+   input       [2:0]                         p5_cmd_instr       ,
+   input       [5:0]                         p5_cmd_bl          ,
+   input       [29:0]                        p5_cmd_byte_addr   ,
+   output                                    p5_cmd_empty       ,
+   output                                    p5_cmd_full        ,
+   input                                     p5_wr_clk          ,
+   input                                     p5_wr_en           ,
+   input       [3:0]                         p5_wr_mask         ,
+   input       [31:0]                        p5_wr_data         ,
+   output                                    p5_wr_full         ,
+   output                                    p5_wr_empty        ,
+   output      [6:0]                         p5_wr_count        ,
+   output                                    p5_wr_underrun     ,
+   output                                    p5_wr_error        ,
+   input                                     p5_rd_clk          ,
+   input                                     p5_rd_en           ,
+   output      [31:0]                        p5_rd_data         ,
+   output                                    p5_rd_full         ,
+   output                                    p5_rd_empty        ,
+   output      [6:0]                         p5_rd_count        ,
+   output                                    p5_rd_overflow     ,
+   output                                    p5_rd_error        ,
+   output      [C_MEM_ADDR_WIDTH-1:0]        mcbx_dram_addr     ,
+   output      [C_MEM_BANKADDR_WIDTH-1:0]    mcbx_dram_ba       ,
+   output                                    mcbx_dram_ras_n    ,
+   output                                    mcbx_dram_cas_n    ,
+   output                                    mcbx_dram_we_n     ,
+   output                                    mcbx_dram_cke      ,
+   output                                    mcbx_dram_clk      ,
+   output                                    mcbx_dram_clk_n    ,
+   inout       [C_NUM_DQ_PINS-1:0]           mcbx_dram_dq       ,
+   inout                                     mcbx_dram_dqs      ,
+   inout                                     mcbx_dram_dqs_n    ,
+   inout                                     mcbx_dram_udqs     ,
+   inout                                     mcbx_dram_udqs_n   ,
+   output                                    mcbx_dram_udm      ,
+   output                                    mcbx_dram_ldm      ,
+   output                                    mcbx_dram_odt      ,
+   output                                    mcbx_dram_ddr3_rst ,
+   input                                     calib_recal        ,
+   inout                                     rzq                ,
+   inout                                     zio                ,
+   input                                     ui_read            ,
+   input                                     ui_add             ,
+   input                                     ui_cs              ,
+   input                                     ui_clk             ,
+   input                                     ui_sdi             ,
+   input       [4:0]                         ui_addr            ,
+   input                                     ui_broadcast       ,
+   input                                     ui_drp_update      ,
+   input                                     ui_done_cal        ,
+   input                                     ui_cmd             ,
+   input                                     ui_cmd_in          ,
+   input                                     ui_cmd_en          ,
+   input       [3:0]                         ui_dqcount         ,
+   input                                     ui_dq_lower_dec    ,
+   input                                     ui_dq_lower_inc    ,
+   input                                     ui_dq_upper_dec    ,
+   input                                     ui_dq_upper_inc    ,
+   input                                     ui_udqs_inc        ,
+   input                                     ui_udqs_dec        ,
+   input                                     ui_ldqs_inc        ,
+   input                                     ui_ldqs_dec        ,
+   output      [7:0]                         uo_data            ,
+   output                                    uo_data_valid      ,
+   output                                    uo_done_cal        ,
+   output                                    uo_cmd_ready_in    ,
+   output                                    uo_refrsh_flag     ,
+   output                                    uo_cal_start       ,
+   output                                    uo_sdo             ,
+   output      [31:0]                        status             ,
+   input                                     selfrefresh_enter  ,
+   output                                    selfrefresh_mode   ,
+   // AXI Signals
+   input  wire                               s0_axi_aclk        ,
+   input  wire                               s0_axi_aresetn     ,
+   input  wire [C_S0_AXI_ID_WIDTH-1:0]       s0_axi_awid        ,
+   input  wire [C_S0_AXI_ADDR_WIDTH-1:0]     s0_axi_awaddr      ,
+   input  wire [7:0]                         s0_axi_awlen       ,
+   input  wire [2:0]                         s0_axi_awsize      ,
+   input  wire [1:0]                         s0_axi_awburst     ,
+   input  wire [0:0]                         s0_axi_awlock      ,
+   input  wire [3:0]                         s0_axi_awcache     ,
+   input  wire [2:0]                         s0_axi_awprot      ,
+   input  wire [3:0]                         s0_axi_awqos       ,
+   input  wire                               s0_axi_awvalid     ,
+   output wire                               s0_axi_awready     ,
+   input  wire [C_S0_AXI_DATA_WIDTH-1:0]     s0_axi_wdata       ,
+   input  wire [C_S0_AXI_DATA_WIDTH/8-1:0]   s0_axi_wstrb       ,
+   input  wire                               s0_axi_wlast       ,
+   input  wire                               s0_axi_wvalid      ,
+   output wire                               s0_axi_wready      ,
+   output wire [C_S0_AXI_ID_WIDTH-1:0]       s0_axi_bid         ,
+   output wire [1:0]                         s0_axi_bresp       ,
+   output wire                               s0_axi_bvalid      ,
+   input  wire                               s0_axi_bready      ,
+   input  wire [C_S0_AXI_ID_WIDTH-1:0]       s0_axi_arid        ,
+   input  wire [C_S0_AXI_ADDR_WIDTH-1:0]     s0_axi_araddr      ,
+   input  wire [7:0]                         s0_axi_arlen       ,
+   input  wire [2:0]                         s0_axi_arsize      ,
+   input  wire [1:0]                         s0_axi_arburst     ,
+   input  wire [0:0]                         s0_axi_arlock      ,
+   input  wire [3:0]                         s0_axi_arcache     ,
+   input  wire [2:0]                         s0_axi_arprot      ,
+   input  wire [3:0]                         s0_axi_arqos       ,
+   input  wire                               s0_axi_arvalid     ,
+   output wire                               s0_axi_arready     ,
+   output wire [C_S0_AXI_ID_WIDTH-1:0]       s0_axi_rid         ,
+   output wire [C_S0_AXI_DATA_WIDTH-1:0]     s0_axi_rdata       ,
+   output wire [1:0]                         s0_axi_rresp       ,
+   output wire                               s0_axi_rlast       ,
+   output wire                               s0_axi_rvalid      ,
+   input  wire                               s0_axi_rready      ,
+
+   input  wire                               s1_axi_aclk        ,
+   input  wire                               s1_axi_aresetn     ,
+   input  wire [C_S1_AXI_ID_WIDTH-1:0]       s1_axi_awid        ,
+   input  wire [C_S1_AXI_ADDR_WIDTH-1:0]     s1_axi_awaddr      ,
+   input  wire [7:0]                         s1_axi_awlen       ,
+   input  wire [2:0]                         s1_axi_awsize      ,
+   input  wire [1:0]                         s1_axi_awburst     ,
+   input  wire [0:0]                         s1_axi_awlock      ,
+   input  wire [3:0]                         s1_axi_awcache     ,
+   input  wire [2:0]                         s1_axi_awprot      ,
+   input  wire [3:0]                         s1_axi_awqos       ,
+   input  wire                               s1_axi_awvalid     ,
+   output wire                               s1_axi_awready     ,
+   input  wire [C_S1_AXI_DATA_WIDTH-1:0]     s1_axi_wdata       ,
+   input  wire [C_S1_AXI_DATA_WIDTH/8-1:0]   s1_axi_wstrb       ,
+   input  wire                               s1_axi_wlast       ,
+   input  wire                               s1_axi_wvalid      ,
+   output wire                               s1_axi_wready      ,
+   output wire [C_S1_AXI_ID_WIDTH-1:0]       s1_axi_bid         ,
+   output wire [1:0]                         s1_axi_bresp       ,
+   output wire                               s1_axi_bvalid      ,
+   input  wire                               s1_axi_bready      ,
+   input  wire [C_S1_AXI_ID_WIDTH-1:0]       s1_axi_arid        ,
+   input  wire [C_S1_AXI_ADDR_WIDTH-1:0]     s1_axi_araddr      ,
+   input  wire [7:0]                         s1_axi_arlen       ,
+   input  wire [2:0]                         s1_axi_arsize      ,
+   input  wire [1:0]                         s1_axi_arburst     ,
+   input  wire [0:0]                         s1_axi_arlock      ,
+   input  wire [3:0]                         s1_axi_arcache     ,
+   input  wire [2:0]                         s1_axi_arprot      ,
+   input  wire [3:0]                         s1_axi_arqos       ,
+   input  wire                               s1_axi_arvalid     ,
+   output wire                               s1_axi_arready     ,
+   output wire [C_S1_AXI_ID_WIDTH-1:0]       s1_axi_rid         ,
+   output wire [C_S1_AXI_DATA_WIDTH-1:0]     s1_axi_rdata       ,
+   output wire [1:0]                         s1_axi_rresp       ,
+   output wire                               s1_axi_rlast       ,
+   output wire                               s1_axi_rvalid      ,
+   input  wire                               s1_axi_rready      ,
+
+   input  wire                               s2_axi_aclk        ,
+   input  wire                               s2_axi_aresetn     ,
+   input  wire [C_S2_AXI_ID_WIDTH-1:0]       s2_axi_awid        ,
+   input  wire [C_S2_AXI_ADDR_WIDTH-1:0]     s2_axi_awaddr      ,
+   input  wire [7:0]                         s2_axi_awlen       ,
+   input  wire [2:0]                         s2_axi_awsize      ,
+   input  wire [1:0]                         s2_axi_awburst     ,
+   input  wire [0:0]                         s2_axi_awlock      ,
+   input  wire [3:0]                         s2_axi_awcache     ,
+   input  wire [2:0]                         s2_axi_awprot      ,
+   input  wire [3:0]                         s2_axi_awqos       ,
+   input  wire                               s2_axi_awvalid     ,
+   output wire                               s2_axi_awready     ,
+   input  wire [C_S2_AXI_DATA_WIDTH-1:0]     s2_axi_wdata       ,
+   input  wire [C_S2_AXI_DATA_WIDTH/8-1:0]   s2_axi_wstrb       ,
+   input  wire                               s2_axi_wlast       ,
+   input  wire                               s2_axi_wvalid      ,
+   output wire                               s2_axi_wready      ,
+   output wire [C_S2_AXI_ID_WIDTH-1:0]       s2_axi_bid         ,
+   output wire [1:0]                         s2_axi_bresp       ,
+   output wire                               s2_axi_bvalid      ,
+   input  wire                               s2_axi_bready      ,
+   input  wire [C_S2_AXI_ID_WIDTH-1:0]       s2_axi_arid        ,
+   input  wire [C_S2_AXI_ADDR_WIDTH-1:0]     s2_axi_araddr      ,
+   input  wire [7:0]                         s2_axi_arlen       ,
+   input  wire [2:0]                         s2_axi_arsize      ,
+   input  wire [1:0]                         s2_axi_arburst     ,
+   input  wire [0:0]                         s2_axi_arlock      ,
+   input  wire [3:0]                         s2_axi_arcache     ,
+   input  wire [2:0]                         s2_axi_arprot      ,
+   input  wire [3:0]                         s2_axi_arqos       ,
+   input  wire                               s2_axi_arvalid     ,
+   output wire                               s2_axi_arready     ,
+   output wire [C_S2_AXI_ID_WIDTH-1:0]       s2_axi_rid         ,
+   output wire [C_S2_AXI_DATA_WIDTH-1:0]     s2_axi_rdata       ,
+   output wire [1:0]                         s2_axi_rresp       ,
+   output wire                               s2_axi_rlast       ,
+   output wire                               s2_axi_rvalid      ,
+   input  wire                               s2_axi_rready      ,
+
+   input  wire                               s3_axi_aclk        ,
+   input  wire                               s3_axi_aresetn     ,
+   input  wire [C_S3_AXI_ID_WIDTH-1:0]       s3_axi_awid        ,
+   input  wire [C_S3_AXI_ADDR_WIDTH-1:0]     s3_axi_awaddr      ,
+   input  wire [7:0]                         s3_axi_awlen       ,
+   input  wire [2:0]                         s3_axi_awsize      ,
+   input  wire [1:0]                         s3_axi_awburst     ,
+   input  wire [0:0]                         s3_axi_awlock      ,
+   input  wire [3:0]                         s3_axi_awcache     ,
+   input  wire [2:0]                         s3_axi_awprot      ,
+   input  wire [3:0]                         s3_axi_awqos       ,
+   input  wire                               s3_axi_awvalid     ,
+   output wire                               s3_axi_awready     ,
+   input  wire [C_S3_AXI_DATA_WIDTH-1:0]     s3_axi_wdata       ,
+   input  wire [C_S3_AXI_DATA_WIDTH/8-1:0]   s3_axi_wstrb       ,
+   input  wire                               s3_axi_wlast       ,
+   input  wire                               s3_axi_wvalid      ,
+   output wire                               s3_axi_wready      ,
+   output wire [C_S3_AXI_ID_WIDTH-1:0]       s3_axi_bid         ,
+   output wire [1:0]                         s3_axi_bresp       ,
+   output wire                               s3_axi_bvalid      ,
+   input  wire                               s3_axi_bready      ,
+   input  wire [C_S3_AXI_ID_WIDTH-1:0]       s3_axi_arid        ,
+   input  wire [C_S3_AXI_ADDR_WIDTH-1:0]     s3_axi_araddr      ,
+   input  wire [7:0]                         s3_axi_arlen       ,
+   input  wire [2:0]                         s3_axi_arsize      ,
+   input  wire [1:0]                         s3_axi_arburst     ,
+   input  wire [0:0]                         s3_axi_arlock      ,
+   input  wire [3:0]                         s3_axi_arcache     ,
+   input  wire [2:0]                         s3_axi_arprot      ,
+   input  wire [3:0]                         s3_axi_arqos       ,
+   input  wire                               s3_axi_arvalid     ,
+   output wire                               s3_axi_arready     ,
+   output wire [C_S3_AXI_ID_WIDTH-1:0]       s3_axi_rid         ,
+   output wire [C_S3_AXI_DATA_WIDTH-1:0]     s3_axi_rdata       ,
+   output wire [1:0]                         s3_axi_rresp       ,
+   output wire                               s3_axi_rlast       ,
+   output wire                               s3_axi_rvalid      ,
+   input  wire                               s3_axi_rready      ,
+
+   input  wire                               s4_axi_aclk        ,
+   input  wire                               s4_axi_aresetn     ,
+   input  wire [C_S4_AXI_ID_WIDTH-1:0]       s4_axi_awid        ,
+   input  wire [C_S4_AXI_ADDR_WIDTH-1:0]     s4_axi_awaddr      ,
+   input  wire [7:0]                         s4_axi_awlen       ,
+   input  wire [2:0]                         s4_axi_awsize      ,
+   input  wire [1:0]                         s4_axi_awburst     ,
+   input  wire [0:0]                         s4_axi_awlock      ,
+   input  wire [3:0]                         s4_axi_awcache     ,
+   input  wire [2:0]                         s4_axi_awprot      ,
+   input  wire [3:0]                         s4_axi_awqos       ,
+   input  wire                               s4_axi_awvalid     ,
+   output wire                               s4_axi_awready     ,
+   input  wire [C_S4_AXI_DATA_WIDTH-1:0]     s4_axi_wdata       ,
+   input  wire [C_S4_AXI_DATA_WIDTH/8-1:0]   s4_axi_wstrb       ,
+   input  wire                               s4_axi_wlast       ,
+   input  wire                               s4_axi_wvalid      ,
+   output wire                               s4_axi_wready      ,
+   output wire [C_S4_AXI_ID_WIDTH-1:0]       s4_axi_bid         ,
+   output wire [1:0]                         s4_axi_bresp       ,
+   output wire                               s4_axi_bvalid      ,
+   input  wire                               s4_axi_bready      ,
+   input  wire [C_S4_AXI_ID_WIDTH-1:0]       s4_axi_arid        ,
+   input  wire [C_S4_AXI_ADDR_WIDTH-1:0]     s4_axi_araddr      ,
+   input  wire [7:0]                         s4_axi_arlen       ,
+   input  wire [2:0]                         s4_axi_arsize      ,
+   input  wire [1:0]                         s4_axi_arburst     ,
+   input  wire [0:0]                         s4_axi_arlock      ,
+   input  wire [3:0]                         s4_axi_arcache     ,
+   input  wire [2:0]                         s4_axi_arprot      ,
+   input  wire [3:0]                         s4_axi_arqos       ,
+   input  wire                               s4_axi_arvalid     ,
+   output wire                               s4_axi_arready     ,
+   output wire [C_S4_AXI_ID_WIDTH-1:0]       s4_axi_rid         ,
+   output wire [C_S4_AXI_DATA_WIDTH-1:0]     s4_axi_rdata       ,
+   output wire [1:0]                         s4_axi_rresp       ,
+   output wire                               s4_axi_rlast       ,
+   output wire                               s4_axi_rvalid      ,
+   input  wire                               s4_axi_rready      ,
+
+   input  wire                               s5_axi_aclk        ,
+   input  wire                               s5_axi_aresetn     ,
+   input  wire [C_S5_AXI_ID_WIDTH-1:0]       s5_axi_awid        ,
+   input  wire [C_S5_AXI_ADDR_WIDTH-1:0]     s5_axi_awaddr      ,
+   input  wire [7:0]                         s5_axi_awlen       ,
+   input  wire [2:0]                         s5_axi_awsize      ,
+   input  wire [1:0]                         s5_axi_awburst     ,
+   input  wire [0:0]                         s5_axi_awlock      ,
+   input  wire [3:0]                         s5_axi_awcache     ,
+   input  wire [2:0]                         s5_axi_awprot      ,
+   input  wire [3:0]                         s5_axi_awqos       ,
+   input  wire                               s5_axi_awvalid     ,
+   output wire                               s5_axi_awready     ,
+   input  wire [C_S5_AXI_DATA_WIDTH-1:0]     s5_axi_wdata       ,
+   input  wire [C_S5_AXI_DATA_WIDTH/8-1:0]   s5_axi_wstrb       ,
+   input  wire                               s5_axi_wlast       ,
+   input  wire                               s5_axi_wvalid      ,
+   output wire                               s5_axi_wready      ,
+   output wire [C_S5_AXI_ID_WIDTH-1:0]       s5_axi_bid         ,
+   output wire [1:0]                         s5_axi_bresp       ,
+   output wire                               s5_axi_bvalid      ,
+   input  wire                               s5_axi_bready      ,
+   input  wire [C_S5_AXI_ID_WIDTH-1:0]       s5_axi_arid        ,
+   input  wire [C_S5_AXI_ADDR_WIDTH-1:0]     s5_axi_araddr      ,
+   input  wire [7:0]                         s5_axi_arlen       ,
+   input  wire [2:0]                         s5_axi_arsize      ,
+   input  wire [1:0]                         s5_axi_arburst     ,
+   input  wire [0:0]                         s5_axi_arlock      ,
+   input  wire [3:0]                         s5_axi_arcache     ,
+   input  wire [2:0]                         s5_axi_arprot      ,
+   input  wire [3:0]                         s5_axi_arqos       ,
+   input  wire                               s5_axi_arvalid     ,
+   output wire                               s5_axi_arready     ,
+   output wire [C_S5_AXI_ID_WIDTH-1:0]       s5_axi_rid         ,
+   output wire [C_S5_AXI_DATA_WIDTH-1:0]     s5_axi_rdata       ,
+   output wire [1:0]                         s5_axi_rresp       ,
+   output wire                               s5_axi_rlast       ,
+   output wire                               s5_axi_rvalid      ,
+   input  wire                               s5_axi_rready
+   );
+
+////////////////////////////////////////////////////////////////////////////////
+// Functions
+////////////////////////////////////////////////////////////////////////////////
+// Barrel Left Shift Octal
+function [17:0] blso (
+  input [17:0] a,
+  input integer shift,
+  input integer width
+);
+begin : func_blso
+  integer i;
+  integer w;
+  integer s;
+  w = width*3;
+  s = (shift*3) % w;
+  blso = 18'o000000;
+  for (i = 0; i < w; i = i + 1) begin
+    blso[i] = a[(i+w-s)%w];
+    //bls[i] = 1'b1;
+  end
+end
+endfunction
+
+// For a given port_config, port_enable and slot, calculate the round robin
+// arbitration that would be generated by the gui.
+function [17:0] rr (
+  input [5:0] port_enable,
+  input integer port_config,
+  input integer slot_num
+);
+begin : func_rr
+  integer i;
+  integer max_ports;
+  integer num_ports;
+  integer port_cnt;
+
+  case (port_config)
+    1: max_ports = 6;
+    2: max_ports = 4;
+    3: max_ports = 3;
+    4: max_ports = 2;
+    5: max_ports = 1;
+// synthesis translate_off
+    default : $display("ERROR: Port Config can't be %d", port_config);
+// synthesis translate_on
+  endcase
+
+  num_ports = 0;
+  for (i = 0; i < max_ports; i = i + 1) begin
+    if (port_enable[i] == 1'b1) begin
+      num_ports = num_ports + 1;
+    end
+  end
+
+  rr = 18'o000000;
+  port_cnt = 0;
+
+  for (i = (num_ports-1); i >= 0; i = i - 1) begin
+    while (port_enable[port_cnt] != 1'b1) begin
+      port_cnt = port_cnt + 1;
+    end
+    rr[i*3 +: 3] = port_cnt[2:0];
+    port_cnt = port_cnt +1;
+  end
+
+
+  rr = blso(rr, slot_num, num_ports);
+end
+endfunction
+
+function [17:0] convert_arb_slot (
+  input [5:0]   port_enable,
+  input integer port_config,
+  input [17:0]  mig_arb_slot
+);
+begin : func_convert_arb_slot
+  integer i;
+  integer num_ports;
+  integer mig_port_num;
+  reg [17:0] port_map;
+  num_ports = 0;
+
+  // Enumerated port configuration for ease of use
+  case (port_config)
+    1: port_map = 18'o543210;
+    2: port_map = 18'o774210;
+    3: port_map = 18'o777420;
+    4: port_map = 18'o777720;
+    5: port_map = 18'o777770;
+// synthesis translate_off
+    default : $display ("ERROR: Invalid Port Configuration.");
+// synthesis translate_on
+  endcase
+
+  // Count the number of ports
+  for (i = 0; i < 6; i = i + 1) begin
+    if (port_enable[i] == 1'b1) begin
+      num_ports = num_ports + 1;
+    end
+  end
+
+  // Map the ports from the MIG GUI to the MCB Wrapper
+  for (i = 0; i < 6; i = i + 1) begin
+    if (i < num_ports) begin
+      mig_port_num = mig_arb_slot[3*(num_ports-i-1) +: 3];
+      convert_arb_slot[3*i +: 3] = port_map[3*mig_port_num +: 3];
+    end else begin
+      convert_arb_slot[3*i +: 3] = 3'b111;
+    end
+  end
+end
+endfunction
+
+// Function to calculate the number of time slots automatically based on the
+// number of ports used.  Will choose 10 if the number of valid ports is 5,
+// otherwise it will be 12.
+function integer calc_num_time_slots (
+  input [5:0]   port_enable,
+  input integer port_config
+);
+begin : func_calc_num_tim_slots
+  integer num_ports;
+  integer i;
+  num_ports = 0;
+  for (i = 0; i < 6; i = i + 1) begin
+    if (port_enable[i] == 1'b1) begin
+      num_ports = num_ports + 1;
+    end
+  end
+  calc_num_time_slots = (port_config == 1 && num_ports == 5) ? 10 : 12;
+end
+endfunction
+////////////////////////////////////////////////////////////////////////////////
+// Local Parameters
+////////////////////////////////////////////////////////////////////////////////
+  localparam P_S0_AXI_ADDRMASK = C_S0_AXI_BASEADDR ^ C_S0_AXI_HIGHADDR;
+  localparam P_S1_AXI_ADDRMASK = C_S1_AXI_BASEADDR ^ C_S1_AXI_HIGHADDR;
+  localparam P_S2_AXI_ADDRMASK = C_S2_AXI_BASEADDR ^ C_S2_AXI_HIGHADDR;
+  localparam P_S3_AXI_ADDRMASK = C_S3_AXI_BASEADDR ^ C_S3_AXI_HIGHADDR;
+  localparam P_S4_AXI_ADDRMASK = C_S4_AXI_BASEADDR ^ C_S4_AXI_HIGHADDR;
+  localparam P_S5_AXI_ADDRMASK = C_S5_AXI_BASEADDR ^ C_S5_AXI_HIGHADDR;
+  localparam P_PORT_CONFIG     = (C_PORT_CONFIG == "B32_B32_B32_B32") ? 2 :
+                                 (C_PORT_CONFIG == "B64_B32_B32"    ) ? 3 :
+                                 (C_PORT_CONFIG == "B64_B64"        ) ? 4 :
+                                 (C_PORT_CONFIG == "B128"           ) ? 5 :
+                                 1; // B32_B32_x32_x32_x32_x32 case
+  localparam P_ARB_NUM_TIME_SLOTS = (C_ARB_ALGORITHM == 0) ? calc_num_time_slots(C_PORT_ENABLE, P_PORT_CONFIG) : C_ARB_NUM_TIME_SLOTS;
+  localparam P_0_ARB_TIME_SLOT_0 =  (C_ARB_ALGORITHM == 0) ? rr(C_PORT_ENABLE, P_PORT_CONFIG, 0 ) : C_ARB_TIME_SLOT_0 ;
+  localparam P_0_ARB_TIME_SLOT_1 =  (C_ARB_ALGORITHM == 0) ? rr(C_PORT_ENABLE, P_PORT_CONFIG, 1 ) : C_ARB_TIME_SLOT_1 ;
+  localparam P_0_ARB_TIME_SLOT_2 =  (C_ARB_ALGORITHM == 0) ? rr(C_PORT_ENABLE, P_PORT_CONFIG, 2 ) : C_ARB_TIME_SLOT_2 ;
+  localparam P_0_ARB_TIME_SLOT_3 =  (C_ARB_ALGORITHM == 0) ? rr(C_PORT_ENABLE, P_PORT_CONFIG, 3 ) : C_ARB_TIME_SLOT_3 ;
+  localparam P_0_ARB_TIME_SLOT_4 =  (C_ARB_ALGORITHM == 0) ? rr(C_PORT_ENABLE, P_PORT_CONFIG, 4 ) : C_ARB_TIME_SLOT_4 ;
+  localparam P_0_ARB_TIME_SLOT_5 =  (C_ARB_ALGORITHM == 0) ? rr(C_PORT_ENABLE, P_PORT_CONFIG, 5 ) : C_ARB_TIME_SLOT_5 ;
+  localparam P_0_ARB_TIME_SLOT_6 =  (C_ARB_ALGORITHM == 0) ? rr(C_PORT_ENABLE, P_PORT_CONFIG, 6 ) : C_ARB_TIME_SLOT_6 ;
+  localparam P_0_ARB_TIME_SLOT_7 =  (C_ARB_ALGORITHM == 0) ? rr(C_PORT_ENABLE, P_PORT_CONFIG, 7 ) : C_ARB_TIME_SLOT_7 ;
+  localparam P_0_ARB_TIME_SLOT_8 =  (C_ARB_ALGORITHM == 0) ? rr(C_PORT_ENABLE, P_PORT_CONFIG, 8 ) : C_ARB_TIME_SLOT_8 ;
+  localparam P_0_ARB_TIME_SLOT_9 =  (C_ARB_ALGORITHM == 0) ? rr(C_PORT_ENABLE, P_PORT_CONFIG, 9 ) : C_ARB_TIME_SLOT_9 ;
+  localparam P_0_ARB_TIME_SLOT_10 = (C_ARB_ALGORITHM == 0) ? rr(C_PORT_ENABLE, P_PORT_CONFIG, 10) : C_ARB_TIME_SLOT_10;
+  localparam P_0_ARB_TIME_SLOT_11 = (C_ARB_ALGORITHM == 0) ? rr(C_PORT_ENABLE, P_PORT_CONFIG, 11) : C_ARB_TIME_SLOT_11;
+  localparam P_ARB_TIME_SLOT_0 =  convert_arb_slot(C_PORT_ENABLE, P_PORT_CONFIG, P_0_ARB_TIME_SLOT_0);
+  localparam P_ARB_TIME_SLOT_1 =  convert_arb_slot(C_PORT_ENABLE, P_PORT_CONFIG, P_0_ARB_TIME_SLOT_1);
+  localparam P_ARB_TIME_SLOT_2 =  convert_arb_slot(C_PORT_ENABLE, P_PORT_CONFIG, P_0_ARB_TIME_SLOT_2);
+  localparam P_ARB_TIME_SLOT_3 =  convert_arb_slot(C_PORT_ENABLE, P_PORT_CONFIG, P_0_ARB_TIME_SLOT_3);
+  localparam P_ARB_TIME_SLOT_4 =  convert_arb_slot(C_PORT_ENABLE, P_PORT_CONFIG, P_0_ARB_TIME_SLOT_4);
+  localparam P_ARB_TIME_SLOT_5 =  convert_arb_slot(C_PORT_ENABLE, P_PORT_CONFIG, P_0_ARB_TIME_SLOT_5);
+  localparam P_ARB_TIME_SLOT_6 =  convert_arb_slot(C_PORT_ENABLE, P_PORT_CONFIG, P_0_ARB_TIME_SLOT_6);
+  localparam P_ARB_TIME_SLOT_7 =  convert_arb_slot(C_PORT_ENABLE, P_PORT_CONFIG, P_0_ARB_TIME_SLOT_7);
+  localparam P_ARB_TIME_SLOT_8 =  convert_arb_slot(C_PORT_ENABLE, P_PORT_CONFIG, P_0_ARB_TIME_SLOT_8);
+  localparam P_ARB_TIME_SLOT_9 =  convert_arb_slot(C_PORT_ENABLE, P_PORT_CONFIG, P_0_ARB_TIME_SLOT_9);
+  localparam P_ARB_TIME_SLOT_10 = convert_arb_slot(C_PORT_ENABLE, P_PORT_CONFIG, P_0_ARB_TIME_SLOT_10);
+  localparam P_ARB_TIME_SLOT_11 = convert_arb_slot(C_PORT_ENABLE, P_PORT_CONFIG, P_0_ARB_TIME_SLOT_11);
+
+////////////////////////////////////////////////////////////////////////////////
+// Wires/Reg declarations
+////////////////////////////////////////////////////////////////////////////////
+  wire [C_S0_AXI_ADDR_WIDTH-1:0] s0_axi_araddr_i;
+  wire [C_S0_AXI_ADDR_WIDTH-1:0] s0_axi_awaddr_i;
+  wire                           p0_arb_en_i;
+  wire                           p0_cmd_clk_i;
+  wire                           p0_cmd_en_i;
+  wire [2:0]                     p0_cmd_instr_i;
+  wire [5:0]                     p0_cmd_bl_i;
+  wire [29:0]                    p0_cmd_byte_addr_i;
+  wire                           p0_cmd_empty_i;
+  wire                           p0_cmd_full_i;
+  wire                           p0_wr_clk_i;
+  wire                           p0_wr_en_i;
+  wire [C_P0_MASK_SIZE-1:0]      p0_wr_mask_i;
+  wire [C_P0_DATA_PORT_SIZE-1:0] p0_wr_data_i;
+  wire                           p0_wr_full_i;
+  wire                           p0_wr_empty_i;
+  wire [6:0]                     p0_wr_count_i;
+  wire                           p0_wr_underrun_i;
+  wire                           p0_wr_error_i;
+  wire                           p0_rd_clk_i;
+  wire                           p0_rd_en_i;
+  wire [C_P0_DATA_PORT_SIZE-1:0] p0_rd_data_i;
+  wire                           p0_rd_full_i;
+  wire                           p0_rd_empty_i;
+  wire [6:0]                     p0_rd_count_i;
+  wire                           p0_rd_overflow_i;
+  wire                           p0_rd_error_i;
+
+  wire [C_S1_AXI_ADDR_WIDTH-1:0] s1_axi_araddr_i;
+  wire [C_S1_AXI_ADDR_WIDTH-1:0] s1_axi_awaddr_i;
+  wire                           p1_arb_en_i;
+  wire                           p1_cmd_clk_i;
+  wire                           p1_cmd_en_i;
+  wire [2:0]                     p1_cmd_instr_i;
+  wire [5:0]                     p1_cmd_bl_i;
+  wire [29:0]                    p1_cmd_byte_addr_i;
+  wire                           p1_cmd_empty_i;
+  wire                           p1_cmd_full_i;
+  wire                           p1_wr_clk_i;
+  wire                           p1_wr_en_i;
+  wire [C_P1_MASK_SIZE-1:0]      p1_wr_mask_i;
+  wire [C_P1_DATA_PORT_SIZE-1:0] p1_wr_data_i;
+  wire                           p1_wr_full_i;
+  wire                           p1_wr_empty_i;
+  wire [6:0]                     p1_wr_count_i;
+  wire                           p1_wr_underrun_i;
+  wire                           p1_wr_error_i;
+  wire                           p1_rd_clk_i;
+  wire                           p1_rd_en_i;
+  wire [C_P1_DATA_PORT_SIZE-1:0] p1_rd_data_i;
+  wire                           p1_rd_full_i;
+  wire                           p1_rd_empty_i;
+  wire [6:0]                     p1_rd_count_i;
+  wire                           p1_rd_overflow_i;
+  wire                           p1_rd_error_i;
+
+  wire [C_S2_AXI_ADDR_WIDTH-1:0] s2_axi_araddr_i;
+  wire [C_S2_AXI_ADDR_WIDTH-1:0] s2_axi_awaddr_i;
+  wire                           p2_arb_en_i;
+  wire                           p2_cmd_clk_i;
+  wire                           p2_cmd_en_i;
+  wire [2:0]                     p2_cmd_instr_i;
+  wire [5:0]                     p2_cmd_bl_i;
+  wire [29:0]                    p2_cmd_byte_addr_i;
+  wire                           p2_cmd_empty_i;
+  wire                           p2_cmd_full_i;
+  wire                           p2_wr_clk_i;
+  wire                           p2_wr_en_i;
+  wire [3:0]                     p2_wr_mask_i;
+  wire [31:0]                    p2_wr_data_i;
+  wire                           p2_wr_full_i;
+  wire                           p2_wr_empty_i;
+  wire [6:0]                     p2_wr_count_i;
+  wire                           p2_wr_underrun_i;
+  wire                           p2_wr_error_i;
+  wire                           p2_rd_clk_i;
+  wire                           p2_rd_en_i;
+  wire [31:0]                    p2_rd_data_i;
+  wire                           p2_rd_full_i;
+  wire                           p2_rd_empty_i;
+  wire [6:0]                     p2_rd_count_i;
+  wire                           p2_rd_overflow_i;
+  wire                           p2_rd_error_i;
+
+  wire [C_S3_AXI_ADDR_WIDTH-1:0] s3_axi_araddr_i;
+  wire [C_S3_AXI_ADDR_WIDTH-1:0] s3_axi_awaddr_i;
+  wire                           p3_arb_en_i;
+  wire                           p3_cmd_clk_i;
+  wire                           p3_cmd_en_i;
+  wire [2:0]                     p3_cmd_instr_i;
+  wire [5:0]                     p3_cmd_bl_i;
+  wire [29:0]                    p3_cmd_byte_addr_i;
+  wire                           p3_cmd_empty_i;
+  wire                           p3_cmd_full_i;
+  wire                           p3_wr_clk_i;
+  wire                           p3_wr_en_i;
+  wire [3:0]                     p3_wr_mask_i;
+  wire [31:0]                    p3_wr_data_i;
+  wire                           p3_wr_full_i;
+  wire                           p3_wr_empty_i;
+  wire [6:0]                     p3_wr_count_i;
+  wire                           p3_wr_underrun_i;
+  wire                           p3_wr_error_i;
+  wire                           p3_rd_clk_i;
+  wire                           p3_rd_en_i;
+  wire [31:0]                    p3_rd_data_i;
+  wire                           p3_rd_full_i;
+  wire                           p3_rd_empty_i;
+  wire [6:0]                     p3_rd_count_i;
+  wire                           p3_rd_overflow_i;
+  wire                           p3_rd_error_i;
+
+  wire [C_S4_AXI_ADDR_WIDTH-1:0] s4_axi_araddr_i;
+  wire [C_S4_AXI_ADDR_WIDTH-1:0] s4_axi_awaddr_i;
+  wire                           p4_arb_en_i;
+  wire                           p4_cmd_clk_i;
+  wire                           p4_cmd_en_i;
+  wire [2:0]                     p4_cmd_instr_i;
+  wire [5:0]                     p4_cmd_bl_i;
+  wire [29:0]                    p4_cmd_byte_addr_i;
+  wire                           p4_cmd_empty_i;
+  wire                           p4_cmd_full_i;
+  wire                           p4_wr_clk_i;
+  wire                           p4_wr_en_i;
+  wire [3:0]                     p4_wr_mask_i;
+  wire [31:0]                    p4_wr_data_i;
+  wire                           p4_wr_full_i;
+  wire                           p4_wr_empty_i;
+  wire [6:0]                     p4_wr_count_i;
+  wire                           p4_wr_underrun_i;
+  wire                           p4_wr_error_i;
+  wire                           p4_rd_clk_i;
+  wire                           p4_rd_en_i;
+  wire [31:0]                    p4_rd_data_i;
+  wire                           p4_rd_full_i;
+  wire                           p4_rd_empty_i;
+  wire [6:0]                     p4_rd_count_i;
+  wire                           p4_rd_overflow_i;
+  wire                           p4_rd_error_i;
+
+  wire [C_S5_AXI_ADDR_WIDTH-1:0] s5_axi_araddr_i;
+  wire [C_S5_AXI_ADDR_WIDTH-1:0] s5_axi_awaddr_i;
+  wire                           p5_arb_en_i;
+  wire                           p5_cmd_clk_i;
+  wire                           p5_cmd_en_i;
+  wire [2:0]                     p5_cmd_instr_i;
+  wire [5:0]                     p5_cmd_bl_i;
+  wire [29:0]                    p5_cmd_byte_addr_i;
+  wire                           p5_cmd_empty_i;
+  wire                           p5_cmd_full_i;
+  wire                           p5_wr_clk_i;
+  wire                           p5_wr_en_i;
+  wire [3:0]                     p5_wr_mask_i;
+  wire [31:0]                    p5_wr_data_i;
+  wire                           p5_wr_full_i;
+  wire                           p5_wr_empty_i;
+  wire [6:0]                     p5_wr_count_i;
+  wire                           p5_wr_underrun_i;
+  wire                           p5_wr_error_i;
+  wire                           p5_rd_clk_i;
+  wire                           p5_rd_en_i;
+  wire [31:0]                    p5_rd_data_i;
+  wire                           p5_rd_full_i;
+  wire                           p5_rd_empty_i;
+  wire [6:0]                     p5_rd_count_i;
+  wire                           p5_rd_overflow_i;
+  wire                           p5_rd_error_i;
+
+  wire                           ioclk0;
+  wire                           ioclk180;
+  wire                           pll_ce_0_i;
+  wire                           pll_ce_90_i;
+
+  generate
+    if (C_MCB_USE_EXTERNAL_BUFPLL == 0) begin : gen_spartan6_bufpll_mcb
+      // Instantiate the PLL for MCB.
+      BUFPLL_MCB #
+      (
+      .DIVIDE   (2),
+      .LOCK_SRC ("LOCK_TO_0")
+      )
+      bufpll_0
+        (
+        .IOCLK0       (ioclk0),
+        .IOCLK1       (ioclk180),
+        .GCLK         (ui_clk),
+        .LOCKED       (pll_lock),
+        .LOCK         (pll_lock_bufpll_o),
+        .SERDESSTROBE0(pll_ce_0_i),
+        .SERDESSTROBE1(pll_ce_90_i),
+        .PLLIN0       (sysclk_2x),
+        .PLLIN1       (sysclk_2x_180)
+        );
+      end else begin : gen_spartan6_no_bufpll_mcb
+        // Use external bufpll_mcb.
+        assign pll_ce_0_i   = pll_ce_0;
+        assign pll_ce_90_i  = pll_ce_90;
+        assign ioclk0     = sysclk_2x;
+        assign ioclk180   = sysclk_2x_180;
+        assign pll_lock_bufpll_o = pll_lock;
+      end
+  endgenerate
+
+  assign sysclk_2x_bufpll_o     = ioclk0;
+  assign sysclk_2x_180_bufpll_o = ioclk180;
+  assign pll_ce_0_bufpll_o      = pll_ce_0_i;
+  assign pll_ce_90_bufpll_o     = pll_ce_90_i;
+
+mcb_raw_wrapper #
+   (
+   .C_MEMCLK_PERIOD           ( C_MEMCLK_PERIOD           ),
+   .C_PORT_ENABLE             ( C_PORT_ENABLE             ),
+   .C_MEM_ADDR_ORDER          ( C_MEM_ADDR_ORDER          ),
+   .C_ARB_NUM_TIME_SLOTS      ( P_ARB_NUM_TIME_SLOTS      ),
+   .C_ARB_TIME_SLOT_0         ( P_ARB_TIME_SLOT_0         ),
+   .C_ARB_TIME_SLOT_1         ( P_ARB_TIME_SLOT_1         ),
+   .C_ARB_TIME_SLOT_2         ( P_ARB_TIME_SLOT_2         ),
+   .C_ARB_TIME_SLOT_3         ( P_ARB_TIME_SLOT_3         ),
+   .C_ARB_TIME_SLOT_4         ( P_ARB_TIME_SLOT_4         ),
+   .C_ARB_TIME_SLOT_5         ( P_ARB_TIME_SLOT_5         ),
+   .C_ARB_TIME_SLOT_6         ( P_ARB_TIME_SLOT_6         ),
+   .C_ARB_TIME_SLOT_7         ( P_ARB_TIME_SLOT_7         ),
+   .C_ARB_TIME_SLOT_8         ( P_ARB_TIME_SLOT_8         ),
+   .C_ARB_TIME_SLOT_9         ( P_ARB_TIME_SLOT_9         ),
+   .C_ARB_TIME_SLOT_10        ( P_ARB_TIME_SLOT_10        ),
+   .C_ARB_TIME_SLOT_11        ( P_ARB_TIME_SLOT_11        ),
+   .C_PORT_CONFIG             ( C_PORT_CONFIG             ),
+   .C_MEM_TRAS                ( C_MEM_TRAS                ),
+   .C_MEM_TRCD                ( C_MEM_TRCD                ),
+   .C_MEM_TREFI               ( C_MEM_TREFI               ),
+   .C_MEM_TRFC                ( C_MEM_TRFC                ),
+   .C_MEM_TRP                 ( C_MEM_TRP                 ),
+   .C_MEM_TWR                 ( C_MEM_TWR                 ),
+   .C_MEM_TRTP                ( C_MEM_TRTP                ),
+   .C_MEM_TWTR                ( C_MEM_TWTR                ),
+   .C_NUM_DQ_PINS             ( C_NUM_DQ_PINS             ),
+   .C_MEM_TYPE                ( C_MEM_TYPE                ),
+   .C_MEM_DENSITY             ( C_MEM_DENSITY             ),
+   .C_MEM_BURST_LEN           ( C_MEM_BURST_LEN           ),
+   .C_MEM_CAS_LATENCY         ( C_MEM_CAS_LATENCY         ),
+   .C_MEM_ADDR_WIDTH          ( C_MEM_ADDR_WIDTH          ),
+   .C_MEM_BANKADDR_WIDTH      ( C_MEM_BANKADDR_WIDTH      ),
+   .C_MEM_NUM_COL_BITS        ( C_MEM_NUM_COL_BITS        ),
+   .C_MEM_DDR3_CAS_LATENCY    ( C_MEM_DDR3_CAS_LATENCY    ),
+   .C_MEM_MOBILE_PA_SR        ( C_MEM_MOBILE_PA_SR        ),
+   .C_MEM_DDR1_2_ODS          ( C_MEM_DDR1_2_ODS          ),
+   .C_MEM_DDR3_ODS            ( C_MEM_DDR3_ODS            ),
+   .C_MEM_DDR2_RTT            ( C_MEM_DDR2_RTT            ),
+   .C_MEM_DDR3_RTT            ( C_MEM_DDR3_RTT            ),
+   .C_MEM_MDDR_ODS            ( C_MEM_MDDR_ODS            ),
+   .C_MEM_DDR2_DIFF_DQS_EN    ( C_MEM_DDR2_DIFF_DQS_EN    ),
+   .C_MEM_DDR2_3_PA_SR        ( C_MEM_DDR2_3_PA_SR        ),
+   .C_MEM_DDR3_CAS_WR_LATENCY ( C_MEM_DDR3_CAS_WR_LATENCY ),
+   .C_MEM_DDR3_AUTO_SR        ( C_MEM_DDR3_AUTO_SR        ),
+   .C_MEM_DDR2_3_HIGH_TEMP_SR ( C_MEM_DDR2_3_HIGH_TEMP_SR ),
+   .C_MEM_DDR3_DYN_WRT_ODT    ( C_MEM_DDR3_DYN_WRT_ODT    ),
+   // Subtract 16 to stop TRFC violations.
+   .C_MEM_TZQINIT_MAXCNT      ( C_MEM_TZQINIT_MAXCNT - 16 ),
+   .C_MC_CALIB_BYPASS         ( C_MC_CALIB_BYPASS         ),
+   .C_MC_CALIBRATION_RA       ( C_MC_CALIBRATION_RA       ),
+   .C_MC_CALIBRATION_BA       ( C_MC_CALIBRATION_BA       ),
+   .C_CALIB_SOFT_IP           ( C_CALIB_SOFT_IP           ),
+   .C_SKIP_IN_TERM_CAL        ( C_SKIP_IN_TERM_CAL        ),
+   .C_SKIP_DYNAMIC_CAL        ( C_SKIP_DYNAMIC_CAL        ),
+   .C_SKIP_DYN_IN_TERM        ( C_SKIP_DYN_IN_TERM        ),
+   .LDQSP_TAP_DELAY_VAL       ( LDQSP_TAP_DELAY_VAL       ),
+   .UDQSP_TAP_DELAY_VAL       ( UDQSP_TAP_DELAY_VAL       ),
+   .LDQSN_TAP_DELAY_VAL       ( LDQSN_TAP_DELAY_VAL       ),
+   .UDQSN_TAP_DELAY_VAL       ( UDQSN_TAP_DELAY_VAL       ),
+   .DQ0_TAP_DELAY_VAL         ( DQ0_TAP_DELAY_VAL         ),
+   .DQ1_TAP_DELAY_VAL         ( DQ1_TAP_DELAY_VAL         ),
+   .DQ2_TAP_DELAY_VAL         ( DQ2_TAP_DELAY_VAL         ),
+   .DQ3_TAP_DELAY_VAL         ( DQ3_TAP_DELAY_VAL         ),
+   .DQ4_TAP_DELAY_VAL         ( DQ4_TAP_DELAY_VAL         ),
+   .DQ5_TAP_DELAY_VAL         ( DQ5_TAP_DELAY_VAL         ),
+   .DQ6_TAP_DELAY_VAL         ( DQ6_TAP_DELAY_VAL         ),
+   .DQ7_TAP_DELAY_VAL         ( DQ7_TAP_DELAY_VAL         ),
+   .DQ8_TAP_DELAY_VAL         ( DQ8_TAP_DELAY_VAL         ),
+   .DQ9_TAP_DELAY_VAL         ( DQ9_TAP_DELAY_VAL         ),
+   .DQ10_TAP_DELAY_VAL        ( DQ10_TAP_DELAY_VAL        ),
+   .DQ11_TAP_DELAY_VAL        ( DQ11_TAP_DELAY_VAL        ),
+   .DQ12_TAP_DELAY_VAL        ( DQ12_TAP_DELAY_VAL        ),
+   .DQ13_TAP_DELAY_VAL        ( DQ13_TAP_DELAY_VAL        ),
+   .DQ14_TAP_DELAY_VAL        ( DQ14_TAP_DELAY_VAL        ),
+   .DQ15_TAP_DELAY_VAL        ( DQ15_TAP_DELAY_VAL        ),
+   .C_MC_CALIBRATION_CA       ( C_MC_CALIBRATION_CA       ),
+   .C_MC_CALIBRATION_CLK_DIV  ( C_MC_CALIBRATION_CLK_DIV  ),
+   .C_MC_CALIBRATION_MODE     ( C_MC_CALIBRATION_MODE     ),
+   .C_MC_CALIBRATION_DELAY    ( C_MC_CALIBRATION_DELAY    ),
+   // synthesis translate_off
+   .C_SIMULATION              ( C_SIMULATION              ),
+   // synthesis translate_on
+   .C_P0_MASK_SIZE            ( C_P0_MASK_SIZE            ),
+   .C_P0_DATA_PORT_SIZE       ( C_P0_DATA_PORT_SIZE       ),
+   .C_P1_MASK_SIZE            ( C_P1_MASK_SIZE            ),
+   .C_P1_DATA_PORT_SIZE       ( C_P1_DATA_PORT_SIZE       )
+   )
+   mcb_raw_wrapper_inst
+   (
+   .sysclk_2x                 ( ioclk0                    ),
+   .sysclk_2x_180             ( ioclk180                  ),
+   .pll_ce_0                  ( pll_ce_0_i                ),
+   .pll_ce_90                 ( pll_ce_90_i               ),
+   .pll_lock                  ( pll_lock_bufpll_o         ),
+   .sys_rst                   ( sys_rst                   ),
+   .p0_arb_en                 ( p0_arb_en_i               ),
+   .p0_cmd_clk                ( p0_cmd_clk_i              ),
+   .p0_cmd_en                 ( p0_cmd_en_i               ),
+   .p0_cmd_instr              ( p0_cmd_instr_i            ),
+   .p0_cmd_bl                 ( p0_cmd_bl_i               ),
+   .p0_cmd_byte_addr          ( p0_cmd_byte_addr_i        ),
+   .p0_cmd_empty              ( p0_cmd_empty_i            ),
+   .p0_cmd_full               ( p0_cmd_full_i             ),
+   .p0_wr_clk                 ( p0_wr_clk_i               ),
+   .p0_wr_en                  ( p0_wr_en_i                ),
+   .p0_wr_mask                ( p0_wr_mask_i              ),
+   .p0_wr_data                ( p0_wr_data_i              ),
+   .p0_wr_full                ( p0_wr_full_i              ),
+   .p0_wr_empty               ( p0_wr_empty_i             ),
+   .p0_wr_count               ( p0_wr_count_i             ),
+   .p0_wr_underrun            ( p0_wr_underrun_i          ),
+   .p0_wr_error               ( p0_wr_error_i             ),
+   .p0_rd_clk                 ( p0_rd_clk_i               ),
+   .p0_rd_en                  ( p0_rd_en_i                ),
+   .p0_rd_data                ( p0_rd_data_i              ),
+   .p0_rd_full                ( p0_rd_full_i              ),
+   .p0_rd_empty               ( p0_rd_empty_i             ),
+   .p0_rd_count               ( p0_rd_count_i             ),
+   .p0_rd_overflow            ( p0_rd_overflow_i          ),
+   .p0_rd_error               ( p0_rd_error_i             ),
+   .p1_arb_en                 ( p1_arb_en_i               ),
+   .p1_cmd_clk                ( p1_cmd_clk_i              ),
+   .p1_cmd_en                 ( p1_cmd_en_i               ),
+   .p1_cmd_instr              ( p1_cmd_instr_i            ),
+   .p1_cmd_bl                 ( p1_cmd_bl_i               ),
+   .p1_cmd_byte_addr          ( p1_cmd_byte_addr_i        ),
+   .p1_cmd_empty              ( p1_cmd_empty_i            ),
+   .p1_cmd_full               ( p1_cmd_full_i             ),
+   .p1_wr_clk                 ( p1_wr_clk_i               ),
+   .p1_wr_en                  ( p1_wr_en_i                ),
+   .p1_wr_mask                ( p1_wr_mask_i              ),
+   .p1_wr_data                ( p1_wr_data_i              ),
+   .p1_wr_full                ( p1_wr_full_i              ),
+   .p1_wr_empty               ( p1_wr_empty_i             ),
+   .p1_wr_count               ( p1_wr_count_i             ),
+   .p1_wr_underrun            ( p1_wr_underrun_i          ),
+   .p1_wr_error               ( p1_wr_error_i             ),
+   .p1_rd_clk                 ( p1_rd_clk_i               ),
+   .p1_rd_en                  ( p1_rd_en_i                ),
+   .p1_rd_data                ( p1_rd_data_i              ),
+   .p1_rd_full                ( p1_rd_full_i              ),
+   .p1_rd_empty               ( p1_rd_empty_i             ),
+   .p1_rd_count               ( p1_rd_count_i             ),
+   .p1_rd_overflow            ( p1_rd_overflow_i          ),
+   .p1_rd_error               ( p1_rd_error_i             ),
+   .p2_arb_en                 ( p2_arb_en_i               ),
+   .p2_cmd_clk                ( p2_cmd_clk_i              ),
+   .p2_cmd_en                 ( p2_cmd_en_i               ),
+   .p2_cmd_instr              ( p2_cmd_instr_i            ),
+   .p2_cmd_bl                 ( p2_cmd_bl_i               ),
+   .p2_cmd_byte_addr          ( p2_cmd_byte_addr_i        ),
+   .p2_cmd_empty              ( p2_cmd_empty_i            ),
+   .p2_cmd_full               ( p2_cmd_full_i             ),
+   .p2_wr_clk                 ( p2_wr_clk_i               ),
+   .p2_wr_en                  ( p2_wr_en_i                ),
+   .p2_wr_mask                ( p2_wr_mask_i              ),
+   .p2_wr_data                ( p2_wr_data_i              ),
+   .p2_wr_full                ( p2_wr_full_i              ),
+   .p2_wr_empty               ( p2_wr_empty_i             ),
+   .p2_wr_count               ( p2_wr_count_i             ),
+   .p2_wr_underrun            ( p2_wr_underrun_i          ),
+   .p2_wr_error               ( p2_wr_error_i             ),
+   .p2_rd_clk                 ( p2_rd_clk_i               ),
+   .p2_rd_en                  ( p2_rd_en_i                ),
+   .p2_rd_data                ( p2_rd_data_i              ),
+   .p2_rd_full                ( p2_rd_full_i              ),
+   .p2_rd_empty               ( p2_rd_empty_i             ),
+   .p2_rd_count               ( p2_rd_count_i             ),
+   .p2_rd_overflow            ( p2_rd_overflow_i          ),
+   .p2_rd_error               ( p2_rd_error_i             ),
+   .p3_arb_en                 ( p3_arb_en_i               ),
+   .p3_cmd_clk                ( p3_cmd_clk_i              ),
+   .p3_cmd_en                 ( p3_cmd_en_i               ),
+   .p3_cmd_instr              ( p3_cmd_instr_i            ),
+   .p3_cmd_bl                 ( p3_cmd_bl_i               ),
+   .p3_cmd_byte_addr          ( p3_cmd_byte_addr_i        ),
+   .p3_cmd_empty              ( p3_cmd_empty_i            ),
+   .p3_cmd_full               ( p3_cmd_full_i             ),
+   .p3_wr_clk                 ( p3_wr_clk_i               ),
+   .p3_wr_en                  ( p3_wr_en_i                ),
+   .p3_wr_mask                ( p3_wr_mask_i              ),
+   .p3_wr_data                ( p3_wr_data_i              ),
+   .p3_wr_full                ( p3_wr_full_i              ),
+   .p3_wr_empty               ( p3_wr_empty_i             ),
+   .p3_wr_count               ( p3_wr_count_i             ),
+   .p3_wr_underrun            ( p3_wr_underrun_i          ),
+   .p3_wr_error               ( p3_wr_error_i             ),
+   .p3_rd_clk                 ( p3_rd_clk_i               ),
+   .p3_rd_en                  ( p3_rd_en_i                ),
+   .p3_rd_data                ( p3_rd_data_i              ),
+   .p3_rd_full                ( p3_rd_full_i              ),
+   .p3_rd_empty               ( p3_rd_empty_i             ),
+   .p3_rd_count               ( p3_rd_count_i             ),
+   .p3_rd_overflow            ( p3_rd_overflow_i          ),
+   .p3_rd_error               ( p3_rd_error_i             ),
+   .p4_arb_en                 ( p4_arb_en_i               ),
+   .p4_cmd_clk                ( p4_cmd_clk_i              ),
+   .p4_cmd_en                 ( p4_cmd_en_i               ),
+   .p4_cmd_instr              ( p4_cmd_instr_i            ),
+   .p4_cmd_bl                 ( p4_cmd_bl_i               ),
+   .p4_cmd_byte_addr          ( p4_cmd_byte_addr_i        ),
+   .p4_cmd_empty              ( p4_cmd_empty_i            ),
+   .p4_cmd_full               ( p4_cmd_full_i             ),
+   .p4_wr_clk                 ( p4_wr_clk_i               ),
+   .p4_wr_en                  ( p4_wr_en_i                ),
+   .p4_wr_mask                ( p4_wr_mask_i              ),
+   .p4_wr_data                ( p4_wr_data_i              ),
+   .p4_wr_full                ( p4_wr_full_i              ),
+   .p4_wr_empty               ( p4_wr_empty_i             ),
+   .p4_wr_count               ( p4_wr_count_i             ),
+   .p4_wr_underrun            ( p4_wr_underrun_i          ),
+   .p4_wr_error               ( p4_wr_error_i             ),
+   .p4_rd_clk                 ( p4_rd_clk_i               ),
+   .p4_rd_en                  ( p4_rd_en_i                ),
+   .p4_rd_data                ( p4_rd_data_i              ),
+   .p4_rd_full                ( p4_rd_full_i              ),
+   .p4_rd_empty               ( p4_rd_empty_i             ),
+   .p4_rd_count               ( p4_rd_count_i             ),
+   .p4_rd_overflow            ( p4_rd_overflow_i          ),
+   .p4_rd_error               ( p4_rd_error_i             ),
+   .p5_arb_en                 ( p5_arb_en_i               ),
+   .p5_cmd_clk                ( p5_cmd_clk_i              ),
+   .p5_cmd_en                 ( p5_cmd_en_i               ),
+   .p5_cmd_instr              ( p5_cmd_instr_i            ),
+   .p5_cmd_bl                 ( p5_cmd_bl_i               ),
+   .p5_cmd_byte_addr          ( p5_cmd_byte_addr_i        ),
+   .p5_cmd_empty              ( p5_cmd_empty_i            ),
+   .p5_cmd_full               ( p5_cmd_full_i             ),
+   .p5_wr_clk                 ( p5_wr_clk_i               ),
+   .p5_wr_en                  ( p5_wr_en_i                ),
+   .p5_wr_mask                ( p5_wr_mask_i              ),
+   .p5_wr_data                ( p5_wr_data_i              ),
+   .p5_wr_full                ( p5_wr_full_i              ),
+   .p5_wr_empty               ( p5_wr_empty_i             ),
+   .p5_wr_count               ( p5_wr_count_i             ),
+   .p5_wr_underrun            ( p5_wr_underrun_i          ),
+   .p5_wr_error               ( p5_wr_error_i             ),
+   .p5_rd_clk                 ( p5_rd_clk_i               ),
+   .p5_rd_en                  ( p5_rd_en_i                ),
+   .p5_rd_data                ( p5_rd_data_i              ),
+   .p5_rd_full                ( p5_rd_full_i              ),
+   .p5_rd_empty               ( p5_rd_empty_i             ),
+   .p5_rd_count               ( p5_rd_count_i             ),
+   .p5_rd_overflow            ( p5_rd_overflow_i          ),
+   .p5_rd_error               ( p5_rd_error_i             ),
+   .mcbx_dram_addr            ( mcbx_dram_addr            ),
+   .mcbx_dram_ba              ( mcbx_dram_ba              ),
+   .mcbx_dram_ras_n           ( mcbx_dram_ras_n           ),
+   .mcbx_dram_cas_n           ( mcbx_dram_cas_n           ),
+   .mcbx_dram_we_n            ( mcbx_dram_we_n            ),
+   .mcbx_dram_cke             ( mcbx_dram_cke             ),
+   .mcbx_dram_clk             ( mcbx_dram_clk             ),
+   .mcbx_dram_clk_n           ( mcbx_dram_clk_n           ),
+   .mcbx_dram_dq              ( mcbx_dram_dq              ),
+   .mcbx_dram_dqs             ( mcbx_dram_dqs             ),
+   .mcbx_dram_dqs_n           ( mcbx_dram_dqs_n           ),
+   .mcbx_dram_udqs            ( mcbx_dram_udqs            ),
+   .mcbx_dram_udqs_n          ( mcbx_dram_udqs_n          ),
+   .mcbx_dram_udm             ( mcbx_dram_udm             ),
+   .mcbx_dram_ldm             ( mcbx_dram_ldm             ),
+   .mcbx_dram_odt             ( mcbx_dram_odt             ),
+   .mcbx_dram_ddr3_rst        ( mcbx_dram_ddr3_rst        ),
+   .calib_recal               ( calib_recal               ),
+   .rzq                       ( rzq                       ),
+   .zio                       ( zio                       ),
+   .ui_read                   ( ui_read                   ),
+   .ui_add                    ( ui_add                    ),
+   .ui_cs                     ( ui_cs                     ),
+   .ui_clk                    ( ui_clk                    ),
+   .ui_sdi                    ( ui_sdi                    ),
+   .ui_addr                   ( ui_addr                   ),
+   .ui_broadcast              ( ui_broadcast              ),
+   .ui_drp_update             ( ui_drp_update             ),
+   .ui_done_cal               ( ui_done_cal               ),
+   .ui_cmd                    ( ui_cmd                    ),
+   .ui_cmd_in                 ( ui_cmd_in                 ),
+   .ui_cmd_en                 ( ui_cmd_en                 ),
+   .ui_dqcount                ( ui_dqcount                ),
+   .ui_dq_lower_dec           ( ui_dq_lower_dec           ),
+   .ui_dq_lower_inc           ( ui_dq_lower_inc           ),
+   .ui_dq_upper_dec           ( ui_dq_upper_dec           ),
+   .ui_dq_upper_inc           ( ui_dq_upper_inc           ),
+   .ui_udqs_inc               ( ui_udqs_inc               ),
+   .ui_udqs_dec               ( ui_udqs_dec               ),
+   .ui_ldqs_inc               ( ui_ldqs_inc               ),
+   .ui_ldqs_dec               ( ui_ldqs_dec               ),
+   .uo_data                   ( uo_data                   ),
+   .uo_data_valid             ( uo_data_valid             ),
+   .uo_done_cal               ( uo_done_cal               ),
+   .uo_cmd_ready_in           ( uo_cmd_ready_in           ),
+   .uo_refrsh_flag            ( uo_refrsh_flag            ),
+   .uo_cal_start              ( uo_cal_start              ),
+   .uo_sdo                    ( uo_sdo                    ),
+   .status                    ( status                    ),
+   .selfrefresh_enter         ( selfrefresh_enter         ),
+   .selfrefresh_mode          ( selfrefresh_mode          )
+   );
+
+// P0 AXI Bridge Mux
+  generate
+    if (C_S0_AXI_ENABLE == 0) begin : P0_UI_MCB
+      assign  p0_arb_en_i        =  p0_arb_en        ; //
+      assign  p0_cmd_clk_i       =  p0_cmd_clk       ; //
+      assign  p0_cmd_en_i        =  p0_cmd_en        ; //
+      assign  p0_cmd_instr_i     =  p0_cmd_instr     ; // [2:0]
+      assign  p0_cmd_bl_i        =  p0_cmd_bl        ; // [5:0]
+      assign  p0_cmd_byte_addr_i =  p0_cmd_byte_addr ; // [29:0]
+      assign  p0_cmd_empty       =  p0_cmd_empty_i   ; //
+      assign  p0_cmd_full        =  p0_cmd_full_i    ; //
+      assign  p0_wr_clk_i        =  p0_wr_clk        ; //
+      assign  p0_wr_en_i         =  p0_wr_en         ; //
+      assign  p0_wr_mask_i       =  p0_wr_mask       ; // [C_P0_MASK_SIZE-1:0]
+      assign  p0_wr_data_i       =  p0_wr_data       ; // [C_P0_DATA_PORT_SIZE-1:0]
+      assign  p0_wr_full         =  p0_wr_full_i     ; //
+      assign  p0_wr_empty        =  p0_wr_empty_i    ; //
+      assign  p0_wr_count        =  p0_wr_count_i    ; // [6:0]
+      assign  p0_wr_underrun     =  p0_wr_underrun_i ; //
+      assign  p0_wr_error        =  p0_wr_error_i    ; //
+      assign  p0_rd_clk_i        =  p0_rd_clk        ; //
+      assign  p0_rd_en_i         =  p0_rd_en         ; //
+      assign  p0_rd_data         =  p0_rd_data_i     ; // [C_P0_DATA_PORT_SIZE-1:0]
+      assign  p0_rd_full         =  p0_rd_full_i     ; //
+      assign  p0_rd_empty        =  p0_rd_empty_i    ; //
+      assign  p0_rd_count        =  p0_rd_count_i    ; // [6:0]
+      assign  p0_rd_overflow     =  p0_rd_overflow_i ; //
+      assign  p0_rd_error        =  p0_rd_error_i    ; //
+    end
+    else begin : P0_UI_AXI
+      assign  p0_arb_en_i        =  p0_arb_en;
+      assign  s0_axi_araddr_i    = s0_axi_araddr & P_S0_AXI_ADDRMASK;
+      assign  s0_axi_awaddr_i    = s0_axi_awaddr & P_S0_AXI_ADDRMASK;
+      wire                     calib_done_synch;
+/*
+      mcb_ui_top_synch #(
+        .C_SYNCH_WIDTH          ( 1 )
+      )
+      axi_mcb_synch
+      (
+        .clk       ( s0_axi_aclk      ) ,
+        .synch_in  ( uo_done_cal      ) ,
+        .synch_out ( calib_done_synch )
+      );
+      axi_mcb #
+        (
+        .C_FAMILY                ( "spartan6"               ) ,
+        .C_S_AXI_ID_WIDTH        ( C_S0_AXI_ID_WIDTH        ) ,
+        .C_S_AXI_ADDR_WIDTH      ( C_S0_AXI_ADDR_WIDTH      ) ,
+        .C_S_AXI_DATA_WIDTH      ( C_S0_AXI_DATA_WIDTH      ) ,
+        .C_S_AXI_SUPPORTS_READ   ( C_S0_AXI_SUPPORTS_READ   ) ,
+        .C_S_AXI_SUPPORTS_WRITE  ( C_S0_AXI_SUPPORTS_WRITE  ) ,
+        .C_S_AXI_REG_EN0         ( C_S0_AXI_REG_EN0         ) ,
+        .C_S_AXI_REG_EN1         ( C_S0_AXI_REG_EN1         ) ,
+        .C_S_AXI_SUPPORTS_NARROW_BURST ( C_S0_AXI_SUPPORTS_NARROW_BURST ) ,
+        .C_MCB_ADDR_WIDTH        ( 30                       ) ,
+        .C_MCB_DATA_WIDTH        ( C_P0_DATA_PORT_SIZE      ) ,
+        .C_STRICT_COHERENCY      ( C_S0_AXI_STRICT_COHERENCY    ) ,
+        .C_ENABLE_AP             ( C_S0_AXI_ENABLE_AP           )
+        )
+        p0_axi_mcb
+        (
+        .aclk              ( s0_axi_aclk        ),
+        .aresetn           ( s0_axi_aresetn     ),
+        .s_axi_awid        ( s0_axi_awid        ),
+        .s_axi_awaddr      ( s0_axi_awaddr_i    ),
+        .s_axi_awlen       ( s0_axi_awlen       ),
+        .s_axi_awsize      ( s0_axi_awsize      ),
+        .s_axi_awburst     ( s0_axi_awburst     ),
+        .s_axi_awlock      ( s0_axi_awlock      ),
+        .s_axi_awcache     ( s0_axi_awcache     ),
+        .s_axi_awprot      ( s0_axi_awprot      ),
+        .s_axi_awqos       ( s0_axi_awqos       ),
+        .s_axi_awvalid     ( s0_axi_awvalid     ),
+        .s_axi_awready     ( s0_axi_awready     ),
+        .s_axi_wdata       ( s0_axi_wdata       ),
+        .s_axi_wstrb       ( s0_axi_wstrb       ),
+        .s_axi_wlast       ( s0_axi_wlast       ),
+        .s_axi_wvalid      ( s0_axi_wvalid      ),
+        .s_axi_wready      ( s0_axi_wready      ),
+        .s_axi_bid         ( s0_axi_bid         ),
+        .s_axi_bresp       ( s0_axi_bresp       ),
+        .s_axi_bvalid      ( s0_axi_bvalid      ),
+        .s_axi_bready      ( s0_axi_bready      ),
+        .s_axi_arid        ( s0_axi_arid        ),
+        .s_axi_araddr      ( s0_axi_araddr_i    ),
+        .s_axi_arlen       ( s0_axi_arlen       ),
+        .s_axi_arsize      ( s0_axi_arsize      ),
+        .s_axi_arburst     ( s0_axi_arburst     ),
+        .s_axi_arlock      ( s0_axi_arlock      ),
+        .s_axi_arcache     ( s0_axi_arcache     ),
+        .s_axi_arprot      ( s0_axi_arprot      ),
+        .s_axi_arqos       ( s0_axi_arqos       ),
+        .s_axi_arvalid     ( s0_axi_arvalid     ),
+        .s_axi_arready     ( s0_axi_arready     ),
+        .s_axi_rid         ( s0_axi_rid         ),
+        .s_axi_rdata       ( s0_axi_rdata       ),
+        .s_axi_rresp       ( s0_axi_rresp       ),
+        .s_axi_rlast       ( s0_axi_rlast       ),
+        .s_axi_rvalid      ( s0_axi_rvalid      ),
+        .s_axi_rready      ( s0_axi_rready      ),
+        .mcb_cmd_clk       ( p0_cmd_clk_i       ),
+        .mcb_cmd_en        ( p0_cmd_en_i        ),
+        .mcb_cmd_instr     ( p0_cmd_instr_i     ),
+        .mcb_cmd_bl        ( p0_cmd_bl_i        ),
+        .mcb_cmd_byte_addr ( p0_cmd_byte_addr_i ),
+        .mcb_cmd_empty     ( p0_cmd_empty_i     ),
+        .mcb_cmd_full      ( p0_cmd_full_i      ),
+        .mcb_wr_clk        ( p0_wr_clk_i        ),
+        .mcb_wr_en         ( p0_wr_en_i         ),
+        .mcb_wr_mask       ( p0_wr_mask_i       ),
+        .mcb_wr_data       ( p0_wr_data_i       ),
+        .mcb_wr_full       ( p0_wr_full_i       ),
+        .mcb_wr_empty      ( p0_wr_empty_i      ),
+        .mcb_wr_count      ( p0_wr_count_i      ),
+        .mcb_wr_underrun   ( p0_wr_underrun_i   ),
+        .mcb_wr_error      ( p0_wr_error_i      ),
+        .mcb_rd_clk        ( p0_rd_clk_i        ),
+        .mcb_rd_en         ( p0_rd_en_i         ),
+        .mcb_rd_data       ( p0_rd_data_i       ),
+        .mcb_rd_full       ( p0_rd_full_i       ),
+        .mcb_rd_empty      ( p0_rd_empty_i      ),
+        .mcb_rd_count      ( p0_rd_count_i      ),
+        .mcb_rd_overflow   ( p0_rd_overflow_i   ),
+        .mcb_rd_error      ( p0_rd_error_i      ),
+        .mcb_calib_done    ( calib_done_synch   )
+        );
+ */
+    end
+  endgenerate
+
+// P1 AXI Bridge Mux
+  generate
+    if (C_S1_AXI_ENABLE == 0) begin : P1_UI_MCB
+      assign  p1_arb_en_i        =  p1_arb_en        ; //
+      assign  p1_cmd_clk_i       =  p1_cmd_clk       ; //
+      assign  p1_cmd_en_i        =  p1_cmd_en        ; //
+      assign  p1_cmd_instr_i     =  p1_cmd_instr     ; // [2:0]
+      assign  p1_cmd_bl_i        =  p1_cmd_bl        ; // [5:0]
+      assign  p1_cmd_byte_addr_i =  p1_cmd_byte_addr ; // [29:0]
+      assign  p1_cmd_empty       =  p1_cmd_empty_i   ; //
+      assign  p1_cmd_full        =  p1_cmd_full_i    ; //
+      assign  p1_wr_clk_i        =  p1_wr_clk        ; //
+      assign  p1_wr_en_i         =  p1_wr_en         ; //
+      assign  p1_wr_mask_i       =  p1_wr_mask       ; // [C_P1_MASK_SIZE-1:0]
+      assign  p1_wr_data_i       =  p1_wr_data       ; // [C_P1_DATA_PORT_SIZE-1:0]
+      assign  p1_wr_full         =  p1_wr_full_i     ; //
+      assign  p1_wr_empty        =  p1_wr_empty_i    ; //
+      assign  p1_wr_count        =  p1_wr_count_i    ; // [6:0]
+      assign  p1_wr_underrun     =  p1_wr_underrun_i ; //
+      assign  p1_wr_error        =  p1_wr_error_i    ; //
+      assign  p1_rd_clk_i        =  p1_rd_clk        ; //
+      assign  p1_rd_en_i         =  p1_rd_en         ; //
+      assign  p1_rd_data         =  p1_rd_data_i     ; // [C_P1_DATA_PORT_SIZE-1:0]
+      assign  p1_rd_full         =  p1_rd_full_i     ; //
+      assign  p1_rd_empty        =  p1_rd_empty_i    ; //
+      assign  p1_rd_count        =  p1_rd_count_i    ; // [6:0]
+      assign  p1_rd_overflow     =  p1_rd_overflow_i ; //
+      assign  p1_rd_error        =  p1_rd_error_i    ; //
+    end
+    else begin : P1_UI_AXI
+      assign  p1_arb_en_i        =  p1_arb_en;
+      assign  s1_axi_araddr_i    = s1_axi_araddr & P_S1_AXI_ADDRMASK;
+      assign  s1_axi_awaddr_i    = s1_axi_awaddr & P_S1_AXI_ADDRMASK;
+      wire                     calib_done_synch;
+/*
+      mcb_ui_top_synch #(
+        .C_SYNCH_WIDTH          ( 1 )
+      )
+      axi_mcb_synch
+      (
+        .clk                    ( s1_axi_aclk      ),
+        .synch_in               ( uo_done_cal      ),
+        .synch_out              ( calib_done_synch )
+      );
+      axi_mcb #
+        (
+        .C_FAMILY                ( "spartan6"               ) ,
+        .C_S_AXI_ID_WIDTH        ( C_S1_AXI_ID_WIDTH        ) ,
+        .C_S_AXI_ADDR_WIDTH      ( C_S1_AXI_ADDR_WIDTH      ) ,
+        .C_S_AXI_DATA_WIDTH      ( C_S1_AXI_DATA_WIDTH      ) ,
+        .C_S_AXI_SUPPORTS_READ   ( C_S1_AXI_SUPPORTS_READ   ) ,
+        .C_S_AXI_SUPPORTS_WRITE  ( C_S1_AXI_SUPPORTS_WRITE  ) ,
+        .C_S_AXI_REG_EN0         ( C_S1_AXI_REG_EN0         ) ,
+        .C_S_AXI_REG_EN1         ( C_S1_AXI_REG_EN1         ) ,
+        .C_S_AXI_SUPPORTS_NARROW_BURST ( C_S1_AXI_SUPPORTS_NARROW_BURST ) ,
+        .C_MCB_ADDR_WIDTH        ( 30                       ) ,
+        .C_MCB_DATA_WIDTH        ( C_P1_DATA_PORT_SIZE      ) ,
+        .C_STRICT_COHERENCY      ( C_S1_AXI_STRICT_COHERENCY    ) ,
+        .C_ENABLE_AP             ( C_S1_AXI_ENABLE_AP           )
+        )
+        p1_axi_mcb
+        (
+        .aclk              ( s1_axi_aclk        ),
+        .aresetn           ( s1_axi_aresetn     ),
+        .s_axi_awid        ( s1_axi_awid        ),
+        .s_axi_awaddr      ( s1_axi_awaddr_i    ),
+        .s_axi_awlen       ( s1_axi_awlen       ),
+        .s_axi_awsize      ( s1_axi_awsize      ),
+        .s_axi_awburst     ( s1_axi_awburst     ),
+        .s_axi_awlock      ( s1_axi_awlock      ),
+        .s_axi_awcache     ( s1_axi_awcache     ),
+        .s_axi_awprot      ( s1_axi_awprot      ),
+        .s_axi_awqos       ( s1_axi_awqos       ),
+        .s_axi_awvalid     ( s1_axi_awvalid     ),
+        .s_axi_awready     ( s1_axi_awready     ),
+        .s_axi_wdata       ( s1_axi_wdata       ),
+        .s_axi_wstrb       ( s1_axi_wstrb       ),
+        .s_axi_wlast       ( s1_axi_wlast       ),
+        .s_axi_wvalid      ( s1_axi_wvalid      ),
+        .s_axi_wready      ( s1_axi_wready      ),
+        .s_axi_bid         ( s1_axi_bid         ),
+        .s_axi_bresp       ( s1_axi_bresp       ),
+        .s_axi_bvalid      ( s1_axi_bvalid      ),
+        .s_axi_bready      ( s1_axi_bready      ),
+        .s_axi_arid        ( s1_axi_arid        ),
+        .s_axi_araddr      ( s1_axi_araddr_i    ),
+        .s_axi_arlen       ( s1_axi_arlen       ),
+        .s_axi_arsize      ( s1_axi_arsize      ),
+        .s_axi_arburst     ( s1_axi_arburst     ),
+        .s_axi_arlock      ( s1_axi_arlock      ),
+        .s_axi_arcache     ( s1_axi_arcache     ),
+        .s_axi_arprot      ( s1_axi_arprot      ),
+        .s_axi_arqos       ( s1_axi_arqos       ),
+        .s_axi_arvalid     ( s1_axi_arvalid     ),
+        .s_axi_arready     ( s1_axi_arready     ),
+        .s_axi_rid         ( s1_axi_rid         ),
+        .s_axi_rdata       ( s1_axi_rdata       ),
+        .s_axi_rresp       ( s1_axi_rresp       ),
+        .s_axi_rlast       ( s1_axi_rlast       ),
+        .s_axi_rvalid      ( s1_axi_rvalid      ),
+        .s_axi_rready      ( s1_axi_rready      ),
+        .mcb_cmd_clk       ( p1_cmd_clk_i       ),
+        .mcb_cmd_en        ( p1_cmd_en_i        ),
+        .mcb_cmd_instr     ( p1_cmd_instr_i     ),
+        .mcb_cmd_bl        ( p1_cmd_bl_i        ),
+        .mcb_cmd_byte_addr ( p1_cmd_byte_addr_i ),
+        .mcb_cmd_empty     ( p1_cmd_empty_i     ),
+        .mcb_cmd_full      ( p1_cmd_full_i      ),
+        .mcb_wr_clk        ( p1_wr_clk_i        ),
+        .mcb_wr_en         ( p1_wr_en_i         ),
+        .mcb_wr_mask       ( p1_wr_mask_i       ),
+        .mcb_wr_data       ( p1_wr_data_i       ),
+        .mcb_wr_full       ( p1_wr_full_i       ),
+        .mcb_wr_empty      ( p1_wr_empty_i      ),
+        .mcb_wr_count      ( p1_wr_count_i      ),
+        .mcb_wr_underrun   ( p1_wr_underrun_i   ),
+        .mcb_wr_error      ( p1_wr_error_i      ),
+        .mcb_rd_clk        ( p1_rd_clk_i        ),
+        .mcb_rd_en         ( p1_rd_en_i         ),
+        .mcb_rd_data       ( p1_rd_data_i       ),
+        .mcb_rd_full       ( p1_rd_full_i       ),
+        .mcb_rd_empty      ( p1_rd_empty_i      ),
+        .mcb_rd_count      ( p1_rd_count_i      ),
+        .mcb_rd_overflow   ( p1_rd_overflow_i   ),
+        .mcb_rd_error      ( p1_rd_error_i      ),
+        .mcb_calib_done    ( calib_done_synch   )
+        );
+ */
+    end
+  endgenerate
+
+// P2 AXI Bridge Mux
+  generate
+    if (C_S2_AXI_ENABLE == 0) begin : P2_UI_MCB
+      assign  p2_arb_en_i        =  p2_arb_en        ; //
+      assign  p2_cmd_clk_i       =  p2_cmd_clk       ; //
+      assign  p2_cmd_en_i        =  p2_cmd_en        ; //
+      assign  p2_cmd_instr_i     =  p2_cmd_instr     ; // [2:0]
+      assign  p2_cmd_bl_i        =  p2_cmd_bl        ; // [5:0]
+      assign  p2_cmd_byte_addr_i =  p2_cmd_byte_addr ; // [29:0]
+      assign  p2_cmd_empty       =  p2_cmd_empty_i   ; //
+      assign  p2_cmd_full        =  p2_cmd_full_i    ; //
+      assign  p2_wr_clk_i        =  p2_wr_clk        ; //
+      assign  p2_wr_en_i         =  p2_wr_en         ; //
+      assign  p2_wr_mask_i       =  p2_wr_mask       ; // [3:0]
+      assign  p2_wr_data_i       =  p2_wr_data       ; // [31:0]
+      assign  p2_wr_full         =  p2_wr_full_i     ; //
+      assign  p2_wr_empty        =  p2_wr_empty_i    ; //
+      assign  p2_wr_count        =  p2_wr_count_i    ; // [6:0]
+      assign  p2_wr_underrun     =  p2_wr_underrun_i ; //
+      assign  p2_wr_error        =  p2_wr_error_i    ; //
+      assign  p2_rd_clk_i        =  p2_rd_clk        ; //
+      assign  p2_rd_en_i         =  p2_rd_en         ; //
+      assign  p2_rd_data         =  p2_rd_data_i     ; // [31:0]
+      assign  p2_rd_full         =  p2_rd_full_i     ; //
+      assign  p2_rd_empty        =  p2_rd_empty_i    ; //
+      assign  p2_rd_count        =  p2_rd_count_i    ; // [6:0]
+      assign  p2_rd_overflow     =  p2_rd_overflow_i ; //
+      assign  p2_rd_error        =  p2_rd_error_i    ; //
+    end
+    else begin : P2_UI_AXI
+      assign  p2_arb_en_i        =  p2_arb_en;
+      assign  s2_axi_araddr_i    = s2_axi_araddr & P_S2_AXI_ADDRMASK;
+      assign  s2_axi_awaddr_i    = s2_axi_awaddr & P_S2_AXI_ADDRMASK;
+      wire                     calib_done_synch;
+/*
+      mcb_ui_top_synch #(
+        .C_SYNCH_WIDTH          ( 1 )
+      )
+      axi_mcb_synch
+      (
+        .clk                    ( s2_axi_aclk      ),
+        .synch_in               ( uo_done_cal      ),
+        .synch_out              ( calib_done_synch )
+      );
+      axi_mcb #
+        (
+        .C_FAMILY                ( "spartan6"               ) ,
+        .C_S_AXI_ID_WIDTH        ( C_S2_AXI_ID_WIDTH        ) ,
+        .C_S_AXI_ADDR_WIDTH      ( C_S2_AXI_ADDR_WIDTH      ) ,
+        .C_S_AXI_DATA_WIDTH      ( 32                       ) ,
+        .C_S_AXI_SUPPORTS_READ   ( C_S2_AXI_SUPPORTS_READ   ) ,
+        .C_S_AXI_SUPPORTS_WRITE  ( C_S2_AXI_SUPPORTS_WRITE  ) ,
+        .C_S_AXI_REG_EN0         ( C_S2_AXI_REG_EN0         ) ,
+        .C_S_AXI_REG_EN1         ( C_S2_AXI_REG_EN1         ) ,
+        .C_S_AXI_SUPPORTS_NARROW_BURST ( C_S2_AXI_SUPPORTS_NARROW_BURST ) ,
+        .C_MCB_ADDR_WIDTH        ( 30                       ) ,
+        .C_MCB_DATA_WIDTH        ( 32                       ) ,
+        .C_STRICT_COHERENCY      ( C_S2_AXI_STRICT_COHERENCY    ) ,
+        .C_ENABLE_AP             ( C_S2_AXI_ENABLE_AP           )
+        )
+        p2_axi_mcb
+        (
+        .aclk              ( s2_axi_aclk        ),
+        .aresetn           ( s2_axi_aresetn     ),
+        .s_axi_awid        ( s2_axi_awid        ),
+        .s_axi_awaddr      ( s2_axi_awaddr_i    ),
+        .s_axi_awlen       ( s2_axi_awlen       ),
+        .s_axi_awsize      ( s2_axi_awsize      ),
+        .s_axi_awburst     ( s2_axi_awburst     ),
+        .s_axi_awlock      ( s2_axi_awlock      ),
+        .s_axi_awcache     ( s2_axi_awcache     ),
+        .s_axi_awprot      ( s2_axi_awprot      ),
+        .s_axi_awqos       ( s2_axi_awqos       ),
+        .s_axi_awvalid     ( s2_axi_awvalid     ),
+        .s_axi_awready     ( s2_axi_awready     ),
+        .s_axi_wdata       ( s2_axi_wdata       ),
+        .s_axi_wstrb       ( s2_axi_wstrb       ),
+        .s_axi_wlast       ( s2_axi_wlast       ),
+        .s_axi_wvalid      ( s2_axi_wvalid      ),
+        .s_axi_wready      ( s2_axi_wready      ),
+        .s_axi_bid         ( s2_axi_bid         ),
+        .s_axi_bresp       ( s2_axi_bresp       ),
+        .s_axi_bvalid      ( s2_axi_bvalid      ),
+        .s_axi_bready      ( s2_axi_bready      ),
+        .s_axi_arid        ( s2_axi_arid        ),
+        .s_axi_araddr      ( s2_axi_araddr_i    ),
+        .s_axi_arlen       ( s2_axi_arlen       ),
+        .s_axi_arsize      ( s2_axi_arsize      ),
+        .s_axi_arburst     ( s2_axi_arburst     ),
+        .s_axi_arlock      ( s2_axi_arlock      ),
+        .s_axi_arcache     ( s2_axi_arcache     ),
+        .s_axi_arprot      ( s2_axi_arprot      ),
+        .s_axi_arqos       ( s2_axi_arqos       ),
+        .s_axi_arvalid     ( s2_axi_arvalid     ),
+        .s_axi_arready     ( s2_axi_arready     ),
+        .s_axi_rid         ( s2_axi_rid         ),
+        .s_axi_rdata       ( s2_axi_rdata       ),
+        .s_axi_rresp       ( s2_axi_rresp       ),
+        .s_axi_rlast       ( s2_axi_rlast       ),
+        .s_axi_rvalid      ( s2_axi_rvalid      ),
+        .s_axi_rready      ( s2_axi_rready      ),
+        .mcb_cmd_clk       ( p2_cmd_clk_i       ),
+        .mcb_cmd_en        ( p2_cmd_en_i        ),
+        .mcb_cmd_instr     ( p2_cmd_instr_i     ),
+        .mcb_cmd_bl        ( p2_cmd_bl_i        ),
+        .mcb_cmd_byte_addr ( p2_cmd_byte_addr_i ),
+        .mcb_cmd_empty     ( p2_cmd_empty_i     ),
+        .mcb_cmd_full      ( p2_cmd_full_i      ),
+        .mcb_wr_clk        ( p2_wr_clk_i        ),
+        .mcb_wr_en         ( p2_wr_en_i         ),
+        .mcb_wr_mask       ( p2_wr_mask_i       ),
+        .mcb_wr_data       ( p2_wr_data_i       ),
+        .mcb_wr_full       ( p2_wr_full_i       ),
+        .mcb_wr_empty      ( p2_wr_empty_i      ),
+        .mcb_wr_count      ( p2_wr_count_i      ),
+        .mcb_wr_underrun   ( p2_wr_underrun_i   ),
+        .mcb_wr_error      ( p2_wr_error_i      ),
+        .mcb_rd_clk        ( p2_rd_clk_i        ),
+        .mcb_rd_en         ( p2_rd_en_i         ),
+        .mcb_rd_data       ( p2_rd_data_i       ),
+        .mcb_rd_full       ( p2_rd_full_i       ),
+        .mcb_rd_empty      ( p2_rd_empty_i      ),
+        .mcb_rd_count      ( p2_rd_count_i      ),
+        .mcb_rd_overflow   ( p2_rd_overflow_i   ),
+        .mcb_rd_error      ( p2_rd_error_i      ),
+        .mcb_calib_done    ( calib_done_synch   )
+        );
+ */
+    end
+  endgenerate
+
+// P3 AXI Bridge Mux
+  generate
+    if (C_S3_AXI_ENABLE == 0) begin : P3_UI_MCB
+      assign  p3_arb_en_i        =  p3_arb_en        ; //
+      assign  p3_cmd_clk_i       =  p3_cmd_clk       ; //
+      assign  p3_cmd_en_i        =  p3_cmd_en        ; //
+      assign  p3_cmd_instr_i     =  p3_cmd_instr     ; // [2:0]
+      assign  p3_cmd_bl_i        =  p3_cmd_bl        ; // [5:0]
+      assign  p3_cmd_byte_addr_i =  p3_cmd_byte_addr ; // [29:0]
+      assign  p3_cmd_empty       =  p3_cmd_empty_i   ; //
+      assign  p3_cmd_full        =  p3_cmd_full_i    ; //
+      assign  p3_wr_clk_i        =  p3_wr_clk        ; //
+      assign  p3_wr_en_i         =  p3_wr_en         ; //
+      assign  p3_wr_mask_i       =  p3_wr_mask       ; // [3:0]
+      assign  p3_wr_data_i       =  p3_wr_data       ; // [31:0]
+      assign  p3_wr_full         =  p3_wr_full_i     ; //
+      assign  p3_wr_empty        =  p3_wr_empty_i    ; //
+      assign  p3_wr_count        =  p3_wr_count_i    ; // [6:0]
+      assign  p3_wr_underrun     =  p3_wr_underrun_i ; //
+      assign  p3_wr_error        =  p3_wr_error_i    ; //
+      assign  p3_rd_clk_i        =  p3_rd_clk        ; //
+      assign  p3_rd_en_i         =  p3_rd_en         ; //
+      assign  p3_rd_data         =  p3_rd_data_i     ; // [31:0]
+      assign  p3_rd_full         =  p3_rd_full_i     ; //
+      assign  p3_rd_empty        =  p3_rd_empty_i    ; //
+      assign  p3_rd_count        =  p3_rd_count_i    ; // [6:0]
+      assign  p3_rd_overflow     =  p3_rd_overflow_i ; //
+      assign  p3_rd_error        =  p3_rd_error_i    ; //
+    end
+    else begin : P3_UI_AXI
+      assign  p3_arb_en_i        =  p3_arb_en;
+      assign  s3_axi_araddr_i    = s3_axi_araddr & P_S3_AXI_ADDRMASK;
+      assign  s3_axi_awaddr_i    = s3_axi_awaddr & P_S3_AXI_ADDRMASK;
+      wire                     calib_done_synch;
+/*
+      mcb_ui_top_synch #(
+        .C_SYNCH_WIDTH          ( 1 )
+      )
+      axi_mcb_synch
+      (
+        .clk                    ( s3_axi_aclk      ),
+        .synch_in               ( uo_done_cal      ),
+        .synch_out              ( calib_done_synch )
+      );
+
+      axi_mcb #
+        (
+        .C_FAMILY                ( "spartan6"               ) ,
+        .C_S_AXI_ID_WIDTH        ( C_S3_AXI_ID_WIDTH        ) ,
+        .C_S_AXI_ADDR_WIDTH      ( C_S3_AXI_ADDR_WIDTH      ) ,
+        .C_S_AXI_DATA_WIDTH      ( 32                       ) ,
+        .C_S_AXI_SUPPORTS_READ   ( C_S3_AXI_SUPPORTS_READ   ) ,
+        .C_S_AXI_SUPPORTS_WRITE  ( C_S3_AXI_SUPPORTS_WRITE  ) ,
+        .C_S_AXI_REG_EN0         ( C_S3_AXI_REG_EN0         ) ,
+        .C_S_AXI_REG_EN1         ( C_S3_AXI_REG_EN1         ) ,
+        .C_S_AXI_SUPPORTS_NARROW_BURST ( C_S3_AXI_SUPPORTS_NARROW_BURST ) ,
+        .C_MCB_ADDR_WIDTH        ( 30                       ) ,
+        .C_MCB_DATA_WIDTH        ( 32                       ) ,
+        .C_STRICT_COHERENCY      ( C_S3_AXI_STRICT_COHERENCY    ) ,
+        .C_ENABLE_AP             ( C_S3_AXI_ENABLE_AP           )
+        )
+        p3_axi_mcb
+        (
+        .aclk              ( s3_axi_aclk        ),
+        .aresetn           ( s3_axi_aresetn     ),
+        .s_axi_awid        ( s3_axi_awid        ),
+        .s_axi_awaddr      ( s3_axi_awaddr_i    ),
+        .s_axi_awlen       ( s3_axi_awlen       ),
+        .s_axi_awsize      ( s3_axi_awsize      ),
+        .s_axi_awburst     ( s3_axi_awburst     ),
+        .s_axi_awlock      ( s3_axi_awlock      ),
+        .s_axi_awcache     ( s3_axi_awcache     ),
+        .s_axi_awprot      ( s3_axi_awprot      ),
+        .s_axi_awqos       ( s3_axi_awqos       ),
+        .s_axi_awvalid     ( s3_axi_awvalid     ),
+        .s_axi_awready     ( s3_axi_awready     ),
+        .s_axi_wdata       ( s3_axi_wdata       ),
+        .s_axi_wstrb       ( s3_axi_wstrb       ),
+        .s_axi_wlast       ( s3_axi_wlast       ),
+        .s_axi_wvalid      ( s3_axi_wvalid      ),
+        .s_axi_wready      ( s3_axi_wready      ),
+        .s_axi_bid         ( s3_axi_bid         ),
+        .s_axi_bresp       ( s3_axi_bresp       ),
+        .s_axi_bvalid      ( s3_axi_bvalid      ),
+        .s_axi_bready      ( s3_axi_bready      ),
+        .s_axi_arid        ( s3_axi_arid        ),
+        .s_axi_araddr      ( s3_axi_araddr_i    ),
+        .s_axi_arlen       ( s3_axi_arlen       ),
+        .s_axi_arsize      ( s3_axi_arsize      ),
+        .s_axi_arburst     ( s3_axi_arburst     ),
+        .s_axi_arlock      ( s3_axi_arlock      ),
+        .s_axi_arcache     ( s3_axi_arcache     ),
+        .s_axi_arprot      ( s3_axi_arprot      ),
+        .s_axi_arqos       ( s3_axi_arqos       ),
+        .s_axi_arvalid     ( s3_axi_arvalid     ),
+        .s_axi_arready     ( s3_axi_arready     ),
+        .s_axi_rid         ( s3_axi_rid         ),
+        .s_axi_rdata       ( s3_axi_rdata       ),
+        .s_axi_rresp       ( s3_axi_rresp       ),
+        .s_axi_rlast       ( s3_axi_rlast       ),
+        .s_axi_rvalid      ( s3_axi_rvalid      ),
+        .s_axi_rready      ( s3_axi_rready      ),
+        .mcb_cmd_clk       ( p3_cmd_clk_i       ),
+        .mcb_cmd_en        ( p3_cmd_en_i        ),
+        .mcb_cmd_instr     ( p3_cmd_instr_i     ),
+        .mcb_cmd_bl        ( p3_cmd_bl_i        ),
+        .mcb_cmd_byte_addr ( p3_cmd_byte_addr_i ),
+        .mcb_cmd_empty     ( p3_cmd_empty_i     ),
+        .mcb_cmd_full      ( p3_cmd_full_i      ),
+        .mcb_wr_clk        ( p3_wr_clk_i        ),
+        .mcb_wr_en         ( p3_wr_en_i         ),
+        .mcb_wr_mask       ( p3_wr_mask_i       ),
+        .mcb_wr_data       ( p3_wr_data_i       ),
+        .mcb_wr_full       ( p3_wr_full_i       ),
+        .mcb_wr_empty      ( p3_wr_empty_i      ),
+        .mcb_wr_count      ( p3_wr_count_i      ),
+        .mcb_wr_underrun   ( p3_wr_underrun_i   ),
+        .mcb_wr_error      ( p3_wr_error_i      ),
+        .mcb_rd_clk        ( p3_rd_clk_i        ),
+        .mcb_rd_en         ( p3_rd_en_i         ),
+        .mcb_rd_data       ( p3_rd_data_i       ),
+        .mcb_rd_full       ( p3_rd_full_i       ),
+        .mcb_rd_empty      ( p3_rd_empty_i      ),
+        .mcb_rd_count      ( p3_rd_count_i      ),
+        .mcb_rd_overflow   ( p3_rd_overflow_i   ),
+        .mcb_rd_error      ( p3_rd_error_i      ),
+        .mcb_calib_done    ( calib_done_synch   )
+        );
+ */
+    end
+  endgenerate
+
+// P4 AXI Bridge Mux
+  generate
+    if (C_S4_AXI_ENABLE == 0) begin : P4_UI_MCB
+      assign  p4_arb_en_i        =  p4_arb_en        ; //
+      assign  p4_cmd_clk_i       =  p4_cmd_clk       ; //
+      assign  p4_cmd_en_i        =  p4_cmd_en        ; //
+      assign  p4_cmd_instr_i     =  p4_cmd_instr     ; // [2:0]
+      assign  p4_cmd_bl_i        =  p4_cmd_bl        ; // [5:0]
+      assign  p4_cmd_byte_addr_i =  p4_cmd_byte_addr ; // [29:0]
+      assign  p4_cmd_empty       =  p4_cmd_empty_i   ; //
+      assign  p4_cmd_full        =  p4_cmd_full_i    ; //
+      assign  p4_wr_clk_i        =  p4_wr_clk        ; //
+      assign  p4_wr_en_i         =  p4_wr_en         ; //
+      assign  p4_wr_mask_i       =  p4_wr_mask       ; // [3:0]
+      assign  p4_wr_data_i       =  p4_wr_data       ; // [31:0]
+      assign  p4_wr_full         =  p4_wr_full_i     ; //
+      assign  p4_wr_empty        =  p4_wr_empty_i    ; //
+      assign  p4_wr_count        =  p4_wr_count_i    ; // [6:0]
+      assign  p4_wr_underrun     =  p4_wr_underrun_i ; //
+      assign  p4_wr_error        =  p4_wr_error_i    ; //
+      assign  p4_rd_clk_i        =  p4_rd_clk        ; //
+      assign  p4_rd_en_i         =  p4_rd_en         ; //
+      assign  p4_rd_data         =  p4_rd_data_i     ; // [31:0]
+      assign  p4_rd_full         =  p4_rd_full_i     ; //
+      assign  p4_rd_empty        =  p4_rd_empty_i    ; //
+      assign  p4_rd_count        =  p4_rd_count_i    ; // [6:0]
+      assign  p4_rd_overflow     =  p4_rd_overflow_i ; //
+      assign  p4_rd_error        =  p4_rd_error_i    ; //
+    end
+    else begin : P4_UI_AXI
+      assign  p4_arb_en_i        =  p4_arb_en;
+      assign  s4_axi_araddr_i    = s4_axi_araddr & P_S4_AXI_ADDRMASK;
+      assign  s4_axi_awaddr_i    = s4_axi_awaddr & P_S4_AXI_ADDRMASK;
+      wire                     calib_done_synch;
+
+/*
+      mcb_ui_top_synch #(
+        .C_SYNCH_WIDTH          ( 1 )
+      )
+      axi_mcb_synch
+      (
+        .clk                    ( s4_axi_aclk      ),
+        .synch_in               ( uo_done_cal      ),
+        .synch_out              ( calib_done_synch )
+      );
+
+      axi_mcb #
+        (
+        .C_FAMILY                ( "spartan6"               ) ,
+        .C_S_AXI_ID_WIDTH        ( C_S4_AXI_ID_WIDTH        ) ,
+        .C_S_AXI_ADDR_WIDTH      ( C_S4_AXI_ADDR_WIDTH      ) ,
+        .C_S_AXI_DATA_WIDTH      ( 32                       ) ,
+        .C_S_AXI_SUPPORTS_READ   ( C_S4_AXI_SUPPORTS_READ   ) ,
+        .C_S_AXI_SUPPORTS_WRITE  ( C_S4_AXI_SUPPORTS_WRITE  ) ,
+        .C_S_AXI_REG_EN0         ( C_S4_AXI_REG_EN0         ) ,
+        .C_S_AXI_REG_EN1         ( C_S4_AXI_REG_EN1         ) ,
+        .C_S_AXI_SUPPORTS_NARROW_BURST ( C_S4_AXI_SUPPORTS_NARROW_BURST ) ,
+        .C_MCB_ADDR_WIDTH        ( 30                       ) ,
+        .C_MCB_DATA_WIDTH        ( 32                       ) ,
+        .C_STRICT_COHERENCY      ( C_S4_AXI_STRICT_COHERENCY    ) ,
+        .C_ENABLE_AP             ( C_S4_AXI_ENABLE_AP           )
+        )
+        p4_axi_mcb
+        (
+        .aclk              ( s4_axi_aclk        ),
+        .aresetn           ( s4_axi_aresetn     ),
+        .s_axi_awid        ( s4_axi_awid        ),
+        .s_axi_awaddr      ( s4_axi_awaddr_i    ),
+        .s_axi_awlen       ( s4_axi_awlen       ),
+        .s_axi_awsize      ( s4_axi_awsize      ),
+        .s_axi_awburst     ( s4_axi_awburst     ),
+        .s_axi_awlock      ( s4_axi_awlock      ),
+        .s_axi_awcache     ( s4_axi_awcache     ),
+        .s_axi_awprot      ( s4_axi_awprot      ),
+        .s_axi_awqos       ( s4_axi_awqos       ),
+        .s_axi_awvalid     ( s4_axi_awvalid     ),
+        .s_axi_awready     ( s4_axi_awready     ),
+        .s_axi_wdata       ( s4_axi_wdata       ),
+        .s_axi_wstrb       ( s4_axi_wstrb       ),
+        .s_axi_wlast       ( s4_axi_wlast       ),
+        .s_axi_wvalid      ( s4_axi_wvalid      ),
+        .s_axi_wready      ( s4_axi_wready      ),
+        .s_axi_bid         ( s4_axi_bid         ),
+        .s_axi_bresp       ( s4_axi_bresp       ),
+        .s_axi_bvalid      ( s4_axi_bvalid      ),
+        .s_axi_bready      ( s4_axi_bready      ),
+        .s_axi_arid        ( s4_axi_arid        ),
+        .s_axi_araddr      ( s4_axi_araddr_i    ),
+        .s_axi_arlen       ( s4_axi_arlen       ),
+        .s_axi_arsize      ( s4_axi_arsize      ),
+        .s_axi_arburst     ( s4_axi_arburst     ),
+        .s_axi_arlock      ( s4_axi_arlock      ),
+        .s_axi_arcache     ( s4_axi_arcache     ),
+        .s_axi_arprot      ( s4_axi_arprot      ),
+        .s_axi_arqos       ( s4_axi_arqos       ),
+        .s_axi_arvalid     ( s4_axi_arvalid     ),
+        .s_axi_arready     ( s4_axi_arready     ),
+        .s_axi_rid         ( s4_axi_rid         ),
+        .s_axi_rdata       ( s4_axi_rdata       ),
+        .s_axi_rresp       ( s4_axi_rresp       ),
+        .s_axi_rlast       ( s4_axi_rlast       ),
+        .s_axi_rvalid      ( s4_axi_rvalid      ),
+        .s_axi_rready      ( s4_axi_rready      ),
+        .mcb_cmd_clk       ( p4_cmd_clk_i       ),
+        .mcb_cmd_en        ( p4_cmd_en_i        ),
+        .mcb_cmd_instr     ( p4_cmd_instr_i     ),
+        .mcb_cmd_bl        ( p4_cmd_bl_i        ),
+        .mcb_cmd_byte_addr ( p4_cmd_byte_addr_i ),
+        .mcb_cmd_empty     ( p4_cmd_empty_i     ),
+        .mcb_cmd_full      ( p4_cmd_full_i      ),
+        .mcb_wr_clk        ( p4_wr_clk_i        ),
+        .mcb_wr_en         ( p4_wr_en_i         ),
+        .mcb_wr_mask       ( p4_wr_mask_i       ),
+        .mcb_wr_data       ( p4_wr_data_i       ),
+        .mcb_wr_full       ( p4_wr_full_i       ),
+        .mcb_wr_empty      ( p4_wr_empty_i      ),
+        .mcb_wr_count      ( p4_wr_count_i      ),
+        .mcb_wr_underrun   ( p4_wr_underrun_i   ),
+        .mcb_wr_error      ( p4_wr_error_i      ),
+        .mcb_rd_clk        ( p4_rd_clk_i        ),
+        .mcb_rd_en         ( p4_rd_en_i         ),
+        .mcb_rd_data       ( p4_rd_data_i       ),
+        .mcb_rd_full       ( p4_rd_full_i       ),
+        .mcb_rd_empty      ( p4_rd_empty_i      ),
+        .mcb_rd_count      ( p4_rd_count_i      ),
+        .mcb_rd_overflow   ( p4_rd_overflow_i   ),
+        .mcb_rd_error      ( p4_rd_error_i      ),
+        .mcb_calib_done    ( calib_done_synch   )
+        );
+ */
+    end
+  endgenerate
+
+// P5 AXI Bridge Mux
+  generate
+    if (C_S5_AXI_ENABLE == 0) begin : P5_UI_MCB
+      assign  p5_arb_en_i        =  p5_arb_en        ; //
+      assign  p5_cmd_clk_i       =  p5_cmd_clk       ; //
+      assign  p5_cmd_en_i        =  p5_cmd_en        ; //
+      assign  p5_cmd_instr_i     =  p5_cmd_instr     ; // [2:0]
+      assign  p5_cmd_bl_i        =  p5_cmd_bl        ; // [5:0]
+      assign  p5_cmd_byte_addr_i =  p5_cmd_byte_addr ; // [29:0]
+      assign  p5_cmd_empty       =  p5_cmd_empty_i   ; //
+      assign  p5_cmd_full        =  p5_cmd_full_i    ; //
+      assign  p5_wr_clk_i        =  p5_wr_clk        ; //
+      assign  p5_wr_en_i         =  p5_wr_en         ; //
+      assign  p5_wr_mask_i       =  p5_wr_mask       ; // [3:0]
+      assign  p5_wr_data_i       =  p5_wr_data       ; // [31:0]
+      assign  p5_wr_full         =  p5_wr_full_i     ; //
+      assign  p5_wr_empty        =  p5_wr_empty_i    ; //
+      assign  p5_wr_count        =  p5_wr_count_i    ; // [6:0]
+      assign  p5_wr_underrun     =  p5_wr_underrun_i ; //
+      assign  p5_wr_error        =  p5_wr_error_i    ; //
+      assign  p5_rd_clk_i        =  p5_rd_clk        ; //
+      assign  p5_rd_en_i         =  p5_rd_en         ; //
+      assign  p5_rd_data         =  p5_rd_data_i     ; // [31:0]
+      assign  p5_rd_full         =  p5_rd_full_i     ; //
+      assign  p5_rd_empty        =  p5_rd_empty_i    ; //
+      assign  p5_rd_count        =  p5_rd_count_i    ; // [6:0]
+      assign  p5_rd_overflow     =  p5_rd_overflow_i ; //
+      assign  p5_rd_error        =  p5_rd_error_i    ; //
+    end
+    else begin : P5_UI_AXI
+      assign  p5_arb_en_i        =  p5_arb_en;
+      assign  s5_axi_araddr_i    = s5_axi_araddr & P_S5_AXI_ADDRMASK;
+      assign  s5_axi_awaddr_i    = s5_axi_awaddr & P_S5_AXI_ADDRMASK;
+      wire                     calib_done_synch;
+/*
+      mcb_ui_top_synch #(
+        .C_SYNCH_WIDTH          ( 1 )
+      )
+      axi_mcb_synch
+      (
+        .clk                    ( s5_axi_aclk      ),
+        .synch_in               ( uo_done_cal      ),
+        .synch_out              ( calib_done_synch )
+      );
+
+      axi_mcb #
+        (
+        .C_FAMILY                ( "spartan6"               ) ,
+        .C_S_AXI_ID_WIDTH        ( C_S5_AXI_ID_WIDTH        ) ,
+        .C_S_AXI_ADDR_WIDTH      ( C_S5_AXI_ADDR_WIDTH      ) ,
+        .C_S_AXI_DATA_WIDTH      ( 32                       ) ,
+        .C_S_AXI_SUPPORTS_READ   ( C_S5_AXI_SUPPORTS_READ   ) ,
+        .C_S_AXI_SUPPORTS_WRITE  ( C_S5_AXI_SUPPORTS_WRITE  ) ,
+        .C_S_AXI_REG_EN0         ( C_S5_AXI_REG_EN0         ) ,
+        .C_S_AXI_REG_EN1         ( C_S5_AXI_REG_EN1         ) ,
+        .C_S_AXI_SUPPORTS_NARROW_BURST ( C_S5_AXI_SUPPORTS_NARROW_BURST ) ,
+        .C_MCB_ADDR_WIDTH        ( 30                       ) ,
+        .C_MCB_DATA_WIDTH        ( 32                       ) ,
+        .C_STRICT_COHERENCY      ( C_S5_AXI_STRICT_COHERENCY    ) ,
+        .C_ENABLE_AP             ( C_S5_AXI_ENABLE_AP           )
+        )
+        p5_axi_mcb
+        (
+        .aclk              ( s5_axi_aclk        ),
+        .aresetn           ( s5_axi_aresetn     ),
+        .s_axi_awid        ( s5_axi_awid        ),
+        .s_axi_awaddr      ( s5_axi_awaddr_i    ),
+        .s_axi_awlen       ( s5_axi_awlen       ),
+        .s_axi_awsize      ( s5_axi_awsize      ),
+        .s_axi_awburst     ( s5_axi_awburst     ),
+        .s_axi_awlock      ( s5_axi_awlock      ),
+        .s_axi_awcache     ( s5_axi_awcache     ),
+        .s_axi_awprot      ( s5_axi_awprot      ),
+        .s_axi_awqos       ( s5_axi_awqos       ),
+        .s_axi_awvalid     ( s5_axi_awvalid     ),
+        .s_axi_awready     ( s5_axi_awready     ),
+        .s_axi_wdata       ( s5_axi_wdata       ),
+        .s_axi_wstrb       ( s5_axi_wstrb       ),
+        .s_axi_wlast       ( s5_axi_wlast       ),
+        .s_axi_wvalid      ( s5_axi_wvalid      ),
+        .s_axi_wready      ( s5_axi_wready      ),
+        .s_axi_bid         ( s5_axi_bid         ),
+        .s_axi_bresp       ( s5_axi_bresp       ),
+        .s_axi_bvalid      ( s5_axi_bvalid      ),
+        .s_axi_bready      ( s5_axi_bready      ),
+        .s_axi_arid        ( s5_axi_arid        ),
+        .s_axi_araddr      ( s5_axi_araddr_i    ),
+        .s_axi_arlen       ( s5_axi_arlen       ),
+        .s_axi_arsize      ( s5_axi_arsize      ),
+        .s_axi_arburst     ( s5_axi_arburst     ),
+        .s_axi_arlock      ( s5_axi_arlock      ),
+        .s_axi_arcache     ( s5_axi_arcache     ),
+        .s_axi_arprot      ( s5_axi_arprot      ),
+        .s_axi_arqos       ( s5_axi_arqos       ),
+        .s_axi_arvalid     ( s5_axi_arvalid     ),
+        .s_axi_arready     ( s5_axi_arready     ),
+        .s_axi_rid         ( s5_axi_rid         ),
+        .s_axi_rdata       ( s5_axi_rdata       ),
+        .s_axi_rresp       ( s5_axi_rresp       ),
+        .s_axi_rlast       ( s5_axi_rlast       ),
+        .s_axi_rvalid      ( s5_axi_rvalid      ),
+        .s_axi_rready      ( s5_axi_rready      ),
+        .mcb_cmd_clk       ( p5_cmd_clk_i       ),
+        .mcb_cmd_en        ( p5_cmd_en_i        ),
+        .mcb_cmd_instr     ( p5_cmd_instr_i     ),
+        .mcb_cmd_bl        ( p5_cmd_bl_i        ),
+        .mcb_cmd_byte_addr ( p5_cmd_byte_addr_i ),
+        .mcb_cmd_empty     ( p5_cmd_empty_i     ),
+        .mcb_cmd_full      ( p5_cmd_full_i      ),
+        .mcb_wr_clk        ( p5_wr_clk_i        ),
+        .mcb_wr_en         ( p5_wr_en_i         ),
+        .mcb_wr_mask       ( p5_wr_mask_i       ),
+        .mcb_wr_data       ( p5_wr_data_i       ),
+        .mcb_wr_full       ( p5_wr_full_i       ),
+        .mcb_wr_empty      ( p5_wr_empty_i      ),
+        .mcb_wr_count      ( p5_wr_count_i      ),
+        .mcb_wr_underrun   ( p5_wr_underrun_i   ),
+        .mcb_wr_error      ( p5_wr_error_i      ),
+        .mcb_rd_clk        ( p5_rd_clk_i        ),
+        .mcb_rd_en         ( p5_rd_en_i         ),
+        .mcb_rd_data       ( p5_rd_data_i       ),
+        .mcb_rd_full       ( p5_rd_full_i       ),
+        .mcb_rd_empty      ( p5_rd_empty_i      ),
+        .mcb_rd_count      ( p5_rd_count_i      ),
+        .mcb_rd_overflow   ( p5_rd_overflow_i   ),
+        .mcb_rd_error      ( p5_rd_error_i      ),
+        .mcb_calib_done    ( calib_done_synch   )
+        );
+ */
+    end
+  endgenerate
+
+endmodule
+

--- a/systems/atlys/rtl/verilog/xilinx_ddr2/memc_wrapper.v
+++ b/systems/atlys/rtl/verilog/xilinx_ddr2/memc_wrapper.v
@@ -1,0 +1,1239 @@
+//*****************************************************************************
+// (c) Copyright 2009-10 Xilinx, Inc. All rights reserved.
+//
+// This file contains confidential and proprietary information
+// of Xilinx, Inc. and is protected under U.S. and
+// international copyright and other intellectual property
+// laws.
+//
+// DISCLAIMER
+// This disclaimer is not a license and does not grant any
+// rights to the materials distributed herewith. Except as
+// otherwise provided in a valid license issued to you by
+// Xilinx, and to the maximum extent permitted by applicable
+// law: (1) THESE MATERIALS ARE MADE AVAILABLE "AS IS" AND
+// WITH ALL FAULTS, AND XILINX HEREBY DISCLAIMS ALL WARRANTIES
+// AND CONDITIONS, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING
+// BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, NON-
+// INFRINGEMENT, OR FITNESS FOR ANY PARTICULAR PURPOSE; and
+// (2) Xilinx shall not be liable (whether in contract or tort,
+// including negligence, or under any other theory of
+// liability) for any loss or damage of any kind or nature
+// related to, arising under or in connection with these
+// materials, including for any direct, or any indirect,
+// special, incidental, or consequential loss or damage
+// (including loss of data, profits, goodwill, or any type of
+// loss or damage suffered as a result of any action brought
+// by a third party) even if such damage or loss was
+// reasonably foreseeable or Xilinx had been advised of the
+// possibility of the same.
+//
+// CRITICAL APPLICATIONS
+// Xilinx products are not designed or intended to be fail-
+// safe, or for use in any application requiring fail-safe
+// performance, such as life-support or safety devices or
+// systems, Class III medical devices, nuclear facilities,
+// applications related to the deployment of airbags, or any
+// other applications that could lead to death, personal
+// injury, or severe property or environmental damage
+// (individually and collectively, "Critical
+// Applications"). Customer assumes the sole risk and
+// liability of any use of Xilinx products in Critical
+// Applications, subject only to applicable laws and
+// regulations governing limitations on product liability.
+//
+// THIS COPYRIGHT NOTICE AND DISCLAIMER MUST BE RETAINED AS
+// PART OF THIS FILE AT ALL TIMES.
+//
+//*****************************************************************************
+//   ____  ____
+//  /   /\/   /
+// /___/  \  /    Vendor             : Xilinx
+// \   \   \/     Application        : MIG             
+//  \   \         Filename           : memc_wrapper.v
+//  /   /         Date Last Modified : $Date: 2010/08/
+// /___/   /\     Date Created       : Mon Mar 2 2009
+// \   \  /  \    
+//  \___\/\___\
+//
+//Device           : Spartan-6
+//Design Name      : DDR/DDR2/DDR3/LPDDR 
+//Purpose          : This is a static top level module instantiating the mcb_ui_top,
+//                   which provides interface to all the standard as well as AXI ports.
+//                   This module memc_wrapper provides interface to only the standard ports.
+//Reference        :
+//Revision History :
+//*****************************************************************************
+`timescale 1ns/1ps
+
+module memc_wrapper  #
+  (
+   parameter         C_MEMCLK_PERIOD           = 2500,
+   parameter         C_P0_MASK_SIZE            = 4,
+   parameter         C_P0_DATA_PORT_SIZE       = 32,
+   parameter         C_P1_MASK_SIZE            = 4,
+   parameter         C_P1_DATA_PORT_SIZE       = 32,
+
+   parameter         C_PORT_ENABLE             = 6'b111111,
+   parameter         C_PORT_CONFIG             = "B128",
+   parameter         C_MEM_ADDR_ORDER          = "BANK_ROW_COLUMN",
+   // The following parameter reflects the GUI selection of the Arbitration algorithm.
+   // Zero value corresponds to round robin algorithm and one to custom selection.
+   // The parameter is used to calculate the arbitration time slot parameters.                           
+   parameter         C_ARB_ALGORITHM           = 0,    								   					   
+   parameter         C_ARB_NUM_TIME_SLOTS      = 12,
+   parameter         C_ARB_TIME_SLOT_0         = 18'o012345,
+   parameter         C_ARB_TIME_SLOT_1         = 18'o123450,
+   parameter         C_ARB_TIME_SLOT_2         = 18'o234501,
+   parameter         C_ARB_TIME_SLOT_3         = 18'o345012,
+   parameter         C_ARB_TIME_SLOT_4         = 18'o450123,
+   parameter         C_ARB_TIME_SLOT_5         = 18'o501234,
+   parameter         C_ARB_TIME_SLOT_6         = 18'o012345,
+   parameter         C_ARB_TIME_SLOT_7         = 18'o123450,
+   parameter         C_ARB_TIME_SLOT_8         = 18'o234501,
+   parameter         C_ARB_TIME_SLOT_9         = 18'o345012,
+   parameter         C_ARB_TIME_SLOT_10        = 18'o450123,
+   parameter         C_ARB_TIME_SLOT_11        = 18'o501234,
+   parameter         C_MEM_TRAS                = 45000,
+   parameter         C_MEM_TRCD                = 12500,
+   parameter         C_MEM_TREFI               = 7800,
+   parameter         C_MEM_TRFC                = 127500,
+   parameter         C_MEM_TRP                 = 12500,
+   parameter         C_MEM_TWR                 = 15000,
+   parameter         C_MEM_TRTP                = 7500,
+   parameter         C_MEM_TWTR                = 7500,
+   parameter         C_NUM_DQ_PINS             = 8,
+   parameter         C_MEM_TYPE                = "DDR3",
+   parameter         C_MEM_DENSITY             = "512M",
+   parameter         C_MEM_BURST_LEN           = 8,
+   parameter         C_MEM_CAS_LATENCY         = 4,
+   parameter         C_MEM_ADDR_WIDTH          = 13,
+   parameter         C_MEM_BANKADDR_WIDTH      = 3,
+   parameter         C_MEM_NUM_COL_BITS        = 11,
+   parameter         C_MEM_DDR3_CAS_LATENCY    = 7,
+   parameter         C_MEM_MOBILE_PA_SR        = "FULL",
+   parameter         C_MEM_DDR1_2_ODS          = "FULL",
+   parameter         C_MEM_DDR3_ODS            = "DIV6",
+   parameter         C_MEM_DDR2_RTT            = "50OHMS",
+   parameter         C_MEM_DDR3_RTT            = "DIV2",
+   parameter         C_MEM_MDDR_ODS            = "FULL",
+   parameter         C_MEM_DDR2_DIFF_DQS_EN    = "YES",
+   parameter         C_MEM_DDR2_3_PA_SR        = "OFF",
+   parameter         C_MEM_DDR3_CAS_WR_LATENCY = 5,
+   parameter         C_MEM_DDR3_AUTO_SR        = "ENABLED",
+   parameter         C_MEM_DDR2_3_HIGH_TEMP_SR = "NORMAL",
+   parameter         C_MEM_DDR3_DYN_WRT_ODT    = "OFF",
+   parameter         C_MC_CALIB_BYPASS         = "NO",
+
+   parameter         LDQSP_TAP_DELAY_VAL       = 0,
+   parameter         UDQSP_TAP_DELAY_VAL       = 0,
+   parameter         LDQSN_TAP_DELAY_VAL       = 0,
+   parameter         UDQSN_TAP_DELAY_VAL       = 0,
+   parameter         DQ0_TAP_DELAY_VAL         = 0,
+   parameter         DQ1_TAP_DELAY_VAL         = 0,
+   parameter         DQ2_TAP_DELAY_VAL         = 0,
+   parameter         DQ3_TAP_DELAY_VAL         = 0,
+   parameter         DQ4_TAP_DELAY_VAL         = 0,
+   parameter         DQ5_TAP_DELAY_VAL         = 0,
+   parameter         DQ6_TAP_DELAY_VAL         = 0,
+   parameter         DQ7_TAP_DELAY_VAL         = 0,
+   parameter         DQ8_TAP_DELAY_VAL         = 0,
+   parameter         DQ9_TAP_DELAY_VAL         = 0,
+   parameter         DQ10_TAP_DELAY_VAL        = 0,
+   parameter         DQ11_TAP_DELAY_VAL        = 0,
+   parameter         DQ12_TAP_DELAY_VAL        = 0,
+   parameter         DQ13_TAP_DELAY_VAL        = 0,
+   parameter         DQ14_TAP_DELAY_VAL        = 0,
+   parameter         DQ15_TAP_DELAY_VAL        = 0,
+
+   parameter         C_CALIB_SOFT_IP           = "TRUE",
+   parameter         C_SIMULATION              = "FALSE",
+   parameter         C_SKIP_IN_TERM_CAL        = 1'b0,
+   parameter         C_SKIP_DYNAMIC_CAL        = 1'b0,
+   parameter         C_MC_CALIBRATION_MODE     = "CALIBRATION",
+   parameter         C_MC_CALIBRATION_DELAY    = "HALF"
+
+  )
+
+  (
+
+   // Raw Wrapper Signals
+   input                                     sysclk_2x,          
+   input                                     sysclk_2x_180, 
+   input                                     pll_ce_0,
+   input                                     pll_ce_90, 
+   input                                     pll_lock,
+   input                                     async_rst,
+   input                                     mcb_drp_clk,       
+   output      [C_MEM_ADDR_WIDTH-1:0]        mcbx_dram_addr,  
+   output      [C_MEM_BANKADDR_WIDTH-1:0]    mcbx_dram_ba,
+   output                                    mcbx_dram_ras_n,       
+   output                                    mcbx_dram_cas_n,       
+   output                                    mcbx_dram_we_n,  
+   output                                    mcbx_dram_cke, 
+   output                                    mcbx_dram_clk, 
+   output                                    mcbx_dram_clk_n,       
+   inout       [C_NUM_DQ_PINS-1:0]           mcbx_dram_dq,
+   inout                                     mcbx_dram_dqs, 
+   inout                                     mcbx_dram_dqs_n,       
+   inout                                     mcbx_dram_udqs,  
+   inout                                     mcbx_dram_udqs_n,       
+   output                                    mcbx_dram_udm, 
+   output                                    mcbx_dram_ldm, 
+   output                                    mcbx_dram_odt, 
+   output                                    mcbx_dram_ddr3_rst,      
+   inout                                     mcbx_rzq,
+   inout                                     mcbx_zio,
+   output                                    calib_done,
+   input                                     selfrefresh_enter,       
+   output                                    selfrefresh_mode,
+
+// This new memc_wrapper shows all the six logical static user ports. The port
+// configuration parameter and the port enable parameter are the ones that 
+// determine the active and non-active ports. The following list shows the 
+// default active ports for each port configuration.
+//
+// Config 1: "B32_B32_X32_X32_X32_X32"
+//            User port 0  --> 32 bit,  User port 1  --> 32 bit 
+//            User port 2  --> 32 bit,  User port 3  --> 32 bit
+//            User port 4  --> 32 bit,  User port 5  --> 32 bit
+// Config 2: "B32_B32_B32_B32"  
+//            User port 0  --> 32 bit 
+//            User port 1  --> 32 bit 
+//            User port 2  --> 32 bit 
+//            User port 3  --> 32 bit 
+// Config 3: "B64_B32_B3"  
+//            User port 0  --> 64 bit 
+//            User port 1  --> 32 bit 
+//            User port 2  --> 32 bit 
+// Config 4: "B64_B64"          
+//            User port 0  --> 64 bit 
+//            User port 1  --> 64 bit
+// Config 5  "B128"          
+//            User port 0  --> 128 bit
+
+
+   // User Port-0 command interface will be active only when the port is enabled in 
+   // the port configurations Config-1, Config-2, Config-3, Config-4 and Config-5
+   input                                     p0_cmd_clk, 
+   input                                     p0_cmd_en, 
+   input       [2:0]                         p0_cmd_instr,
+   input       [5:0]                         p0_cmd_bl, 
+   input       [29:0]                        p0_cmd_byte_addr,       
+   output                                    p0_cmd_full,
+   output                                    p0_cmd_empty,
+   // User Port-0 data write interface will be active only when the port is enabled in
+   // the port configurations Config-1, Config-2, Config-3, Config-4 and Config-5
+   input                                     p0_wr_clk,       
+   input                                     p0_wr_en,
+   input       [C_P0_MASK_SIZE-1:0]          p0_wr_mask,
+   input       [C_P0_DATA_PORT_SIZE-1:0]     p0_wr_data,
+   output                                    p0_wr_full,
+   output      [6:0]                         p0_wr_count,
+   output                                    p0_wr_empty,
+   output                                    p0_wr_underrun,  
+   output                                    p0_wr_error,
+   // User Port-0 data read interface will be active only when the port is enabled in
+   // the port configurations Config-1, Config-2, Config-3, Config-4 and Config-5
+   input                                     p0_rd_clk,
+   input                                     p0_rd_en,
+   output      [C_P0_DATA_PORT_SIZE-1:0]     p0_rd_data,
+   output                                    p0_rd_empty,
+   output      [6:0]                         p0_rd_count,
+   output                                    p0_rd_full,
+   output                                    p0_rd_overflow,  
+   output                                    p0_rd_error,
+
+   // User Port-1 command interface will be active only when the port is enabled in 
+   // the port configurations Config-1, Config-2, Config-3 and Config-4
+   input                                     p1_cmd_clk, 
+   input                                     p1_cmd_en, 
+   input       [2:0]                         p1_cmd_instr,
+   input       [5:0]                         p1_cmd_bl, 
+   input       [29:0]                        p1_cmd_byte_addr,       
+   output                                    p1_cmd_full,
+   output                                    p1_cmd_empty,
+   // User Port-1 data write interface will be active only when the port is enabled in 
+   // the port configurations Config-1, Config-2, Config-3 and Config-4
+   input                                     p1_wr_clk,       
+   input                                     p1_wr_en,
+   input       [C_P1_MASK_SIZE-1:0]          p1_wr_mask,
+   input       [C_P1_DATA_PORT_SIZE-1:0]     p1_wr_data,
+   output                                    p1_wr_full,
+   output      [6:0]                         p1_wr_count,
+   output                                    p1_wr_empty,
+   output                                    p1_wr_underrun,  
+   output                                    p1_wr_error,
+   // User Port-1 data read interface will be active only when the port is enabled in 
+   // the port configurations Config-1, Config-2, Config-3 and Config-4
+   input                                     p1_rd_clk,
+   input                                     p1_rd_en,
+   output      [C_P1_DATA_PORT_SIZE-1:0]     p1_rd_data,
+   output                                    p1_rd_empty,
+   output      [6:0]                         p1_rd_count,
+   output                                    p1_rd_full,
+   output                                    p1_rd_overflow,  
+   output                                    p1_rd_error,
+
+   // User Port-2 command interface will be active only when the port is enabled in 
+   // the port configurations Config-1, Config-2 and Config-3
+   input                                     p2_cmd_clk, 
+   input                                     p2_cmd_en, 
+   input       [2:0]                         p2_cmd_instr,
+   input       [5:0]                         p2_cmd_bl, 
+   input       [29:0]                        p2_cmd_byte_addr,       
+   output                                    p2_cmd_full,
+   output                                    p2_cmd_empty,
+   // User Port-2 data write interface will be active only when the port is enabled in 
+   // the port configurations Config-1 write direction, Config-2 and Config-3
+   input                                     p2_wr_clk,       
+   input                                     p2_wr_en,
+   input       [3:0]                         p2_wr_mask,
+   input       [31:0]                        p2_wr_data,
+   output                                    p2_wr_full,
+   output      [6:0]                         p2_wr_count,
+   output                                    p2_wr_empty,
+   output                                    p2_wr_underrun,  
+   output                                    p2_wr_error,
+   // User Port-2 data read interface will be active only when the port is enabled in 
+   // the port configurations Config-1 read direction, Config-2 and Config-3
+   input                                     p2_rd_clk,
+   input                                     p2_rd_en,
+   output      [31:0]                        p2_rd_data,
+   output                                    p2_rd_empty,
+   output      [6:0]                         p2_rd_count,
+   output                                    p2_rd_full,
+   output                                    p2_rd_overflow,  
+   output                                    p2_rd_error,
+
+   // User Port-3 command interface will be active only when the port is enabled in 
+   // the port configurations Config-1 and Config-2
+   input                                     p3_cmd_clk, 
+   input                                     p3_cmd_en, 
+   input       [2:0]                         p3_cmd_instr,
+   input       [5:0]                         p3_cmd_bl, 
+   input       [29:0]                        p3_cmd_byte_addr,       
+   output                                    p3_cmd_full,
+   output                                    p3_cmd_empty,
+   // User Port-3 data write interface will be active only when the port is enabled in 
+   // the port configurations Config-1 write direction and Config-2
+   input                                     p3_wr_clk,       
+   input                                     p3_wr_en,
+   input       [3:0]                         p3_wr_mask,
+   input       [31:0]                        p3_wr_data,
+   output                                    p3_wr_full,
+   output      [6:0]                         p3_wr_count,
+   output                                    p3_wr_empty,
+   output                                    p3_wr_underrun,  
+   output                                    p3_wr_error,
+   // User Port-3 data read interface will be active only when the port is enabled in 
+   // the port configurations Config-1 read direction and Config-2
+   input                                     p3_rd_clk,
+   input                                     p3_rd_en,
+   output      [31:0]                        p3_rd_data,
+   output                                    p3_rd_empty,
+   output      [6:0]                         p3_rd_count,
+   output                                    p3_rd_full,
+   output                                    p3_rd_overflow,  
+   output                                    p3_rd_error,
+
+   // User Port-4 command interface will be active only when the port is enabled in 
+   // the port configuration Config-1
+   input                                     p4_cmd_clk, 
+   input                                     p4_cmd_en, 
+   input       [2:0]                         p4_cmd_instr,
+   input       [5:0]                         p4_cmd_bl, 
+   input       [29:0]                        p4_cmd_byte_addr,       
+   output                                    p4_cmd_full,
+   output                                    p4_cmd_empty,
+   // User Port-4 data write interface will be active only when the port is enabled in 
+   // the port configuration Config-1 write direction
+   input                                     p4_wr_clk,       
+   input                                     p4_wr_en,
+   input       [3:0]                         p4_wr_mask,
+   input       [31:0]                        p4_wr_data,
+   output                                    p4_wr_full,
+   output      [6:0]                         p4_wr_count,
+   output                                    p4_wr_empty,
+   output                                    p4_wr_underrun,  
+   output                                    p4_wr_error,
+   // User Port-4 data read interface will be active only when the port is enabled in 
+   // the port configuration Config-1 read direction
+   input                                     p4_rd_clk,
+   input                                     p4_rd_en,
+   output      [31:0]                        p4_rd_data,
+   output                                    p4_rd_empty,
+   output      [6:0]                         p4_rd_count,
+   output                                    p4_rd_full,
+   output                                    p4_rd_overflow,  
+   output                                    p4_rd_error,
+   // User Port-5 command interface will be active only when the port is enabled in 
+   // the port configuration Config-1
+   input                                     p5_cmd_clk, 
+   input                                     p5_cmd_en, 
+   input       [2:0]                         p5_cmd_instr,
+   input       [5:0]                         p5_cmd_bl, 
+   input       [29:0]                        p5_cmd_byte_addr,       
+   output                                    p5_cmd_full,
+   output                                    p5_cmd_empty,
+   // User Port-5 data write interface will be active only when the port is enabled in 
+   // the port configuration Config-1 write direction
+   input                                     p5_wr_clk,       
+   input                                     p5_wr_en,
+   input       [3:0]                         p5_wr_mask,
+   input       [31:0]                        p5_wr_data,
+   output                                    p5_wr_full,
+   output      [6:0]                         p5_wr_count,
+   output                                    p5_wr_empty,
+   output                                    p5_wr_underrun,  
+   output                                    p5_wr_error,
+   // User Port-5 data read interface will be active only when the port is enabled in 
+   // the port configuration Config-1 read direction
+   input                                     p5_rd_clk,
+   input                                     p5_rd_en,
+   output      [31:0]                        p5_rd_data,
+   output                                    p5_rd_empty,
+   output      [6:0]                         p5_rd_count,
+   output                                    p5_rd_full,
+   output                                    p5_rd_overflow,  
+   output                                    p5_rd_error
+
+  );
+  
+   localparam C_MC_CALIBRATION_CLK_DIV  = 1;
+   localparam C_MEM_TZQINIT_MAXCNT      = 10'd512 + 10'd16;   // 16 clock cycles are added to avoid trfc violations
+   localparam C_SKIP_DYN_IN_TERM        = 1'b1;
+
+   localparam C_MC_CALIBRATION_RA       = 16'h0000;       
+   localparam C_MC_CALIBRATION_BA       = 3'h0;       
+   localparam C_MC_CALIBRATION_CA       = 12'h000;       
+
+// All the following new localparams and signals are added to support 
+// the AXI slave interface. They have no function to play in a standard
+// interface design and can be ignored. 
+   localparam C_S0_AXI_ID_WIDTH         = 4;
+   localparam C_S0_AXI_ADDR_WIDTH       = 64;
+   localparam C_S0_AXI_DATA_WIDTH       = 32;
+   localparam C_S1_AXI_ID_WIDTH         = 4;
+   localparam C_S1_AXI_ADDR_WIDTH       = 64;
+   localparam C_S1_AXI_DATA_WIDTH       = 32;
+   localparam C_S2_AXI_ID_WIDTH         = 4;
+   localparam C_S2_AXI_ADDR_WIDTH       = 64;
+   localparam C_S2_AXI_DATA_WIDTH       = 32;
+   localparam C_S3_AXI_ID_WIDTH         = 4;
+   localparam C_S3_AXI_ADDR_WIDTH       = 64;
+   localparam C_S3_AXI_DATA_WIDTH       = 32;
+   localparam C_S4_AXI_ID_WIDTH         = 4;
+   localparam C_S4_AXI_ADDR_WIDTH       = 64;
+   localparam C_S4_AXI_DATA_WIDTH       = 32;
+   localparam C_S5_AXI_ID_WIDTH         = 4;
+   localparam C_S5_AXI_ADDR_WIDTH       = 64;
+   localparam C_S5_AXI_DATA_WIDTH       = 32;
+   localparam C_MCB_USE_EXTERNAL_BUFPLL = 1;
+
+// AXI wire declarations
+// AXI interface of the mcb_ui_top module is connected to the following
+// floating wires in all the standard interface designs.
+   wire                                      s0_axi_aclk;
+   wire                                      s0_axi_aresetn;
+   wire [C_S0_AXI_ID_WIDTH-1:0]              s0_axi_awid; 
+   wire [C_S0_AXI_ADDR_WIDTH-1:0]            s0_axi_awaddr; 
+   wire [7:0]                                s0_axi_awlen; 
+   wire [2:0]                                s0_axi_awsize; 
+   wire [1:0]                                s0_axi_awburst; 
+   wire [0:0]                                s0_axi_awlock; 
+   wire [3:0]                                s0_axi_awcache; 
+   wire [2:0]                                s0_axi_awprot; 
+   wire [3:0]                                s0_axi_awqos; 
+   wire                                      s0_axi_awvalid; 
+   wire                                      s0_axi_awready; 
+   wire [C_S0_AXI_DATA_WIDTH-1:0]            s0_axi_wdata; 
+   wire [C_S0_AXI_DATA_WIDTH/8-1:0]          s0_axi_wstrb; 
+   wire                                      s0_axi_wlast; 
+   wire                                      s0_axi_wvalid; 
+   wire                                      s0_axi_wready; 
+   wire [C_S0_AXI_ID_WIDTH-1:0]              s0_axi_bid; 
+   wire [1:0]                                s0_axi_bresp; 
+   wire                                      s0_axi_bvalid; 
+   wire                                      s0_axi_bready; 
+   wire [C_S0_AXI_ID_WIDTH-1:0]              s0_axi_arid; 
+   wire [C_S0_AXI_ADDR_WIDTH-1:0]            s0_axi_araddr; 
+   wire [7:0]                                s0_axi_arlen; 
+   wire [2:0]                                s0_axi_arsize; 
+   wire [1:0]                                s0_axi_arburst; 
+   wire [0:0]                                s0_axi_arlock; 
+   wire [3:0]                                s0_axi_arcache; 
+   wire [2:0]                                s0_axi_arprot; 
+   wire [3:0]                                s0_axi_arqos; 
+   wire                                      s0_axi_arvalid; 
+   wire                                      s0_axi_arready; 
+   wire [C_S0_AXI_ID_WIDTH-1:0]              s0_axi_rid; 
+   wire [C_S0_AXI_DATA_WIDTH-1:0]            s0_axi_rdata; 
+   wire [1:0]                                s0_axi_rresp; 
+   wire                                      s0_axi_rlast; 
+   wire                                      s0_axi_rvalid; 
+   wire                                      s0_axi_rready;
+
+   wire                                      s1_axi_aclk;
+   wire                                      s1_axi_aresetn;
+   wire [C_S1_AXI_ID_WIDTH-1:0]              s1_axi_awid; 
+   wire [C_S1_AXI_ADDR_WIDTH-1:0]            s1_axi_awaddr; 
+   wire [7:0]                                s1_axi_awlen; 
+   wire [2:0]                                s1_axi_awsize; 
+   wire [1:0]                                s1_axi_awburst; 
+   wire [0:0]                                s1_axi_awlock; 
+   wire [3:0]                                s1_axi_awcache; 
+   wire [2:0]                                s1_axi_awprot; 
+   wire [3:0]                                s1_axi_awqos; 
+   wire                                      s1_axi_awvalid; 
+   wire                                      s1_axi_awready; 
+   wire [C_S1_AXI_DATA_WIDTH-1:0]            s1_axi_wdata; 
+   wire [C_S1_AXI_DATA_WIDTH/8-1:0]          s1_axi_wstrb; 
+   wire                                      s1_axi_wlast; 
+   wire                                      s1_axi_wvalid; 
+   wire                                      s1_axi_wready; 
+   wire [C_S1_AXI_ID_WIDTH-1:0]              s1_axi_bid; 
+   wire [1:0]                                s1_axi_bresp; 
+   wire                                      s1_axi_bvalid; 
+   wire                                      s1_axi_bready; 
+   wire [C_S1_AXI_ID_WIDTH-1:0]              s1_axi_arid; 
+   wire [C_S1_AXI_ADDR_WIDTH-1:0]            s1_axi_araddr; 
+   wire [7:0]                                s1_axi_arlen; 
+   wire [2:0]                                s1_axi_arsize; 
+   wire [1:0]                                s1_axi_arburst; 
+   wire [0:0]                                s1_axi_arlock; 
+   wire [3:0]                                s1_axi_arcache; 
+   wire [2:0]                                s1_axi_arprot; 
+   wire [3:0]                                s1_axi_arqos; 
+   wire                                      s1_axi_arvalid; 
+   wire                                      s1_axi_arready; 
+   wire [C_S1_AXI_ID_WIDTH-1:0]              s1_axi_rid; 
+   wire [C_S1_AXI_DATA_WIDTH-1:0]            s1_axi_rdata; 
+   wire [1:0]                                s1_axi_rresp; 
+   wire                                      s1_axi_rlast; 
+   wire                                      s1_axi_rvalid; 
+   wire                                      s1_axi_rready;
+
+   wire                                      s2_axi_aclk;
+   wire                                      s2_axi_aresetn;
+   wire [C_S2_AXI_ID_WIDTH-1:0]              s2_axi_awid; 
+   wire [C_S2_AXI_ADDR_WIDTH-1:0]            s2_axi_awaddr; 
+   wire [7:0]                                s2_axi_awlen; 
+   wire [2:0]                                s2_axi_awsize; 
+   wire [1:0]                                s2_axi_awburst; 
+   wire [0:0]                                s2_axi_awlock; 
+   wire [3:0]                                s2_axi_awcache; 
+   wire [2:0]                                s2_axi_awprot; 
+   wire [3:0]                                s2_axi_awqos; 
+   wire                                      s2_axi_awvalid; 
+   wire                                      s2_axi_awready; 
+   wire [C_S2_AXI_DATA_WIDTH-1:0]            s2_axi_wdata; 
+   wire [C_S2_AXI_DATA_WIDTH/8-1:0]          s2_axi_wstrb; 
+   wire                                      s2_axi_wlast; 
+   wire                                      s2_axi_wvalid; 
+   wire                                      s2_axi_wready; 
+   wire [C_S2_AXI_ID_WIDTH-1:0]              s2_axi_bid; 
+   wire [1:0]                                s2_axi_bresp; 
+   wire                                      s2_axi_bvalid; 
+   wire                                      s2_axi_bready; 
+   wire [C_S2_AXI_ID_WIDTH-1:0]              s2_axi_arid; 
+   wire [C_S2_AXI_ADDR_WIDTH-1:0]            s2_axi_araddr; 
+   wire [7:0]                                s2_axi_arlen; 
+   wire [2:0]                                s2_axi_arsize; 
+   wire [1:0]                                s2_axi_arburst; 
+   wire [0:0]                                s2_axi_arlock; 
+   wire [3:0]                                s2_axi_arcache; 
+   wire [2:0]                                s2_axi_arprot; 
+   wire [3:0]                                s2_axi_arqos; 
+   wire                                      s2_axi_arvalid; 
+   wire                                      s2_axi_arready; 
+   wire [C_S2_AXI_ID_WIDTH-1:0]              s2_axi_rid; 
+   wire [C_S2_AXI_DATA_WIDTH-1:0]            s2_axi_rdata; 
+   wire [1:0]                                s2_axi_rresp; 
+   wire                                      s2_axi_rlast; 
+   wire                                      s2_axi_rvalid; 
+   wire                                      s2_axi_rready;
+
+   wire                                      s3_axi_aclk;
+   wire                                      s3_axi_aresetn;
+   wire [C_S3_AXI_ID_WIDTH-1:0]              s3_axi_awid; 
+   wire [C_S3_AXI_ADDR_WIDTH-1:0]            s3_axi_awaddr; 
+   wire [7:0]                                s3_axi_awlen; 
+   wire [2:0]                                s3_axi_awsize; 
+   wire [1:0]                                s3_axi_awburst; 
+   wire [0:0]                                s3_axi_awlock; 
+   wire [3:0]                                s3_axi_awcache; 
+   wire [2:0]                                s3_axi_awprot; 
+   wire [3:0]                                s3_axi_awqos; 
+   wire                                      s3_axi_awvalid; 
+   wire                                      s3_axi_awready; 
+   wire [C_S3_AXI_DATA_WIDTH-1:0]            s3_axi_wdata; 
+   wire [C_S3_AXI_DATA_WIDTH/8-1:0]          s3_axi_wstrb; 
+   wire                                      s3_axi_wlast; 
+   wire                                      s3_axi_wvalid; 
+   wire                                      s3_axi_wready; 
+   wire [C_S3_AXI_ID_WIDTH-1:0]              s3_axi_bid; 
+   wire [1:0]                                s3_axi_bresp; 
+   wire                                      s3_axi_bvalid; 
+   wire                                      s3_axi_bready; 
+   wire [C_S3_AXI_ID_WIDTH-1:0]              s3_axi_arid; 
+   wire [C_S3_AXI_ADDR_WIDTH-1:0]            s3_axi_araddr; 
+   wire [7:0]                                s3_axi_arlen; 
+   wire [2:0]                                s3_axi_arsize; 
+   wire [1:0]                                s3_axi_arburst; 
+   wire [0:0]                                s3_axi_arlock; 
+   wire [3:0]                                s3_axi_arcache; 
+   wire [2:0]                                s3_axi_arprot; 
+   wire [3:0]                                s3_axi_arqos; 
+   wire                                      s3_axi_arvalid; 
+   wire                                      s3_axi_arready; 
+   wire [C_S3_AXI_ID_WIDTH-1:0]              s3_axi_rid; 
+   wire [C_S3_AXI_DATA_WIDTH-1:0]            s3_axi_rdata; 
+   wire [1:0]                                s3_axi_rresp; 
+   wire                                      s3_axi_rlast; 
+   wire                                      s3_axi_rvalid; 
+   wire                                      s3_axi_rready;
+
+   wire                                      s4_axi_aclk;
+   wire                                      s4_axi_aresetn;
+   wire [C_S4_AXI_ID_WIDTH-1:0]              s4_axi_awid; 
+   wire [C_S4_AXI_ADDR_WIDTH-1:0]            s4_axi_awaddr; 
+   wire [7:0]                                s4_axi_awlen; 
+   wire [2:0]                                s4_axi_awsize; 
+   wire [1:0]                                s4_axi_awburst; 
+   wire [0:0]                                s4_axi_awlock; 
+   wire [3:0]                                s4_axi_awcache; 
+   wire [2:0]                                s4_axi_awprot; 
+   wire [3:0]                                s4_axi_awqos; 
+   wire                                      s4_axi_awvalid; 
+   wire                                      s4_axi_awready; 
+   wire [C_S4_AXI_DATA_WIDTH-1:0]            s4_axi_wdata; 
+   wire [C_S4_AXI_DATA_WIDTH/8-1:0]          s4_axi_wstrb; 
+   wire                                      s4_axi_wlast; 
+   wire                                      s4_axi_wvalid; 
+   wire                                      s4_axi_wready; 
+   wire [C_S4_AXI_ID_WIDTH-1:0]              s4_axi_bid; 
+   wire [1:0]                                s4_axi_bresp; 
+   wire                                      s4_axi_bvalid; 
+   wire                                      s4_axi_bready; 
+   wire [C_S4_AXI_ID_WIDTH-1:0]              s4_axi_arid; 
+   wire [C_S4_AXI_ADDR_WIDTH-1:0]            s4_axi_araddr; 
+   wire [7:0]                                s4_axi_arlen; 
+   wire [2:0]                                s4_axi_arsize; 
+   wire [1:0]                                s4_axi_arburst; 
+   wire [0:0]                                s4_axi_arlock; 
+   wire [3:0]                                s4_axi_arcache; 
+   wire [2:0]                                s4_axi_arprot; 
+   wire [3:0]                                s4_axi_arqos; 
+   wire                                      s4_axi_arvalid; 
+   wire                                      s4_axi_arready; 
+   wire [C_S4_AXI_ID_WIDTH-1:0]              s4_axi_rid; 
+   wire [C_S4_AXI_DATA_WIDTH-1:0]            s4_axi_rdata; 
+   wire [1:0]                                s4_axi_rresp; 
+   wire                                      s4_axi_rlast; 
+   wire                                      s4_axi_rvalid; 
+   wire                                      s4_axi_rready;
+
+   wire                                      s5_axi_aclk;
+   wire                                      s5_axi_aresetn;
+   wire [C_S5_AXI_ID_WIDTH-1:0]              s5_axi_awid; 
+   wire [C_S5_AXI_ADDR_WIDTH-1:0]            s5_axi_awaddr; 
+   wire [7:0]                                s5_axi_awlen; 
+   wire [2:0]                                s5_axi_awsize; 
+   wire [1:0]                                s5_axi_awburst; 
+   wire [0:0]                                s5_axi_awlock; 
+   wire [3:0]                                s5_axi_awcache; 
+   wire [2:0]                                s5_axi_awprot; 
+   wire [3:0]                                s5_axi_awqos; 
+   wire                                      s5_axi_awvalid; 
+   wire                                      s5_axi_awready; 
+   wire [C_S5_AXI_DATA_WIDTH-1:0]            s5_axi_wdata; 
+   wire [C_S5_AXI_DATA_WIDTH/8-1:0]          s5_axi_wstrb; 
+   wire                                      s5_axi_wlast; 
+   wire                                      s5_axi_wvalid; 
+   wire                                      s5_axi_wready; 
+   wire [C_S5_AXI_ID_WIDTH-1:0]              s5_axi_bid; 
+   wire [1:0]                                s5_axi_bresp; 
+   wire                                      s5_axi_bvalid; 
+   wire                                      s5_axi_bready; 
+   wire [C_S5_AXI_ID_WIDTH-1:0]              s5_axi_arid; 
+   wire [C_S5_AXI_ADDR_WIDTH-1:0]            s5_axi_araddr; 
+   wire [7:0]                                s5_axi_arlen; 
+   wire [2:0]                                s5_axi_arsize; 
+   wire [1:0]                                s5_axi_arburst; 
+   wire [0:0]                                s5_axi_arlock; 
+   wire [3:0]                                s5_axi_arcache; 
+   wire [2:0]                                s5_axi_arprot; 
+   wire [3:0]                                s5_axi_arqos; 
+   wire                                      s5_axi_arvalid; 
+   wire                                      s5_axi_arready; 
+   wire [C_S5_AXI_ID_WIDTH-1:0]              s5_axi_rid; 
+   wire [C_S5_AXI_DATA_WIDTH-1:0]            s5_axi_rdata; 
+   wire [1:0]                                s5_axi_rresp; 
+   wire                                      s5_axi_rlast; 
+   wire                                      s5_axi_rvalid; 
+   wire                                      s5_axi_rready;
+
+   wire [7:0]                                uo_data;        
+   wire                                      uo_data_valid;  
+   wire                                      uo_cmd_ready_in;
+   wire                                      uo_refrsh_flag; 
+   wire                                      uo_cal_start;   
+   wire                                      uo_sdo;
+   wire [31:0]                               status;  
+   wire                                      sysclk_2x_bufpll_o;
+   wire                                      sysclk_2x_180_bufpll_o;
+   wire                                      pll_ce_0_bufpll_o;
+   wire                                      pll_ce_90_bufpll_o;
+   wire                                      pll_lock_bufpll_o;
+
+
+// mcb_ui_top instantiation
+mcb_ui_top #
+  (
+   // Raw Wrapper Parameters
+   .C_MEMCLK_PERIOD               (C_MEMCLK_PERIOD), 
+   .C_PORT_ENABLE                 (C_PORT_ENABLE), 
+   .C_MEM_ADDR_ORDER              (C_MEM_ADDR_ORDER), 
+   .C_ARB_ALGORITHM               (C_ARB_ALGORITHM), 
+   .C_ARB_NUM_TIME_SLOTS          (C_ARB_NUM_TIME_SLOTS), 
+   .C_ARB_TIME_SLOT_0             (C_ARB_TIME_SLOT_0), 
+   .C_ARB_TIME_SLOT_1             (C_ARB_TIME_SLOT_1), 
+   .C_ARB_TIME_SLOT_2             (C_ARB_TIME_SLOT_2), 
+   .C_ARB_TIME_SLOT_3             (C_ARB_TIME_SLOT_3), 
+   .C_ARB_TIME_SLOT_4             (C_ARB_TIME_SLOT_4), 
+   .C_ARB_TIME_SLOT_5             (C_ARB_TIME_SLOT_5), 
+   .C_ARB_TIME_SLOT_6             (C_ARB_TIME_SLOT_6), 
+   .C_ARB_TIME_SLOT_7             (C_ARB_TIME_SLOT_7), 
+   .C_ARB_TIME_SLOT_8             (C_ARB_TIME_SLOT_8), 
+   .C_ARB_TIME_SLOT_9             (C_ARB_TIME_SLOT_9), 
+   .C_ARB_TIME_SLOT_10            (C_ARB_TIME_SLOT_10), 
+   .C_ARB_TIME_SLOT_11            (C_ARB_TIME_SLOT_11), 
+   .C_PORT_CONFIG                 (C_PORT_CONFIG), 
+   .C_MEM_TRAS                    (C_MEM_TRAS), 
+   .C_MEM_TRCD                    (C_MEM_TRCD), 
+   .C_MEM_TREFI                   (C_MEM_TREFI), 
+   .C_MEM_TRFC                    (C_MEM_TRFC), 
+   .C_MEM_TRP                     (C_MEM_TRP), 
+   .C_MEM_TWR                     (C_MEM_TWR), 
+   .C_MEM_TRTP                    (C_MEM_TRTP), 
+   .C_MEM_TWTR                    (C_MEM_TWTR), 
+   .C_NUM_DQ_PINS                 (C_NUM_DQ_PINS), 
+   .C_MEM_TYPE                    (C_MEM_TYPE), 
+   .C_MEM_DENSITY                 (C_MEM_DENSITY), 
+   .C_MEM_BURST_LEN               (C_MEM_BURST_LEN), 
+   .C_MEM_CAS_LATENCY             (C_MEM_CAS_LATENCY), 
+   .C_MEM_ADDR_WIDTH              (C_MEM_ADDR_WIDTH), 
+   .C_MEM_BANKADDR_WIDTH          (C_MEM_BANKADDR_WIDTH), 
+   .C_MEM_NUM_COL_BITS            (C_MEM_NUM_COL_BITS), 
+   .C_MEM_DDR3_CAS_LATENCY        (C_MEM_DDR3_CAS_LATENCY), 
+   .C_MEM_MOBILE_PA_SR            (C_MEM_MOBILE_PA_SR), 
+   .C_MEM_DDR1_2_ODS              (C_MEM_DDR1_2_ODS), 
+   .C_MEM_DDR3_ODS                (C_MEM_DDR3_ODS), 
+   .C_MEM_DDR2_RTT                (C_MEM_DDR2_RTT), 
+   .C_MEM_DDR3_RTT                (C_MEM_DDR3_RTT), 
+   .C_MEM_MDDR_ODS                (C_MEM_MDDR_ODS), 
+   .C_MEM_DDR2_DIFF_DQS_EN        (C_MEM_DDR2_DIFF_DQS_EN), 
+   .C_MEM_DDR2_3_PA_SR            (C_MEM_DDR2_3_PA_SR), 
+   .C_MEM_DDR3_CAS_WR_LATENCY     (C_MEM_DDR3_CAS_WR_LATENCY), 
+   .C_MEM_DDR3_AUTO_SR            (C_MEM_DDR3_AUTO_SR), 
+   .C_MEM_DDR2_3_HIGH_TEMP_SR     (C_MEM_DDR2_3_HIGH_TEMP_SR), 
+   .C_MEM_DDR3_DYN_WRT_ODT        (C_MEM_DDR3_DYN_WRT_ODT), 
+   .C_MEM_TZQINIT_MAXCNT          (C_MEM_TZQINIT_MAXCNT), 
+   .C_MC_CALIB_BYPASS             (C_MC_CALIB_BYPASS), 
+   .C_MC_CALIBRATION_RA           (C_MC_CALIBRATION_RA),
+   .C_MC_CALIBRATION_BA           (C_MC_CALIBRATION_BA),
+   .C_MC_CALIBRATION_CA           (C_MC_CALIBRATION_CA),
+   .C_CALIB_SOFT_IP               (C_CALIB_SOFT_IP), 
+   .C_SKIP_IN_TERM_CAL            (C_SKIP_IN_TERM_CAL), 
+   .C_SKIP_DYNAMIC_CAL            (C_SKIP_DYNAMIC_CAL), 
+   .C_SKIP_DYN_IN_TERM            (C_SKIP_DYN_IN_TERM), 
+   .LDQSP_TAP_DELAY_VAL           (LDQSP_TAP_DELAY_VAL), 
+   .UDQSP_TAP_DELAY_VAL           (UDQSP_TAP_DELAY_VAL), 
+   .LDQSN_TAP_DELAY_VAL           (LDQSN_TAP_DELAY_VAL), 
+   .UDQSN_TAP_DELAY_VAL           (UDQSN_TAP_DELAY_VAL), 
+   .DQ0_TAP_DELAY_VAL             (DQ0_TAP_DELAY_VAL), 
+   .DQ1_TAP_DELAY_VAL             (DQ1_TAP_DELAY_VAL), 
+   .DQ2_TAP_DELAY_VAL             (DQ2_TAP_DELAY_VAL), 
+   .DQ3_TAP_DELAY_VAL             (DQ3_TAP_DELAY_VAL), 
+   .DQ4_TAP_DELAY_VAL             (DQ4_TAP_DELAY_VAL), 
+   .DQ5_TAP_DELAY_VAL             (DQ5_TAP_DELAY_VAL), 
+   .DQ6_TAP_DELAY_VAL             (DQ6_TAP_DELAY_VAL), 
+   .DQ7_TAP_DELAY_VAL             (DQ7_TAP_DELAY_VAL), 
+   .DQ8_TAP_DELAY_VAL             (DQ8_TAP_DELAY_VAL), 
+   .DQ9_TAP_DELAY_VAL             (DQ9_TAP_DELAY_VAL), 
+   .DQ10_TAP_DELAY_VAL            (DQ10_TAP_DELAY_VAL), 
+   .DQ11_TAP_DELAY_VAL            (DQ11_TAP_DELAY_VAL), 
+   .DQ12_TAP_DELAY_VAL            (DQ12_TAP_DELAY_VAL), 
+   .DQ13_TAP_DELAY_VAL            (DQ13_TAP_DELAY_VAL), 
+   .DQ14_TAP_DELAY_VAL            (DQ14_TAP_DELAY_VAL), 
+   .DQ15_TAP_DELAY_VAL            (DQ15_TAP_DELAY_VAL), 
+   .C_MC_CALIBRATION_CLK_DIV      (C_MC_CALIBRATION_CLK_DIV), 
+   .C_MC_CALIBRATION_MODE         (C_MC_CALIBRATION_MODE), 
+   .C_MC_CALIBRATION_DELAY        (C_MC_CALIBRATION_DELAY),
+   .C_SIMULATION                  (C_SIMULATION), 
+   .C_P0_MASK_SIZE                (C_P0_MASK_SIZE), 
+   .C_P0_DATA_PORT_SIZE           (C_P0_DATA_PORT_SIZE), 
+   .C_P1_MASK_SIZE                (C_P1_MASK_SIZE), 
+   .C_P1_DATA_PORT_SIZE           (C_P1_DATA_PORT_SIZE), 
+   .C_MCB_USE_EXTERNAL_BUFPLL     (C_MCB_USE_EXTERNAL_BUFPLL)
+  )
+mcb_ui_top_inst
+  (
+   // Raw Wrapper Signals
+   .sysclk_2x                     (sysclk_2x),          
+   .sysclk_2x_180                 (sysclk_2x_180), 
+   .pll_ce_0                      (pll_ce_0),
+   .pll_ce_90                     (pll_ce_90), 
+   .pll_lock                      (pll_lock),
+   .sysclk_2x_bufpll_o            (sysclk_2x_bufpll_o),     
+   .sysclk_2x_180_bufpll_o        (sysclk_2x_180_bufpll_o),
+   .pll_ce_0_bufpll_o             (pll_ce_0_bufpll_o),
+   .pll_ce_90_bufpll_o            (pll_ce_90_bufpll_o),
+   .pll_lock_bufpll_o             (pll_lock_bufpll_o),   
+   .sys_rst                       (async_rst),
+   .p0_arb_en                     (1'b1), 
+   .p0_cmd_clk                    (p0_cmd_clk),
+   .p0_cmd_en                     (p0_cmd_en), 
+   .p0_cmd_instr                  (p0_cmd_instr),
+   .p0_cmd_bl                     (p0_cmd_bl), 
+   .p0_cmd_byte_addr              (p0_cmd_byte_addr),       
+   .p0_cmd_empty                  (p0_cmd_empty),
+   .p0_cmd_full                   (p0_cmd_full),
+   .p0_wr_clk                     (p0_wr_clk), 
+   .p0_wr_en                      (p0_wr_en),
+   .p0_wr_mask                    (p0_wr_mask),
+   .p0_wr_data                    (p0_wr_data),
+   .p0_wr_full                    (p0_wr_full),
+   .p0_wr_empty                   (p0_wr_empty),
+   .p0_wr_count                   (p0_wr_count),
+   .p0_wr_underrun                (p0_wr_underrun),  
+   .p0_wr_error                   (p0_wr_error),
+   .p0_rd_clk                     (p0_rd_clk), 
+   .p0_rd_en                      (p0_rd_en),
+   .p0_rd_data                    (p0_rd_data),
+   .p0_rd_full                    (p0_rd_full),
+   .p0_rd_empty                   (p0_rd_empty),
+   .p0_rd_count                   (p0_rd_count),
+   .p0_rd_overflow                (p0_rd_overflow),  
+   .p0_rd_error                   (p0_rd_error),
+   .p1_arb_en                     (1'b1), 
+   .p1_cmd_clk                    (p1_cmd_clk),
+   .p1_cmd_en                     (p1_cmd_en), 
+   .p1_cmd_instr                  (p1_cmd_instr),
+   .p1_cmd_bl                     (p1_cmd_bl), 
+   .p1_cmd_byte_addr              (p1_cmd_byte_addr),       
+   .p1_cmd_empty                  (p1_cmd_empty),
+   .p1_cmd_full                   (p1_cmd_full),
+   .p1_wr_clk                     (p1_wr_clk), 
+   .p1_wr_en                      (p1_wr_en),
+   .p1_wr_mask                    (p1_wr_mask),
+   .p1_wr_data                    (p1_wr_data),
+   .p1_wr_full                    (p1_wr_full),
+   .p1_wr_empty                   (p1_wr_empty),
+   .p1_wr_count                   (p1_wr_count),
+   .p1_wr_underrun                (p1_wr_underrun),  
+   .p1_wr_error                   (p1_wr_error),
+   .p1_rd_clk                     (p1_rd_clk), 
+   .p1_rd_en                      (p1_rd_en),
+   .p1_rd_data                    (p1_rd_data),
+   .p1_rd_full                    (p1_rd_full),
+   .p1_rd_empty                   (p1_rd_empty),
+   .p1_rd_count                   (p1_rd_count),
+   .p1_rd_overflow                (p1_rd_overflow),  
+   .p1_rd_error                   (p1_rd_error),
+   .p2_arb_en                     (1'b1), 
+   .p2_cmd_clk                    (p2_cmd_clk),
+   .p2_cmd_en                     (p2_cmd_en), 
+   .p2_cmd_instr                  (p2_cmd_instr),
+   .p2_cmd_bl                     (p2_cmd_bl), 
+   .p2_cmd_byte_addr              (p2_cmd_byte_addr),       
+   .p2_cmd_empty                  (p2_cmd_empty),
+   .p2_cmd_full                   (p2_cmd_full),
+   .p2_wr_clk                     (p2_wr_clk), 
+   .p2_wr_en                      (p2_wr_en),
+   .p2_wr_mask                    (p2_wr_mask),
+   .p2_wr_data                    (p2_wr_data),
+   .p2_wr_full                    (p2_wr_full),
+   .p2_wr_empty                   (p2_wr_empty),
+   .p2_wr_count                   (p2_wr_count),
+   .p2_wr_underrun                (p2_wr_underrun),  
+   .p2_wr_error                   (p2_wr_error),
+   .p2_rd_clk                     (p2_rd_clk), 
+   .p2_rd_en                      (p2_rd_en),
+   .p2_rd_data                    (p2_rd_data),
+   .p2_rd_full                    (p2_rd_full),
+   .p2_rd_empty                   (p2_rd_empty),
+   .p2_rd_count                   (p2_rd_count),
+   .p2_rd_overflow                (p2_rd_overflow),  
+   .p2_rd_error                   (p2_rd_error),
+   .p3_arb_en                     (1'b1), 
+   .p3_cmd_clk                    (p3_cmd_clk),
+   .p3_cmd_en                     (p3_cmd_en), 
+   .p3_cmd_instr                  (p3_cmd_instr),
+   .p3_cmd_bl                     (p3_cmd_bl), 
+   .p3_cmd_byte_addr              (p3_cmd_byte_addr),       
+   .p3_cmd_empty                  (p3_cmd_empty),
+   .p3_cmd_full                   (p3_cmd_full),
+   .p3_wr_clk                     (p3_wr_clk), 
+   .p3_wr_en                      (p3_wr_en),
+   .p3_wr_mask                    (p3_wr_mask),
+   .p3_wr_data                    (p3_wr_data),
+   .p3_wr_full                    (p3_wr_full),
+   .p3_wr_empty                   (p3_wr_empty),
+   .p3_wr_count                   (p3_wr_count),
+   .p3_wr_underrun                (p3_wr_underrun),  
+   .p3_wr_error                   (p3_wr_error),
+   .p3_rd_clk                     (p3_rd_clk), 
+   .p3_rd_en                      (p3_rd_en),
+   .p3_rd_data                    (p3_rd_data),
+   .p3_rd_full                    (p3_rd_full),
+   .p3_rd_empty                   (p3_rd_empty),
+   .p3_rd_count                   (p3_rd_count),
+   .p3_rd_overflow                (p3_rd_overflow),  
+   .p3_rd_error                   (p3_rd_error),
+   .p4_arb_en                     (1'b1), 
+   .p4_cmd_clk                    (p4_cmd_clk),
+   .p4_cmd_en                     (p4_cmd_en), 
+   .p4_cmd_instr                  (p4_cmd_instr),
+   .p4_cmd_bl                     (p4_cmd_bl), 
+   .p4_cmd_byte_addr              (p4_cmd_byte_addr),       
+   .p4_cmd_empty                  (p4_cmd_empty),
+   .p4_cmd_full                   (p4_cmd_full),
+   .p4_wr_clk                     (p4_wr_clk), 
+   .p4_wr_en                      (p4_wr_en),
+   .p4_wr_mask                    (p4_wr_mask),
+   .p4_wr_data                    (p4_wr_data),
+   .p4_wr_full                    (p4_wr_full),
+   .p4_wr_empty                   (p4_wr_empty),
+   .p4_wr_count                   (p4_wr_count),
+   .p4_wr_underrun                (p4_wr_underrun),  
+   .p4_wr_error                   (p4_wr_error),
+   .p4_rd_clk                     (p4_rd_clk), 
+   .p4_rd_en                      (p4_rd_en),
+   .p4_rd_data                    (p4_rd_data),
+   .p4_rd_full                    (p4_rd_full),
+   .p4_rd_empty                   (p4_rd_empty),
+   .p4_rd_count                   (p4_rd_count),
+   .p4_rd_overflow                (p4_rd_overflow),  
+   .p4_rd_error                   (p4_rd_error),
+   .p5_arb_en                     (1'b1), 
+   .p5_cmd_clk                    (p5_cmd_clk),
+   .p5_cmd_en                     (p5_cmd_en), 
+   .p5_cmd_instr                  (p5_cmd_instr),
+   .p5_cmd_bl                     (p5_cmd_bl), 
+   .p5_cmd_byte_addr              (p5_cmd_byte_addr),       
+   .p5_cmd_empty                  (p5_cmd_empty),
+   .p5_cmd_full                   (p5_cmd_full),
+   .p5_wr_clk                     (p5_wr_clk), 
+   .p5_wr_en                      (p5_wr_en),
+   .p5_wr_mask                    (p5_wr_mask),
+   .p5_wr_data                    (p5_wr_data),
+   .p5_wr_full                    (p5_wr_full),
+   .p5_wr_empty                   (p5_wr_empty),
+   .p5_wr_count                   (p5_wr_count),
+   .p5_wr_underrun                (p5_wr_underrun),  
+   .p5_wr_error                   (p5_wr_error),
+   .p5_rd_clk                     (p5_rd_clk), 
+   .p5_rd_en                      (p5_rd_en),
+   .p5_rd_data                    (p5_rd_data),
+   .p5_rd_full                    (p5_rd_full),
+   .p5_rd_empty                   (p5_rd_empty),
+   .p5_rd_count                   (p5_rd_count),
+   .p5_rd_overflow                (p5_rd_overflow),  
+   .p5_rd_error                   (p5_rd_error),
+   .mcbx_dram_addr                (mcbx_dram_addr),  
+   .mcbx_dram_ba                  (mcbx_dram_ba),
+   .mcbx_dram_ras_n               (mcbx_dram_ras_n),       
+   .mcbx_dram_cas_n               (mcbx_dram_cas_n),       
+   .mcbx_dram_we_n                (mcbx_dram_we_n),  
+   .mcbx_dram_cke                 (mcbx_dram_cke), 
+   .mcbx_dram_clk                 (mcbx_dram_clk), 
+   .mcbx_dram_clk_n               (mcbx_dram_clk_n),       
+   .mcbx_dram_dq                  (mcbx_dram_dq),
+   .mcbx_dram_dqs                 (mcbx_dram_dqs), 
+   .mcbx_dram_dqs_n               (mcbx_dram_dqs_n),       
+   .mcbx_dram_udqs                (mcbx_dram_udqs),  
+   .mcbx_dram_udqs_n              (mcbx_dram_udqs_n),       
+   .mcbx_dram_udm                 (mcbx_dram_udm), 
+   .mcbx_dram_ldm                 (mcbx_dram_ldm), 
+   .mcbx_dram_odt                 (mcbx_dram_odt), 
+   .mcbx_dram_ddr3_rst            (mcbx_dram_ddr3_rst),      
+   .calib_recal                   (1'b0),
+   .rzq                           (mcbx_rzq),
+   .zio                           (mcbx_zio),
+   .ui_read                       (1'b0),
+   .ui_add                        (1'b0),
+   .ui_cs                         (1'b0),
+   .ui_clk                        (mcb_drp_clk),
+   .ui_sdi                        (1'b0),
+   .ui_addr                       (5'b0),
+   .ui_broadcast                  (1'b0),
+   .ui_drp_update                 (1'b0), 
+   .ui_done_cal                   (1'b1),
+   .ui_cmd                        (1'b0),
+   .ui_cmd_in                     (1'b0), 
+   .ui_cmd_en                     (1'b0), 
+   .ui_dqcount                    (4'b0),
+   .ui_dq_lower_dec               (1'b0),       
+   .ui_dq_lower_inc               (1'b0),       
+   .ui_dq_upper_dec               (1'b0),       
+   .ui_dq_upper_inc               (1'b0),       
+   .ui_udqs_inc                   (1'b0),
+   .ui_udqs_dec                   (1'b0),
+   .ui_ldqs_inc                   (1'b0),
+   .ui_ldqs_dec                   (1'b0),
+   .uo_data                       (uo_data),
+   .uo_data_valid                 (uo_data_valid), 
+   .uo_done_cal                   (calib_done),
+   .uo_cmd_ready_in               (uo_cmd_ready_in),       
+   .uo_refrsh_flag                (uo_refrsh_flag),  
+   .uo_cal_start                  (uo_cal_start),
+   .uo_sdo                        (uo_sdo),
+   .status                        (status),
+   .selfrefresh_enter             (selfrefresh_enter),       
+   .selfrefresh_mode              (selfrefresh_mode),
+
+   // AXI Signals                 
+   .s0_axi_aclk                   (s0_axi_aclk),
+   .s0_axi_aresetn                (s0_axi_aresetn),
+   .s0_axi_awid                   (s0_axi_awid), 
+   .s0_axi_awaddr                 (s0_axi_awaddr), 
+   .s0_axi_awlen                  (s0_axi_awlen), 
+   .s0_axi_awsize                 (s0_axi_awsize), 
+   .s0_axi_awburst                (s0_axi_awburst), 
+   .s0_axi_awlock                 (s0_axi_awlock), 
+   .s0_axi_awcache                (s0_axi_awcache), 
+   .s0_axi_awprot                 (s0_axi_awprot), 
+   .s0_axi_awqos                  (s0_axi_awqos), 
+   .s0_axi_awvalid                (s0_axi_awvalid), 
+   .s0_axi_awready                (s0_axi_awready), 
+   .s0_axi_wdata                  (s0_axi_wdata), 
+   .s0_axi_wstrb                  (s0_axi_wstrb), 
+   .s0_axi_wlast                  (s0_axi_wlast), 
+   .s0_axi_wvalid                 (s0_axi_wvalid), 
+   .s0_axi_wready                 (s0_axi_wready), 
+   .s0_axi_bid                    (s0_axi_bid), 
+   .s0_axi_bresp                  (s0_axi_bresp), 
+   .s0_axi_bvalid                 (s0_axi_bvalid), 
+   .s0_axi_bready                 (s0_axi_bready), 
+   .s0_axi_arid                   (s0_axi_arid), 
+   .s0_axi_araddr                 (s0_axi_araddr), 
+   .s0_axi_arlen                  (s0_axi_arlen), 
+   .s0_axi_arsize                 (s0_axi_arsize), 
+   .s0_axi_arburst                (s0_axi_arburst), 
+   .s0_axi_arlock                 (s0_axi_arlock), 
+   .s0_axi_arcache                (s0_axi_arcache), 
+   .s0_axi_arprot                 (s0_axi_arprot), 
+   .s0_axi_arqos                  (s0_axi_arqos), 
+   .s0_axi_arvalid                (s0_axi_arvalid), 
+   .s0_axi_arready                (s0_axi_arready), 
+   .s0_axi_rid                    (s0_axi_rid), 
+   .s0_axi_rdata                  (s0_axi_rdata), 
+   .s0_axi_rresp                  (s0_axi_rresp), 
+   .s0_axi_rlast                  (s0_axi_rlast), 
+   .s0_axi_rvalid                 (s0_axi_rvalid), 
+   .s0_axi_rready                 (s0_axi_rready),
+                                                   
+   .s1_axi_aclk                   (s1_axi_aclk),
+   .s1_axi_aresetn                (s1_axi_aresetn),
+   .s1_axi_awid                   (s1_axi_awid), 
+   .s1_axi_awaddr                 (s1_axi_awaddr), 
+   .s1_axi_awlen                  (s1_axi_awlen), 
+   .s1_axi_awsize                 (s1_axi_awsize), 
+   .s1_axi_awburst                (s1_axi_awburst), 
+   .s1_axi_awlock                 (s1_axi_awlock), 
+   .s1_axi_awcache                (s1_axi_awcache), 
+   .s1_axi_awprot                 (s1_axi_awprot), 
+   .s1_axi_awqos                  (s1_axi_awqos), 
+   .s1_axi_awvalid                (s1_axi_awvalid), 
+   .s1_axi_awready                (s1_axi_awready), 
+   .s1_axi_wdata                  (s1_axi_wdata), 
+   .s1_axi_wstrb                  (s1_axi_wstrb), 
+   .s1_axi_wlast                  (s1_axi_wlast), 
+   .s1_axi_wvalid                 (s1_axi_wvalid), 
+   .s1_axi_wready                 (s1_axi_wready), 
+   .s1_axi_bid                    (s1_axi_bid), 
+   .s1_axi_bresp                  (s1_axi_bresp), 
+   .s1_axi_bvalid                 (s1_axi_bvalid), 
+   .s1_axi_bready                 (s1_axi_bready), 
+   .s1_axi_arid                   (s1_axi_arid), 
+   .s1_axi_araddr                 (s1_axi_araddr), 
+   .s1_axi_arlen                  (s1_axi_arlen), 
+   .s1_axi_arsize                 (s1_axi_arsize), 
+   .s1_axi_arburst                (s1_axi_arburst), 
+   .s1_axi_arlock                 (s1_axi_arlock), 
+   .s1_axi_arcache                (s1_axi_arcache), 
+   .s1_axi_arprot                 (s1_axi_arprot), 
+   .s1_axi_arqos                  (s1_axi_arqos), 
+   .s1_axi_arvalid                (s1_axi_arvalid), 
+   .s1_axi_arready                (s1_axi_arready), 
+   .s1_axi_rid                    (s1_axi_rid), 
+   .s1_axi_rdata                  (s1_axi_rdata), 
+   .s1_axi_rresp                  (s1_axi_rresp), 
+   .s1_axi_rlast                  (s1_axi_rlast), 
+   .s1_axi_rvalid                 (s1_axi_rvalid), 
+   .s1_axi_rready                 (s1_axi_rready),
+                                                   
+   .s2_axi_aclk                   (s2_axi_aclk),
+   .s2_axi_aresetn                (s2_axi_aresetn),
+   .s2_axi_awid                   (s2_axi_awid), 
+   .s2_axi_awaddr                 (s2_axi_awaddr), 
+   .s2_axi_awlen                  (s2_axi_awlen), 
+   .s2_axi_awsize                 (s2_axi_awsize), 
+   .s2_axi_awburst                (s2_axi_awburst), 
+   .s2_axi_awlock                 (s2_axi_awlock), 
+   .s2_axi_awcache                (s2_axi_awcache), 
+   .s2_axi_awprot                 (s2_axi_awprot), 
+   .s2_axi_awqos                  (s2_axi_awqos), 
+   .s2_axi_awvalid                (s2_axi_awvalid), 
+   .s2_axi_awready                (s2_axi_awready), 
+   .s2_axi_wdata                  (s2_axi_wdata), 
+   .s2_axi_wstrb                  (s2_axi_wstrb), 
+   .s2_axi_wlast                  (s2_axi_wlast), 
+   .s2_axi_wvalid                 (s2_axi_wvalid), 
+   .s2_axi_wready                 (s2_axi_wready), 
+   .s2_axi_bid                    (s2_axi_bid), 
+   .s2_axi_bresp                  (s2_axi_bresp), 
+   .s2_axi_bvalid                 (s2_axi_bvalid), 
+   .s2_axi_bready                 (s2_axi_bready), 
+   .s2_axi_arid                   (s2_axi_arid), 
+   .s2_axi_araddr                 (s2_axi_araddr), 
+   .s2_axi_arlen                  (s2_axi_arlen), 
+   .s2_axi_arsize                 (s2_axi_arsize), 
+   .s2_axi_arburst                (s2_axi_arburst), 
+   .s2_axi_arlock                 (s2_axi_arlock), 
+   .s2_axi_arcache                (s2_axi_arcache), 
+   .s2_axi_arprot                 (s2_axi_arprot), 
+   .s2_axi_arqos                  (s2_axi_arqos), 
+   .s2_axi_arvalid                (s2_axi_arvalid), 
+   .s2_axi_arready                (s2_axi_arready), 
+   .s2_axi_rid                    (s2_axi_rid), 
+   .s2_axi_rdata                  (s2_axi_rdata), 
+   .s2_axi_rresp                  (s2_axi_rresp), 
+   .s2_axi_rlast                  (s2_axi_rlast), 
+   .s2_axi_rvalid                 (s2_axi_rvalid), 
+   .s2_axi_rready                 (s2_axi_rready),
+                                                   
+   .s3_axi_aclk                   (s3_axi_aclk),
+   .s3_axi_aresetn                (s3_axi_aresetn),
+   .s3_axi_awid                   (s3_axi_awid), 
+   .s3_axi_awaddr                 (s3_axi_awaddr), 
+   .s3_axi_awlen                  (s3_axi_awlen), 
+   .s3_axi_awsize                 (s3_axi_awsize), 
+   .s3_axi_awburst                (s3_axi_awburst), 
+   .s3_axi_awlock                 (s3_axi_awlock), 
+   .s3_axi_awcache                (s3_axi_awcache), 
+   .s3_axi_awprot                 (s3_axi_awprot), 
+   .s3_axi_awqos                  (s3_axi_awqos), 
+   .s3_axi_awvalid                (s3_axi_awvalid), 
+   .s3_axi_awready                (s3_axi_awready), 
+   .s3_axi_wdata                  (s3_axi_wdata), 
+   .s3_axi_wstrb                  (s3_axi_wstrb), 
+   .s3_axi_wlast                  (s3_axi_wlast), 
+   .s3_axi_wvalid                 (s3_axi_wvalid), 
+   .s3_axi_wready                 (s3_axi_wready), 
+   .s3_axi_bid                    (s3_axi_bid), 
+   .s3_axi_bresp                  (s3_axi_bresp), 
+   .s3_axi_bvalid                 (s3_axi_bvalid), 
+   .s3_axi_bready                 (s3_axi_bready), 
+   .s3_axi_arid                   (s3_axi_arid), 
+   .s3_axi_araddr                 (s3_axi_araddr), 
+   .s3_axi_arlen                  (s3_axi_arlen), 
+   .s3_axi_arsize                 (s3_axi_arsize), 
+   .s3_axi_arburst                (s3_axi_arburst), 
+   .s3_axi_arlock                 (s3_axi_arlock), 
+   .s3_axi_arcache                (s3_axi_arcache), 
+   .s3_axi_arprot                 (s3_axi_arprot), 
+   .s3_axi_arqos                  (s3_axi_arqos), 
+   .s3_axi_arvalid                (s3_axi_arvalid), 
+   .s3_axi_arready                (s3_axi_arready), 
+   .s3_axi_rid                    (s3_axi_rid), 
+   .s3_axi_rdata                  (s3_axi_rdata), 
+   .s3_axi_rresp                  (s3_axi_rresp), 
+   .s3_axi_rlast                  (s3_axi_rlast), 
+   .s3_axi_rvalid                 (s3_axi_rvalid), 
+   .s3_axi_rready                 (s3_axi_rready),
+                                                   
+   .s4_axi_aclk                   (s4_axi_aclk),
+   .s4_axi_aresetn                (s4_axi_aresetn),
+   .s4_axi_awid                   (s4_axi_awid), 
+   .s4_axi_awaddr                 (s4_axi_awaddr), 
+   .s4_axi_awlen                  (s4_axi_awlen), 
+   .s4_axi_awsize                 (s4_axi_awsize), 
+   .s4_axi_awburst                (s4_axi_awburst), 
+   .s4_axi_awlock                 (s4_axi_awlock), 
+   .s4_axi_awcache                (s4_axi_awcache), 
+   .s4_axi_awprot                 (s4_axi_awprot), 
+   .s4_axi_awqos                  (s4_axi_awqos), 
+   .s4_axi_awvalid                (s4_axi_awvalid), 
+   .s4_axi_awready                (s4_axi_awready), 
+   .s4_axi_wdata                  (s4_axi_wdata), 
+   .s4_axi_wstrb                  (s4_axi_wstrb), 
+   .s4_axi_wlast                  (s4_axi_wlast), 
+   .s4_axi_wvalid                 (s4_axi_wvalid), 
+   .s4_axi_wready                 (s4_axi_wready), 
+   .s4_axi_bid                    (s4_axi_bid), 
+   .s4_axi_bresp                  (s4_axi_bresp), 
+   .s4_axi_bvalid                 (s4_axi_bvalid), 
+   .s4_axi_bready                 (s4_axi_bready), 
+   .s4_axi_arid                   (s4_axi_arid), 
+   .s4_axi_araddr                 (s4_axi_araddr), 
+   .s4_axi_arlen                  (s4_axi_arlen), 
+   .s4_axi_arsize                 (s4_axi_arsize), 
+   .s4_axi_arburst                (s4_axi_arburst), 
+   .s4_axi_arlock                 (s4_axi_arlock), 
+   .s4_axi_arcache                (s4_axi_arcache), 
+   .s4_axi_arprot                 (s4_axi_arprot), 
+   .s4_axi_arqos                  (s4_axi_arqos), 
+   .s4_axi_arvalid                (s4_axi_arvalid), 
+   .s4_axi_arready                (s4_axi_arready), 
+   .s4_axi_rid                    (s4_axi_rid), 
+   .s4_axi_rdata                  (s4_axi_rdata), 
+   .s4_axi_rresp                  (s4_axi_rresp), 
+   .s4_axi_rlast                  (s4_axi_rlast), 
+   .s4_axi_rvalid                 (s4_axi_rvalid), 
+   .s4_axi_rready                 (s4_axi_rready),
+                                                   
+   .s5_axi_aclk                   (s5_axi_aclk),
+   .s5_axi_aresetn                (s5_axi_aresetn),
+   .s5_axi_awid                   (s5_axi_awid), 
+   .s5_axi_awaddr                 (s5_axi_awaddr), 
+   .s5_axi_awlen                  (s5_axi_awlen), 
+   .s5_axi_awsize                 (s5_axi_awsize), 
+   .s5_axi_awburst                (s5_axi_awburst), 
+   .s5_axi_awlock                 (s5_axi_awlock), 
+   .s5_axi_awcache                (s5_axi_awcache), 
+   .s5_axi_awprot                 (s5_axi_awprot), 
+   .s5_axi_awqos                  (s5_axi_awqos), 
+   .s5_axi_awvalid                (s5_axi_awvalid), 
+   .s5_axi_awready                (s5_axi_awready), 
+   .s5_axi_wdata                  (s5_axi_wdata), 
+   .s5_axi_wstrb                  (s5_axi_wstrb), 
+   .s5_axi_wlast                  (s5_axi_wlast), 
+   .s5_axi_wvalid                 (s5_axi_wvalid), 
+   .s5_axi_wready                 (s5_axi_wready), 
+   .s5_axi_bid                    (s5_axi_bid), 
+   .s5_axi_bresp                  (s5_axi_bresp), 
+   .s5_axi_bvalid                 (s5_axi_bvalid), 
+   .s5_axi_bready                 (s5_axi_bready), 
+   .s5_axi_arid                   (s5_axi_arid), 
+   .s5_axi_araddr                 (s5_axi_araddr), 
+   .s5_axi_arlen                  (s5_axi_arlen), 
+   .s5_axi_arsize                 (s5_axi_arsize), 
+   .s5_axi_arburst                (s5_axi_arburst), 
+   .s5_axi_arlock                 (s5_axi_arlock), 
+   .s5_axi_arcache                (s5_axi_arcache), 
+   .s5_axi_arprot                 (s5_axi_arprot), 
+   .s5_axi_arqos                  (s5_axi_arqos), 
+   .s5_axi_arvalid                (s5_axi_arvalid), 
+   .s5_axi_arready                (s5_axi_arready), 
+   .s5_axi_rid                    (s5_axi_rid), 
+   .s5_axi_rdata                  (s5_axi_rdata), 
+   .s5_axi_rresp                  (s5_axi_rresp), 
+   .s5_axi_rlast                  (s5_axi_rlast), 
+   .s5_axi_rvalid                 (s5_axi_rvalid), 
+   .s5_axi_rready                 (s5_axi_rready)
+  );
+
+endmodule

--- a/systems/atlys/rtl/verilog/xilinx_ddr2/xilinx_ddr2.v
+++ b/systems/atlys/rtl/verilog/xilinx_ddr2/xilinx_ddr2.v
@@ -1,0 +1,345 @@
+/* 
+ * Wrapper for Xilinx MIG'd DDR2 controller
+ * The DDR2 controller have 5 wishbone slave interfaces,
+ * if more masters than that is needed, arbiters have to be added
+ */
+
+module xilinx_ddr2
+  (
+   // Inputs
+    input [31:0]  wbm0_adr_i, 
+    input [1:0]   wbm0_bte_i, 
+    input [2:0]   wbm0_cti_i, 
+    input 	  wbm0_cyc_i, 
+    input [31:0]  wbm0_dat_i, 
+    input [3:0]   wbm0_sel_i,
+  
+    input 	  wbm0_stb_i, 
+    input 	  wbm0_we_i,
+  
+   // Outputs
+    output 	  wbm0_ack_o, 
+    output 	  wbm0_err_o, 
+    output 	  wbm0_rty_o, 
+    output [31:0] wbm0_dat_o,
+  
+  
+   // Inputs
+    input [31:0]  wbm1_adr_i, 
+    input [1:0]   wbm1_bte_i, 
+    input [2:0]   wbm1_cti_i, 
+    input 	  wbm1_cyc_i, 
+    input [31:0]  wbm1_dat_i, 
+    input [3:0]   wbm1_sel_i,
+  
+    input 	  wbm1_stb_i, 
+    input 	  wbm1_we_i,
+  
+   // Outputs
+    output 	  wbm1_ack_o, 
+    output 	  wbm1_err_o, 
+    output 	  wbm1_rty_o, 
+    output [31:0] wbm1_dat_o,
+
+
+  
+   // Inputs
+    input [31:0]  wbm2_adr_i, 
+    input [1:0]   wbm2_bte_i, 
+    input [2:0]   wbm2_cti_i, 
+    input 	  wbm2_cyc_i, 
+    input [31:0]  wbm2_dat_i, 
+    input [3:0]   wbm2_sel_i,
+  
+    input 	  wbm2_stb_i, 
+    input 	  wbm2_we_i,
+  
+   // Outputs
+    output 	  wbm2_ack_o, 
+    output 	  wbm2_err_o, 
+    output 	  wbm2_rty_o, 
+    output [31:0] wbm2_dat_o,
+
+   // Inputs
+    input [31:0]  wbm3_adr_i, 
+    input [1:0]   wbm3_bte_i, 
+    input [2:0]   wbm3_cti_i, 
+    input 	  wbm3_cyc_i, 
+    input [31:0]  wbm3_dat_i, 
+    input [3:0]   wbm3_sel_i,
+  
+    input 	  wbm3_stb_i, 
+    input 	  wbm3_we_i,
+  
+   // Outputs
+    output 	  wbm3_ack_o, 
+    output 	  wbm3_err_o, 
+    output 	  wbm3_rty_o, 
+    output [31:0] wbm3_dat_o,
+
+   // Inputs
+    input [31:0]  wbm4_adr_i, 
+    input [1:0]   wbm4_bte_i, 
+    input [2:0]   wbm4_cti_i, 
+    input 	  wbm4_cyc_i, 
+    input [31:0]  wbm4_dat_i, 
+    input [3:0]   wbm4_sel_i,
+  
+    input 	  wbm4_stb_i, 
+    input 	  wbm4_we_i,
+  
+   // Outputs
+    output 	  wbm4_ack_o, 
+    output 	  wbm4_err_o, 
+    output 	  wbm4_rty_o, 
+    output [31:0] wbm4_dat_o,
+
+    input 	  wb_clk,
+    input 	  wb_rst,
+
+    output [12:0] ddr2_a,
+    output [2:0]  ddr2_ba,
+    output 	  ddr2_ras_n,
+    output 	  ddr2_cas_n,
+    output 	  ddr2_we_n,
+    output 	  ddr2_rzq,
+    output 	  ddr2_zio,
+
+    output 	  ddr2_odt,
+    output 	  ddr2_cke,
+    output 	  ddr2_dm,
+    output 	  ddr2_udm,
+   
+    inout [15:0]  ddr2_dq, 
+    inout 	  ddr2_dqs,
+    inout 	  ddr2_dqs_n,
+    inout 	  ddr2_udqs,
+    inout 	  ddr2_udqs_n,
+    output 	  ddr2_ck,
+    output 	  ddr2_ck_n,
+
+    input 	  ddr2_if_clk,
+    input 	  ddr2_if_rst
+   ,
+    output [31:0] ddr2_trace_data0_o,
+    output [31:0] ddr2_trace_data1_o,
+    output [31:0] ddr2_trace_data2_o,
+    output [31:0] ddr2_trace_data3_o,
+    output [31:0] ddr2_trace_data4_o,
+    output [31:0] ddr2_trace_data5_o
+
+   );
+
+   // Wires to the four slaves of the DDR2 interface
+   wire [31:0]    wbs0_ram_adr_i;
+   wire [1:0]     wbs0_ram_bte_i;
+   wire [2:0]     wbs0_ram_cti_i;
+   wire           wbs0_ram_cyc_i;
+   wire [31:0] 	  wbs0_ram_dat_i;
+   wire [3:0]     wbs0_ram_sel_i;
+   wire           wbs0_ram_stb_i;
+   wire           wbs0_ram_we_i;   
+   wire           wbs0_ram_ack_o;
+   wire [31:0]    wbs0_ram_dat_o;
+
+   wire [31:0]    wbs1_ram_adr_i;
+   wire [1:0]     wbs1_ram_bte_i;
+   wire [2:0]     wbs1_ram_cti_i;
+   wire           wbs1_ram_cyc_i;
+   wire [31:0]    wbs1_ram_dat_i;
+   wire [3:0]     wbs1_ram_sel_i;
+   wire           wbs1_ram_stb_i;
+   wire           wbs1_ram_we_i;
+   wire           wbs1_ram_ack_o;
+   wire [31:0]    wbs1_ram_dat_o;
+
+   wire [31:0]    wbs2_ram_adr_i;
+   wire [1:0]     wbs2_ram_bte_i;
+   wire [2:0]     wbs2_ram_cti_i;
+   wire           wbs2_ram_cyc_i;
+   wire [31:0]    wbs2_ram_dat_i;
+   wire [3:0]     wbs2_ram_sel_i;
+   wire           wbs2_ram_stb_i;
+   wire           wbs2_ram_we_i;   
+   wire           wbs2_ram_ack_o;
+   wire [31:0]    wbs2_ram_dat_o;
+
+   wire [31:0]    wbs3_ram_adr_i;
+   wire [1:0]     wbs3_ram_bte_i;
+   wire [2:0]     wbs3_ram_cti_i;
+   wire           wbs3_ram_cyc_i;
+   wire [31:0]    wbs3_ram_dat_i;
+   wire [3:0]     wbs3_ram_sel_i;
+   wire           wbs3_ram_stb_i;
+   wire           wbs3_ram_we_i;
+   wire           wbs3_ram_ack_o;
+   wire [31:0]    wbs3_ram_dat_o;
+
+   wire [31:0]    wbs4_ram_adr_i;
+   wire [1:0]     wbs4_ram_bte_i;
+   wire [2:0]     wbs4_ram_cti_i;
+   wire           wbs4_ram_cyc_i;
+   wire [31:0]    wbs4_ram_dat_i;
+   wire [3:0]     wbs4_ram_sel_i;
+   wire           wbs4_ram_stb_i;
+   wire           wbs4_ram_we_i;
+   wire           wbs4_ram_ack_o;
+   wire [31:0]    wbs4_ram_dat_o;
+
+   // assign masters to slaves 
+   assign wbs0_ram_adr_i = wbm0_adr_i;
+   assign wbs0_ram_bte_i = wbm0_bte_i;
+   assign wbs0_ram_cti_i = wbm0_cti_i;
+   assign wbs0_ram_cyc_i = wbm0_cyc_i;
+   assign wbs0_ram_dat_i = wbm0_dat_i;
+   assign wbs0_ram_sel_i = wbm0_sel_i;
+   assign wbs0_ram_stb_i = wbm0_stb_i;
+   assign wbs0_ram_we_i  = wbm0_we_i;   
+   assign wbm0_ack_o     = wbs0_ram_ack_o;
+   assign wbm0_dat_o     = wbs0_ram_dat_o;
+   assign wbm0_err_o     = 0;   
+   assign wbm0_rty_o     = 0;
+      
+   assign wbs1_ram_adr_i = wbm1_adr_i;
+   assign wbs1_ram_bte_i = wbm1_bte_i;
+   assign wbs1_ram_cti_i = wbm1_cti_i;
+   assign wbs1_ram_cyc_i = wbm1_cyc_i;
+   assign wbs1_ram_dat_i = wbm1_dat_i;
+   assign wbs1_ram_sel_i = wbm1_sel_i;
+   assign wbs1_ram_stb_i = wbm1_stb_i;
+   assign wbs1_ram_we_i  = wbm1_we_i;   
+   assign wbm1_ack_o     = wbs1_ram_ack_o;
+   assign wbm1_dat_o     = wbs1_ram_dat_o;
+   assign wbm1_err_o     = 0;   
+   assign wbm1_rty_o     = 0;
+
+   assign wbs2_ram_adr_i = wbm2_adr_i;
+   assign wbs2_ram_bte_i = wbm2_bte_i;
+   assign wbs2_ram_cti_i = wbm2_cti_i;
+   assign wbs2_ram_cyc_i = wbm2_cyc_i;
+   assign wbs2_ram_dat_i = wbm2_dat_i;
+   assign wbs2_ram_sel_i = wbm2_sel_i;
+   assign wbs2_ram_stb_i = wbm2_stb_i;
+   assign wbs2_ram_we_i  = wbm2_we_i;   
+   assign wbm2_ack_o     = wbs2_ram_ack_o;
+   assign wbm2_dat_o     = wbs2_ram_dat_o;
+   assign wbm2_err_o     = 0;   
+   assign wbm2_rty_o     = 0;
+
+   assign wbs3_ram_adr_i = wbm3_adr_i;
+   assign wbs3_ram_bte_i = wbm3_bte_i;
+   assign wbs3_ram_cti_i = wbm3_cti_i;
+   assign wbs3_ram_cyc_i = wbm3_cyc_i;
+   assign wbs3_ram_dat_i = wbm3_dat_i;
+   assign wbs3_ram_sel_i = wbm3_sel_i;
+   assign wbs3_ram_stb_i = wbm3_stb_i;
+   assign wbs3_ram_we_i  = wbm3_we_i;   
+   assign wbm3_ack_o     = wbs3_ram_ack_o;
+   assign wbm3_dat_o     = wbs3_ram_dat_o;
+   assign wbm3_err_o     = 0;   
+   assign wbm3_rty_o     = 0;
+
+   assign wbs4_ram_adr_i = wbm4_adr_i;
+   assign wbs4_ram_bte_i = wbm4_bte_i;
+   assign wbs4_ram_cti_i = wbm4_cti_i;
+   assign wbs4_ram_cyc_i = wbm4_cyc_i;
+   assign wbs4_ram_dat_i = wbm4_dat_i;
+   assign wbs4_ram_sel_i = wbm4_sel_i;
+   assign wbs4_ram_stb_i = wbm4_stb_i;
+   assign wbs4_ram_we_i  = wbm4_we_i;   
+   assign wbm4_ack_o     = wbs4_ram_ack_o;
+   assign wbm4_dat_o     = wbs4_ram_dat_o;
+   assign wbm4_err_o     = 0;   
+   assign wbm4_rty_o     = 0;
+
+    xilinx_ddr2_if xilinx_ddr2_if0
+     (
+
+      .wb0_dat_o            (wbs0_ram_dat_o),
+      .wb0_ack_o            (wbs0_ram_ack_o),
+      .wb0_adr_i            (wbs0_ram_adr_i[31:0]),
+      .wb0_stb_i            (wbs0_ram_stb_i),
+      .wb0_cti_i            (wbs0_ram_cti_i),
+      .wb0_bte_i            (wbs0_ram_bte_i),
+      .wb0_cyc_i            (wbs0_ram_cyc_i),
+      .wb0_we_i             (wbs0_ram_we_i),
+      .wb0_sel_i            (wbs0_ram_sel_i[3:0]),
+      .wb0_dat_i            (wbs0_ram_dat_i[31:0]),
+
+      .wb1_dat_o            (wbs1_ram_dat_o),
+      .wb1_ack_o            (wbs1_ram_ack_o),
+      .wb1_adr_i            (wbs1_ram_adr_i[31:0]),
+      .wb1_stb_i            (wbs1_ram_stb_i),
+      .wb1_cti_i            (wbs1_ram_cti_i),
+      .wb1_bte_i            (wbs1_ram_bte_i),
+      .wb1_cyc_i            (wbs1_ram_cyc_i),
+      .wb1_we_i             (wbs1_ram_we_i),
+      .wb1_sel_i            (wbs1_ram_sel_i[3:0]),
+      .wb1_dat_i            (wbs1_ram_dat_i[31:0]),
+
+      .wb2_dat_o            (wbs2_ram_dat_o),
+      .wb2_ack_o            (wbs2_ram_ack_o),
+      .wb2_adr_i            (wbs2_ram_adr_i[31:0]),
+      .wb2_stb_i            (wbs2_ram_stb_i),
+      .wb2_cti_i            (wbs2_ram_cti_i),
+      .wb2_bte_i            (wbs2_ram_bte_i),
+      .wb2_cyc_i            (wbs2_ram_cyc_i),
+      .wb2_we_i             (wbs2_ram_we_i),
+      .wb2_sel_i            (wbs2_ram_sel_i[3:0]),
+      .wb2_dat_i            (wbs2_ram_dat_i[31:0]),
+
+      .wb3_dat_o            (wbs3_ram_dat_o),
+      .wb3_ack_o            (wbs3_ram_ack_o),
+      .wb3_adr_i            (wbs3_ram_adr_i[31:0]),
+      .wb3_stb_i            (wbs3_ram_stb_i),
+      .wb3_cti_i            (wbs3_ram_cti_i),
+      .wb3_bte_i            (wbs3_ram_bte_i),
+      .wb3_cyc_i            (wbs3_ram_cyc_i),
+      .wb3_we_i             (wbs3_ram_we_i),
+      .wb3_sel_i            (wbs3_ram_sel_i[3:0]),
+      .wb3_dat_i            (wbs3_ram_dat_i[31:0]),
+
+      .wb4_dat_o            (wbs4_ram_dat_o),
+      .wb4_ack_o            (wbs4_ram_ack_o),
+      .wb4_adr_i            (wbs4_ram_adr_i[31:0]),
+      .wb4_stb_i            (wbs4_ram_stb_i),
+      .wb4_cti_i            (wbs4_ram_cti_i),
+      .wb4_bte_i            (wbs4_ram_bte_i),
+      .wb4_cyc_i            (wbs4_ram_cyc_i),
+      .wb4_we_i             (wbs4_ram_we_i),
+      .wb4_sel_i            (wbs4_ram_sel_i[3:0]),
+      .wb4_dat_i            (wbs4_ram_dat_i[31:0]),
+
+      .ddr2_a               (ddr2_a[12:0]),
+      .ddr2_ba              (ddr2_ba),
+      .ddr2_ras_n           (ddr2_ras_n),
+      .ddr2_cas_n           (ddr2_cas_n),
+      .ddr2_we_n            (ddr2_we_n),
+      .ddr2_rzq             (ddr2_rzq),
+      .ddr2_zio             (ddr2_zio),
+      .ddr2_odt             (ddr2_odt),
+      .ddr2_cke             (ddr2_cke),
+      .ddr2_dm              (ddr2_dm),
+      .ddr2_udm             (ddr2_udm),
+      .ddr2_ck              (ddr2_ck),
+      .ddr2_ck_n            (ddr2_ck_n),
+      .ddr2_dq              (ddr2_dq),
+      .ddr2_dqs             (ddr2_dqs),
+      .ddr2_dqs_n           (ddr2_dqs_n),
+      .ddr2_udqs            (ddr2_udqs),
+      .ddr2_udqs_n          (ddr2_udqs_n),
+
+      .ddr2_if_clk      	  (ddr2_if_clk),
+      .ddr2_if_rst          (ddr2_if_rst),
+      .wb_clk               (wb_clk),
+      .wb_rst               (wb_rst)
+,
+      .ddr2_trace_data0_o		(ddr2_trace_data0_o[31:0]),
+      .ddr2_trace_data1_o		(ddr2_trace_data1_o[31:0]),
+      .ddr2_trace_data2_o		(ddr2_trace_data2_o[31:0]),
+      .ddr2_trace_data3_o		(ddr2_trace_data3_o[31:0]),
+      .ddr2_trace_data4_o		(ddr2_trace_data4_o[31:0]),
+      .ddr2_trace_data5_o		(ddr2_trace_data5_o[31:0])
+);
+
+endmodule //xilinx_ddr2

--- a/systems/atlys/rtl/verilog/xilinx_ddr2/xilinx_ddr2_if.v
+++ b/systems/atlys/rtl/verilog/xilinx_ddr2/xilinx_ddr2_if.v
@@ -1,0 +1,890 @@
+//////////////////////////////////////////////////////////////////////
+////                                                              ////
+////  Xilinx DDR2 controller Wishbone Interface                   ////
+////                                                              ////
+////  Description                                                 ////
+////  Simple interface to the Xilinx MIG generated DDR2 controller////
+////  The interface presents five wishbone slaves,                ////
+////  which are mapped into 32-bit user ports of the MIG          ////
+////                                                              ////
+////                                                              ////
+////  Author(s):                                                  ////
+////      - Stefan Kristiansson, stefan.kristiansson@saunalahti.fi////
+////                                                              ////
+//////////////////////////////////////////////////////////////////////
+////                                                              ////
+//// Copyright (C) 2010 Authors and OPENCORES.ORG                 ////
+////                                                              ////
+//// This source file may be used and distributed without         ////
+//// restriction provided that this copyright statement is not    ////
+//// removed from the file and that any derivative work contains  ////
+//// the original copyright notice and the associated disclaimer. ////
+////                                                              ////
+//// This source file is free software; you can redistribute it   ////
+//// and/or modify it under the terms of the GNU Lesser General   ////
+//// Public License as published by the Free Software Foundation; ////
+//// either version 2.1 of the License, or (at your option) any   ////
+//// later version.                                               ////
+////                                                              ////
+//// This source is distributed in the hope that it will be       ////
+//// useful, but WITHOUT ANY WARRANTY; without even the implied   ////
+//// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR      ////
+//// PURPOSE.  See the GNU Lesser General Public License for more ////
+//// details.                                                     ////
+////                                                              ////
+//// You should have received a copy of the GNU Lesser General    ////
+//// Public License along with this source; if not, download it   ////
+//// from http://www.opencores.org/lgpl.shtml                     ////
+////                                                              ////
+//////////////////////////////////////////////////////////////////////
+
+module xilinx_ddr2_if ( 
+    input [31:0]       wb0_adr_i,
+    input 	           wb0_stb_i,
+    input 	           wb0_cyc_i,
+    input  [2:0]       wb0_cti_i,
+    input  [1:0]       wb0_bte_i,
+    input 	           wb0_we_i,
+    input  [3:0]       wb0_sel_i,
+    input  [31:0]      wb0_dat_i,
+    output [31:0]      wb0_dat_o,
+    output             wb0_ack_o,
+
+    input [31:0]       wb1_adr_i,
+    input              wb1_stb_i,
+    input              wb1_cyc_i,
+    input  [2:0]       wb1_cti_i,
+    input  [1:0]       wb1_bte_i,
+    input              wb1_we_i,
+    input  [3:0]       wb1_sel_i,
+    input  [31:0]      wb1_dat_i,
+    output [31:0]      wb1_dat_o,
+    output             wb1_ack_o,
+
+    input [31:0]       wb2_adr_i,
+    input              wb2_stb_i,
+    input              wb2_cyc_i,
+    input  [2:0]       wb2_cti_i,
+    input  [1:0]       wb2_bte_i,
+    input              wb2_we_i,
+    input  [3:0]       wb2_sel_i,
+    input  [31:0]      wb2_dat_i,
+    output [31:0]      wb2_dat_o,
+    output             wb2_ack_o,
+
+    input [31:0]       wb3_adr_i,
+    input              wb3_stb_i,
+    input              wb3_cyc_i,
+    input  [2:0]       wb3_cti_i,
+    input  [1:0]       wb3_bte_i,
+    input              wb3_we_i,
+    input  [3:0]       wb3_sel_i,
+    input  [31:0]      wb3_dat_i,
+    output [31:0]      wb3_dat_o,
+    output             wb3_ack_o,
+
+    input [31:0]       wb4_adr_i,
+    input              wb4_stb_i,
+    input              wb4_cyc_i,
+    input  [2:0]       wb4_cti_i,
+    input  [1:0]       wb4_bte_i,
+    input              wb4_we_i,
+    input  [3:0]       wb4_sel_i,
+    input  [31:0]      wb4_dat_i,
+    output [31:0]      wb4_dat_o,
+    output             wb4_ack_o,
+
+    output [12:0]      ddr2_a,
+    output [2:0]       ddr2_ba,
+    output 	           ddr2_ras_n,
+    output 	           ddr2_cas_n,
+    output 	           ddr2_we_n,
+    output             ddr2_rzq,
+    output             ddr2_zio,
+    output             ddr2_odt,
+    output             ddr2_cke,
+    output             ddr2_dm,
+    output             ddr2_udm,
+
+    inout [15:0]       ddr2_dq,		  
+    inout              ddr2_dqs,
+    inout              ddr2_dqs_n,
+    inout              ddr2_udqs,
+    inout              ddr2_udqs_n,
+    output             ddr2_ck,
+    output             ddr2_ck_n,
+
+    input 	           ddr2_if_clk,
+    input 	           ddr2_if_rst,
+    input 	           wb_clk,
+    input 	           wb_rst
+,
+   output [31:0] 		     ddr2_trace_data0_o,
+   output [31:0] 		     ddr2_trace_data1_o,
+   output [31:0] 		     ddr2_trace_data2_o,
+   output [31:0] 		     ddr2_trace_data3_o,
+   output [31:0] 		     ddr2_trace_data4_o,
+   output [31:0] 		     ddr2_trace_data5_o
+);
+   
+`include "orpsoc-defines.v"
+`include "xilinx_ddr2_params.v"
+    parameter NUM_USERPORTS = 5;
+    parameter P0_BURST_ADDR_WIDTH = 4;
+    parameter P0_BURST_ADDR_ALIGN = P0_BURST_ADDR_WIDTH + 2;
+	 parameter P0_WB_BURSTING      = "TRUE";
+	 
+    parameter P1_BURST_ADDR_WIDTH = 5;
+    parameter P1_BURST_ADDR_ALIGN = P1_BURST_ADDR_WIDTH + 2;
+	 parameter P1_WB_BURSTING      = "TRUE";
+  
+    parameter P2_BURST_ADDR_WIDTH = 6;
+    parameter P2_BURST_ADDR_ALIGN = P2_BURST_ADDR_WIDTH + 2;
+	 parameter P2_WB_BURSTING      = "TRUE";
+  
+    parameter P3_BURST_ADDR_WIDTH = 4;
+    parameter P3_BURST_ADDR_ALIGN = P3_BURST_ADDR_WIDTH + 2;
+	 parameter P3_WB_BURSTING      = "TRUE";
+
+    parameter P4_BURST_ADDR_WIDTH = 4;
+    parameter P4_BURST_ADDR_ALIGN = P4_BURST_ADDR_WIDTH + 2;
+	 parameter P4_WB_BURSTING      = "TRUE";
+
+    wire 	              ddr2_clk; // DDR2 iface domain clock.
+    wire 	              ddr2_rst; // reset from the ddr2 module
+ 
+    wire  [31:0]        wb_px_adr_i[NUM_USERPORTS-1:0];
+    wire 	              wb_px_stb_i[NUM_USERPORTS-1:0];
+    wire 	              wb_px_cyc_i[NUM_USERPORTS-1:0];
+    wire  [2:0]         wb_px_cti_i[NUM_USERPORTS-1:0];
+    wire  [1:0]         wb_px_bte_i[NUM_USERPORTS-1:0];
+    wire 	              wb_px_we_i[NUM_USERPORTS-1:0];
+    wire  [3:0]         wb_px_sel_i[NUM_USERPORTS-1:0];
+    wire  [31:0]        wb_px_dat_i[NUM_USERPORTS-1:0];
+    wire  [31:0]        wb_px_dat_o[NUM_USERPORTS-1:0];
+    wire                wb_px_ack_o[NUM_USERPORTS-1:0];
+ 
+    wire 	              wb_px_req[NUM_USERPORTS-1:0];
+    reg 		            wb_px_req_r[NUM_USERPORTS-1:0];
+    wire 	              wb_px_req_new[NUM_USERPORTS-1:0];
+    wire                wb_px_wr_req[NUM_USERPORTS-1:0];
+   
+    // DDR2 MIG interface wires
+    wire                ddr2_px_cmd_full[NUM_USERPORTS-1:0];
+    wire                ddr2_px_wr_full[NUM_USERPORTS-1:0];
+    wire                ddr2_px_wr_en[NUM_USERPORTS-1:0];
+    wire                ddr2_px_cmd_en[NUM_USERPORTS-1:0];
+    wire [29:0]         ddr2_px_cmd_byte_addr[NUM_USERPORTS-1:0];
+    wire [2:0]          ddr2_px_cmd_instr[NUM_USERPORTS-1:0];
+    wire [31:0]         ddr2_px_wr_data[NUM_USERPORTS-1:0];
+    wire [3:0]          ddr2_px_wr_mask[NUM_USERPORTS-1:0];
+    wire [31:0]         ddr2_px_rd_data[NUM_USERPORTS-1:0];
+    wire [5:0]          ddr2_px_cmd_bl[NUM_USERPORTS-1:0];
+    wire                ddr2_px_rd_en[NUM_USERPORTS-1:0];
+    wire                ddr2_px_cmd_empty[NUM_USERPORTS-1:0];
+    wire                ddr2_px_wr_empty[NUM_USERPORTS-1:0];
+    wire                ddr2_px_wr_count[NUM_USERPORTS-1:0];
+    wire                ddr2_px_wr_underrun[NUM_USERPORTS-1:0];
+    wire                ddr2_px_wr_error[NUM_USERPORTS-1:0];
+    wire                ddr2_px_rd_full[NUM_USERPORTS-1:0];
+    wire                ddr2_px_rd_empty[NUM_USERPORTS-1:0];
+    wire                ddr2_px_rd_count[NUM_USERPORTS-1:0];
+    wire                ddr2_px_rd_overflow[NUM_USERPORTS-1:0];
+    wire                ddr2_px_rd_error[NUM_USERPORTS-1:0];
+    wire 	              ddr2_calib_done;
+    reg [1:0]           ddr2_calib_done_r;
+
+    assign wb_px_adr_i[0] = wb0_adr_i;
+    assign wb_px_stb_i[0] = wb0_stb_i;
+    assign wb_px_cyc_i[0] = wb0_cyc_i;
+    assign wb_px_cti_i[0] = wb0_cti_i;
+    assign wb_px_bte_i[0] = wb0_bte_i;
+    assign wb_px_we_i[0]  = wb0_we_i;
+    assign wb_px_sel_i[0] = wb0_sel_i;
+    assign wb_px_dat_i[0] = wb0_dat_i;
+    assign wb0_dat_o = wb_px_dat_o[0];
+    assign wb0_ack_o = wb_px_ack_o[0];
+
+    assign wb_px_adr_i[1] = wb1_adr_i;
+    assign wb_px_stb_i[1] = wb1_stb_i;
+    assign wb_px_cyc_i[1] = wb1_cyc_i;
+    assign wb_px_cti_i[1] = wb1_cti_i;
+    assign wb_px_bte_i[1] = wb1_bte_i;
+    assign wb_px_we_i[1]  = wb1_we_i;
+    assign wb_px_sel_i[1] = wb1_sel_i;
+    assign wb_px_dat_i[1] = wb1_dat_i;
+    assign wb1_dat_o = wb_px_dat_o[1];
+    assign wb1_ack_o = wb_px_ack_o[1];
+
+    assign wb_px_adr_i[2] = wb2_adr_i;
+    assign wb_px_stb_i[2] = wb2_stb_i;
+    assign wb_px_cyc_i[2] = wb2_cyc_i;
+    assign wb_px_cti_i[2] = wb2_cti_i;
+    assign wb_px_bte_i[2] = wb2_bte_i;
+    assign wb_px_we_i[2]  = wb2_we_i;
+    assign wb_px_sel_i[2] = wb2_sel_i;
+    assign wb_px_dat_i[2] = wb2_dat_i;
+    assign wb2_dat_o = wb_px_dat_o[2];
+    assign wb2_ack_o = wb_px_ack_o[2];
+
+    assign wb_px_adr_i[3] = wb3_adr_i;
+    assign wb_px_stb_i[3] = wb3_stb_i;
+    assign wb_px_cyc_i[3] = wb3_cyc_i;
+    assign wb_px_cti_i[3] = wb3_cti_i;
+    assign wb_px_bte_i[3] = wb3_bte_i;
+    assign wb_px_we_i[3]  = wb3_we_i;
+    assign wb_px_sel_i[3] = wb3_sel_i;
+    assign wb_px_dat_i[3] = wb3_dat_i;
+    assign wb3_dat_o = wb_px_dat_o[3];
+    assign wb3_ack_o = wb_px_ack_o[3];
+
+    assign wb_px_adr_i[4] = wb4_adr_i;
+    assign wb_px_stb_i[4] = wb4_stb_i;
+    assign wb_px_cyc_i[4] = wb4_cyc_i;
+    assign wb_px_cti_i[4] = wb4_cti_i;
+    assign wb_px_bte_i[4] = wb4_bte_i;
+    assign wb_px_we_i[4]  = wb4_we_i;
+    assign wb_px_sel_i[4] = wb4_sel_i;
+    assign wb_px_dat_i[4] = wb4_dat_i;
+    assign wb4_dat_o = wb_px_dat_o[4];
+    assign wb4_ack_o = wb_px_ack_o[4];
+
+    // Map wishbone signals to/from DDR2 MIG controller
+
+    wire        px_addr_dirty[NUM_USERPORTS-1:0];
+    wire [31:0] px_cache_addr[NUM_USERPORTS-1:0];
+
+    // Let the port know if another port have wrote to its current cache buffer address
+    // TODO: own writes to own cache
+    assign px_addr_dirty[0] = ((wb0_adr_i[31:P0_BURST_ADDR_ALIGN] == px_cache_addr[0][31:P0_BURST_ADDR_ALIGN]) & wb_px_wr_req[0]) |
+                              ((wb1_adr_i[31:P0_BURST_ADDR_ALIGN] == px_cache_addr[0][31:P0_BURST_ADDR_ALIGN]) & wb_px_wr_req[1]) | 
+                              ((wb2_adr_i[31:P0_BURST_ADDR_ALIGN] == px_cache_addr[0][31:P0_BURST_ADDR_ALIGN]) & wb_px_wr_req[2]) |
+                              ((wb3_adr_i[31:P0_BURST_ADDR_ALIGN] == px_cache_addr[0][31:P0_BURST_ADDR_ALIGN]) & wb_px_wr_req[3]) |
+                              ((wb4_adr_i[31:P0_BURST_ADDR_ALIGN] == px_cache_addr[0][31:P0_BURST_ADDR_ALIGN]) & wb_px_wr_req[4]);
+                           
+    assign px_addr_dirty[1] = ((wb0_adr_i[31:P1_BURST_ADDR_ALIGN] == px_cache_addr[1][31:P1_BURST_ADDR_ALIGN]) & wb_px_wr_req[0]) | 
+                              ((wb1_adr_i[31:P1_BURST_ADDR_ALIGN] == px_cache_addr[1][31:P1_BURST_ADDR_ALIGN]) & wb_px_wr_req[1]) | 
+                              ((wb2_adr_i[31:P1_BURST_ADDR_ALIGN] == px_cache_addr[1][31:P1_BURST_ADDR_ALIGN]) & wb_px_wr_req[2]) |
+                              ((wb3_adr_i[31:P1_BURST_ADDR_ALIGN] == px_cache_addr[1][31:P1_BURST_ADDR_ALIGN]) & wb_px_wr_req[3]) |
+                              ((wb4_adr_i[31:P1_BURST_ADDR_ALIGN] == px_cache_addr[1][31:P1_BURST_ADDR_ALIGN]) & wb_px_wr_req[4]);
+                           
+    assign px_addr_dirty[2] = ((wb0_adr_i[31:P2_BURST_ADDR_ALIGN] == px_cache_addr[2][31:P2_BURST_ADDR_ALIGN]) & wb_px_wr_req[0]) | 
+                              ((wb1_adr_i[31:P2_BURST_ADDR_ALIGN] == px_cache_addr[2][31:P2_BURST_ADDR_ALIGN]) & wb_px_wr_req[1]) |
+                              ((wb2_adr_i[31:P2_BURST_ADDR_ALIGN] == px_cache_addr[2][31:P2_BURST_ADDR_ALIGN]) & wb_px_wr_req[2]) |
+                              ((wb3_adr_i[31:P2_BURST_ADDR_ALIGN] == px_cache_addr[2][31:P2_BURST_ADDR_ALIGN]) & wb_px_wr_req[3]) |
+                              ((wb4_adr_i[31:P2_BURST_ADDR_ALIGN] == px_cache_addr[2][31:P2_BURST_ADDR_ALIGN]) & wb_px_wr_req[4]);
+    
+    assign px_addr_dirty[3] = ((wb0_adr_i[31:P3_BURST_ADDR_ALIGN] == px_cache_addr[3][31:P3_BURST_ADDR_ALIGN]) & wb_px_wr_req[0]) | 
+                              ((wb1_adr_i[31:P3_BURST_ADDR_ALIGN] == px_cache_addr[3][31:P3_BURST_ADDR_ALIGN]) & wb_px_wr_req[1]) |
+                              ((wb2_adr_i[31:P3_BURST_ADDR_ALIGN] == px_cache_addr[3][31:P3_BURST_ADDR_ALIGN]) & wb_px_wr_req[2]) |
+                              ((wb3_adr_i[31:P3_BURST_ADDR_ALIGN] == px_cache_addr[3][31:P3_BURST_ADDR_ALIGN]) & wb_px_wr_req[3]) |
+                              ((wb4_adr_i[31:P3_BURST_ADDR_ALIGN] == px_cache_addr[3][31:P3_BURST_ADDR_ALIGN]) & wb_px_wr_req[4]);
+
+    assign px_addr_dirty[4] = ((wb0_adr_i[31:P3_BURST_ADDR_ALIGN] == px_cache_addr[4][31:P3_BURST_ADDR_ALIGN]) & wb_px_wr_req[0]) | 
+                              ((wb1_adr_i[31:P3_BURST_ADDR_ALIGN] == px_cache_addr[4][31:P3_BURST_ADDR_ALIGN]) & wb_px_wr_req[1]) |
+                              ((wb2_adr_i[31:P3_BURST_ADDR_ALIGN] == px_cache_addr[4][31:P3_BURST_ADDR_ALIGN]) & wb_px_wr_req[2]) |
+                              ((wb3_adr_i[31:P3_BURST_ADDR_ALIGN] == px_cache_addr[4][31:P3_BURST_ADDR_ALIGN]) & wb_px_wr_req[3]) |
+                              ((wb4_adr_i[31:P3_BURST_ADDR_ALIGN] == px_cache_addr[4][31:P3_BURST_ADDR_ALIGN]) & wb_px_wr_req[4]);
+
+   always @ (posedge wb_clk)
+     ddr2_calib_done_r[1:0] <= {ddr2_calib_done, ddr2_calib_done_r[1]};
+
+   assign ddr2_trace_data3_o = wb_px_adr_i[1];
+   assign ddr2_trace_data4_o = ddr2_px_rd_data[1];
+   assign ddr2_trace_data5_o = {
+				ddr2_px_cmd_full[1],
+				ddr2_px_wr_full[1],
+				ddr2_px_wr_en[1],
+				ddr2_px_cmd_en[1],
+				ddr2_px_cmd_instr[1], // =3
+				ddr2_px_rd_en[1],
+				ddr2_px_cmd_empty[1],
+				ddr2_px_wr_empty[1],
+				ddr2_px_rd_full[1],
+				ddr2_px_rd_empty[1],
+				ddr2_px_rd_error[1],
+				ddr2_px_wr_error[1],
+				18'h0
+				};
+
+      assign wb_px_req[0]     = wb_px_stb_i[0] & wb_px_cyc_i[0] & ddr2_calib_done_r[0]; 
+      assign wb_px_req_new[0] = wb_px_req[0] & !wb_px_req_r[0];
+      assign wb_px_wr_req[0]  = wb_px_req_new[0] & wb_px_we_i[0];
+
+      always @(posedge wb_clk)
+        wb_px_req_r[0] <= wb_px_req[0] & !wb_px_ack_o[0];
+
+       wb_to_userport #(
+        .BURST_ADDR_WIDTH(P0_BURST_ADDR_WIDTH),
+        .BURST_ADDR_ALIGN(P0_BURST_ADDR_ALIGN),
+        .WB_BURSTING(P0_WB_BURSTING)
+       )
+       wb2up0 (
+        .wb_clk                     (wb_clk),
+        .wb_rst                     (wb_rst),
+        .wb_adr_i                   (wb_px_adr_i[0]),
+        .wb_stb_i                   (wb_px_stb_i[0]),
+        .wb_cyc_i                   (wb_px_cyc_i[0]),
+        .wb_cti_i                   (wb_px_cti_i[0]),
+        .wb_bte_i                   (wb_px_bte_i[0]),
+        .wb_we_i                    (wb_px_we_i[0]),
+        .wb_sel_i                   (wb_px_sel_i[0]),
+        .wb_dat_i                   (wb_px_dat_i[0]),
+        .wb_dat_o                   (wb_px_dat_o[0]),
+        .wb_ack_o                   (wb_px_ack_o[0]),
+
+        .addr_dirty                 (px_addr_dirty[0]),
+        .cache_addr                 (px_cache_addr[0]),
+
+        .ddr2_px_cmd_full           (ddr2_px_cmd_full[0]),
+        .ddr2_px_wr_full            (ddr2_px_wr_full[0]),
+        .ddr2_px_wr_en              (ddr2_px_wr_en[0]),
+        .ddr2_px_cmd_en             (ddr2_px_cmd_en[0]),
+        .ddr2_px_cmd_byte_addr      (ddr2_px_cmd_byte_addr[0]),
+        .ddr2_px_cmd_instr          (ddr2_px_cmd_instr[0]),
+        .ddr2_px_wr_data            (ddr2_px_wr_data[0]),
+        .ddr2_px_wr_mask            (ddr2_px_wr_mask[0]),
+        .ddr2_px_rd_data            (ddr2_px_rd_data[0]),
+        .ddr2_px_cmd_bl             (ddr2_px_cmd_bl[0]),
+        .ddr2_px_rd_en              (ddr2_px_rd_en[0]),
+        .ddr2_px_cmd_empty          (ddr2_px_cmd_empty[0]),
+        .ddr2_px_wr_empty           (ddr2_px_wr_empty[0]),
+        .ddr2_px_rd_full            (ddr2_px_rd_full[0]),
+        .ddr2_px_rd_empty           (ddr2_px_rd_empty[0]),
+        .ddr2_calib_done            (ddr2_calib_done)
+        );
+
+      assign wb_px_req[1]     = wb_px_stb_i[1] & wb_px_cyc_i[1] & ddr2_calib_done_r[0]; 
+      assign wb_px_req_new[1] = wb_px_req[1] & !wb_px_req_r[1];
+      assign wb_px_wr_req[1]  = wb_px_req_new[1] & wb_px_we_i[1];
+
+      always @(posedge wb_clk)
+        wb_px_req_r[1] <= wb_px_req[1] & !wb_px_ack_o[1];
+
+       wb_to_userport #(
+        .BURST_ADDR_WIDTH(P1_BURST_ADDR_WIDTH),
+        .BURST_ADDR_ALIGN(P1_BURST_ADDR_ALIGN),
+        .WB_BURSTING(P1_WB_BURSTING)
+       )
+       wb2up1 (
+        .wb_clk                     (wb_clk),
+        .wb_rst                     (wb_rst),
+        .wb_adr_i                   (wb_px_adr_i[1]),
+        .wb_stb_i                   (wb_px_stb_i[1]),
+        .wb_cyc_i                   (wb_px_cyc_i[1]),
+        .wb_cti_i                   (wb_px_cti_i[1]),
+        .wb_bte_i                   (wb_px_bte_i[1]),
+        .wb_we_i                    (wb_px_we_i[1]),
+        .wb_sel_i                   (wb_px_sel_i[1]),
+        .wb_dat_i                   (wb_px_dat_i[1]),
+        .wb_dat_o                   (wb_px_dat_o[1]),
+        .wb_ack_o                   (wb_px_ack_o[1]),
+
+        .addr_dirty                 (px_addr_dirty[1]),
+        .cache_addr                 (px_cache_addr[1]),
+
+        .ddr2_px_cmd_full           (ddr2_px_cmd_full[1]),
+        .ddr2_px_wr_full            (ddr2_px_wr_full[1]),
+        .ddr2_px_wr_en              (ddr2_px_wr_en[1]),
+        .ddr2_px_cmd_en             (ddr2_px_cmd_en[1]),
+        .ddr2_px_cmd_byte_addr      (ddr2_px_cmd_byte_addr[1]),
+        .ddr2_px_cmd_instr          (ddr2_px_cmd_instr[1]),
+        .ddr2_px_wr_data            (ddr2_px_wr_data[1]),
+        .ddr2_px_wr_mask            (ddr2_px_wr_mask[1]),
+        .ddr2_px_rd_data            (ddr2_px_rd_data[1]),
+        .ddr2_px_cmd_bl             (ddr2_px_cmd_bl[1]),
+        .ddr2_px_rd_en              (ddr2_px_rd_en[1]),
+        .ddr2_px_cmd_empty          (ddr2_px_cmd_empty[1]),
+        .ddr2_px_wr_empty           (ddr2_px_wr_empty[1]),
+        .ddr2_px_rd_full            (ddr2_px_rd_full[1]),
+        .ddr2_px_rd_empty           (ddr2_px_rd_empty[1]),
+        .ddr2_calib_done            (ddr2_calib_done)
+        );
+
+      assign wb_px_req[2]     = wb_px_stb_i[2] & wb_px_cyc_i[2] & ddr2_calib_done_r[0]; 
+      assign wb_px_req_new[2] = wb_px_req[2] & !wb_px_req_r[2];
+      assign wb_px_wr_req[2]  = wb_px_req_new[2] & wb_px_we_i[2];
+
+      always @(posedge wb_clk)
+        wb_px_req_r[2] <= wb_px_req[2] & !wb_px_ack_o[2];
+
+       wb_to_userport #(
+        .BURST_ADDR_WIDTH(P2_BURST_ADDR_WIDTH),
+        .BURST_ADDR_ALIGN(P2_BURST_ADDR_ALIGN),
+        .WB_BURSTING(P2_WB_BURSTING)
+       )
+       wb2up2 (
+        .wb_clk                     (wb_clk),
+        .wb_rst                     (wb_rst),
+        .wb_adr_i                   (wb_px_adr_i[2]),
+        .wb_stb_i                   (wb_px_stb_i[2]),
+        .wb_cyc_i                   (wb_px_cyc_i[2]),
+        .wb_cti_i                   (wb_px_cti_i[2]),
+        .wb_bte_i                   (wb_px_bte_i[2]),
+        .wb_we_i                    (wb_px_we_i[2]),
+        .wb_sel_i                   (wb_px_sel_i[2]),
+        .wb_dat_i                   (wb_px_dat_i[2]),
+        .wb_dat_o                   (wb_px_dat_o[2]),
+        .wb_ack_o                   (wb_px_ack_o[2]),
+
+        .addr_dirty                 (px_addr_dirty[2]),
+        .cache_addr                 (px_cache_addr[2]),
+
+        .ddr2_px_cmd_full           (ddr2_px_cmd_full[2]),
+        .ddr2_px_wr_full            (ddr2_px_wr_full[2]),
+        .ddr2_px_wr_en              (ddr2_px_wr_en[2]),
+        .ddr2_px_cmd_en             (ddr2_px_cmd_en[2]),
+        .ddr2_px_cmd_byte_addr      (ddr2_px_cmd_byte_addr[2]),
+        .ddr2_px_cmd_instr          (ddr2_px_cmd_instr[2]),
+        .ddr2_px_wr_data            (ddr2_px_wr_data[2]),
+        .ddr2_px_wr_mask            (ddr2_px_wr_mask[2]),
+        .ddr2_px_rd_data            (ddr2_px_rd_data[2]),
+        .ddr2_px_cmd_bl             (ddr2_px_cmd_bl[2]),
+        .ddr2_px_rd_en              (ddr2_px_rd_en[2]),
+        .ddr2_px_cmd_empty          (ddr2_px_cmd_empty[2]),
+        .ddr2_px_wr_empty           (ddr2_px_wr_empty[2]),
+        .ddr2_px_rd_full            (ddr2_px_rd_full[2]),
+        .ddr2_px_rd_empty           (ddr2_px_rd_empty[2]),
+        .ddr2_calib_done            (ddr2_calib_done)
+        );
+
+      assign wb_px_req[3]     = wb_px_stb_i[3] & wb_px_cyc_i[3] & ddr2_calib_done_r[0]; 
+      assign wb_px_req_new[3] = wb_px_req[3] & !wb_px_req_r[3];
+      assign wb_px_wr_req[3]  = wb_px_req_new[3] & wb_px_we_i[3];
+
+      always @(posedge wb_clk)
+        wb_px_req_r[3] <= wb_px_req[3] & !wb_px_ack_o[3];
+
+       wb_to_userport #(
+        .BURST_ADDR_WIDTH(P3_BURST_ADDR_WIDTH),
+        .BURST_ADDR_ALIGN(P3_BURST_ADDR_ALIGN),
+        .WB_BURSTING(P3_WB_BURSTING)
+       )
+       wb2up3 (
+        .wb_clk                     (wb_clk),
+        .wb_rst                     (wb_rst),
+        .wb_adr_i                   (wb_px_adr_i[3]),
+        .wb_stb_i                   (wb_px_stb_i[3]),
+        .wb_cyc_i                   (wb_px_cyc_i[3]),
+        .wb_cti_i                   (wb_px_cti_i[3]),
+        .wb_bte_i                   (wb_px_bte_i[3]),
+        .wb_we_i                    (wb_px_we_i[3]),
+        .wb_sel_i                   (wb_px_sel_i[3]),
+        .wb_dat_i                   (wb_px_dat_i[3]),
+        .wb_dat_o                   (wb_px_dat_o[3]),
+        .wb_ack_o                   (wb_px_ack_o[3]),
+
+        .addr_dirty                 (px_addr_dirty[3]),
+        .cache_addr                 (px_cache_addr[3]),
+
+        .ddr2_px_cmd_full           (ddr2_px_cmd_full[3]),
+        .ddr2_px_wr_full            (ddr2_px_wr_full[3]),
+        .ddr2_px_wr_en              (ddr2_px_wr_en[3]),
+        .ddr2_px_cmd_en             (ddr2_px_cmd_en[3]),
+        .ddr2_px_cmd_byte_addr      (ddr2_px_cmd_byte_addr[3]),
+        .ddr2_px_cmd_instr          (ddr2_px_cmd_instr[3]),
+        .ddr2_px_wr_data            (ddr2_px_wr_data[3]),
+        .ddr2_px_wr_mask            (ddr2_px_wr_mask[3]),
+        .ddr2_px_rd_data            (ddr2_px_rd_data[3]),
+        .ddr2_px_cmd_bl             (ddr2_px_cmd_bl[3]),
+        .ddr2_px_rd_en              (ddr2_px_rd_en[3]),
+        .ddr2_px_cmd_empty          (ddr2_px_cmd_empty[3]),
+        .ddr2_px_wr_empty           (ddr2_px_wr_empty[3]),
+        .ddr2_px_rd_full            (ddr2_px_rd_full[3]),
+        .ddr2_px_rd_empty           (ddr2_px_rd_empty[3]),
+        .ddr2_calib_done            (ddr2_calib_done)
+        );
+
+      assign wb_px_req[4]     = wb_px_stb_i[4] & wb_px_cyc_i[4] & ddr2_calib_done_r[0]; 
+      assign wb_px_req_new[4] = wb_px_req[4] & !wb_px_req_r[4];
+      assign wb_px_wr_req[4]  = wb_px_req_new[4] & wb_px_we_i[4];
+
+      always @(posedge wb_clk)
+        wb_px_req_r[4] <= wb_px_req[4] & !wb_px_ack_o[4];
+
+       wb_to_userport #(
+        .BURST_ADDR_WIDTH(P4_BURST_ADDR_WIDTH),
+        .BURST_ADDR_ALIGN(P4_BURST_ADDR_ALIGN),
+        .WB_BURSTING(P4_WB_BURSTING)
+       )
+       wb2up4 (
+        .wb_clk                     (wb_clk),
+        .wb_rst                     (wb_rst),
+        .wb_adr_i                   (wb_px_adr_i[4]),
+        .wb_stb_i                   (wb_px_stb_i[4]),
+        .wb_cyc_i                   (wb_px_cyc_i[4]),
+        .wb_cti_i                   (wb_px_cti_i[4]),
+        .wb_bte_i                   (wb_px_bte_i[4]),
+        .wb_we_i                    (wb_px_we_i[4]),
+        .wb_sel_i                   (wb_px_sel_i[4]),
+        .wb_dat_i                   (wb_px_dat_i[4]),
+        .wb_dat_o                   (wb_px_dat_o[4]),
+        .wb_ack_o                   (wb_px_ack_o[4]),
+
+        .addr_dirty                 (px_addr_dirty[4]),
+        .cache_addr                 (px_cache_addr[4]),
+
+        .ddr2_px_cmd_full           (ddr2_px_cmd_full[4]),
+        .ddr2_px_wr_full            (ddr2_px_wr_full[4]),
+        .ddr2_px_wr_en              (ddr2_px_wr_en[4]),
+        .ddr2_px_cmd_en             (ddr2_px_cmd_en[4]),
+        .ddr2_px_cmd_byte_addr      (ddr2_px_cmd_byte_addr[4]),
+        .ddr2_px_cmd_instr          (ddr2_px_cmd_instr[4]),
+        .ddr2_px_wr_data            (ddr2_px_wr_data[4]),
+        .ddr2_px_wr_mask            (ddr2_px_wr_mask[4]),
+        .ddr2_px_rd_data            (ddr2_px_rd_data[4]),
+        .ddr2_px_cmd_bl             (ddr2_px_cmd_bl[4]),
+        .ddr2_px_rd_en              (ddr2_px_rd_en[4]),
+        .ddr2_px_cmd_empty          (ddr2_px_cmd_empty[4]),
+        .ddr2_px_wr_empty           (ddr2_px_wr_empty[4]),
+        .ddr2_px_rd_full            (ddr2_px_rd_full[4]),
+        .ddr2_px_rd_empty           (ddr2_px_rd_empty[4]),
+        .ddr2_calib_done            (ddr2_calib_done)
+        );
+
+/*
+	 // Forward parameters to WB to userports
+    defparam wb2up[0].BURST_ADDR_WIDTH = P0_BURST_ADDR_WIDTH;
+    defparam wb2up[0].BURST_ADDR_ALIGN = P0_BURST_ADDR_ALIGN;
+    defparam wb2up[0].WB_BURSTING      = P0_WB_BURSTING;
+
+    defparam wb2up[1].BURST_ADDR_WIDTH = P1_BURST_ADDR_WIDTH;
+    defparam wb2up[1].BURST_ADDR_ALIGN = P1_BURST_ADDR_ALIGN;
+    defparam wb2up[1].WB_BURSTING      = P1_WB_BURSTING;
+
+    defparam wb2up[2].BURST_ADDR_WIDTH = P2_BURST_ADDR_WIDTH;
+    defparam wb2up[2].BURST_ADDR_ALIGN = P2_BURST_ADDR_ALIGN;
+    defparam wb2up[2].WB_BURSTING      = P2_WB_BURSTING;
+
+    defparam wb2up[3].BURST_ADDR_WIDTH = P3_BURST_ADDR_WIDTH;
+    defparam wb2up[3].BURST_ADDR_ALIGN = P3_BURST_ADDR_ALIGN;
+    defparam wb2up[3].WB_BURSTING      = P3_WB_BURSTING;
+
+    defparam wb2up[4].BURST_ADDR_WIDTH = P4_BURST_ADDR_WIDTH;
+    defparam wb2up[4].BURST_ADDR_ALIGN = P4_BURST_ADDR_ALIGN;
+    defparam wb2up[4].WB_BURSTING      = P4_WB_BURSTING;
+*/
+  // The user ports are configured as follows:
+  // P0 = 32 bit, Read and Write
+  // P1 = 32 bit, Read and Write
+  // P2 = 32 bit, Read only
+  // P3 = 32 bit, Write only
+  // P4 = 32 bit, Read only
+  // P5 = 32 bit, Read only
+  ddr2_mig  #
+  (
+   .C3_P0_MASK_SIZE       (C3_P0_MASK_SIZE),
+   .C3_P0_DATA_PORT_SIZE  (C3_P0_DATA_PORT_SIZE),
+   .C3_P1_MASK_SIZE       (C3_P1_MASK_SIZE),
+   .C3_P1_DATA_PORT_SIZE  (C3_P1_DATA_PORT_SIZE),
+   .DEBUG_EN              (DEBUG_EN),       
+   .C3_MEMCLK_PERIOD      (C3_MEMCLK_PERIOD),       
+   .C3_CALIB_SOFT_IP      (C3_CALIB_SOFT_IP),       
+   .C3_SIMULATION         (C3_SIMULATION),       
+   .C3_RST_ACT_LOW        (C3_RST_ACT_LOW),       
+   .C3_INPUT_CLK_TYPE     (C3_INPUT_CLK_TYPE),       
+   .C3_MEM_ADDR_ORDER     (C3_MEM_ADDR_ORDER),       
+   .C3_NUM_DQ_PINS        (C3_NUM_DQ_PINS),       
+   .C3_MEM_ADDR_WIDTH     (C3_MEM_ADDR_WIDTH),       
+   .C3_MEM_BANKADDR_WIDTH (C3_MEM_BANKADDR_WIDTH)       
+   )
+   ddr2_mig
+   (
+    .mcb3_dram_dq         (ddr2_dq),
+    .mcb3_dram_a          (ddr2_a),
+    .mcb3_dram_ba         (ddr2_ba),
+    .mcb3_dram_ras_n      (ddr2_ras_n),
+    .mcb3_dram_cas_n      (ddr2_cas_n),
+    .mcb3_dram_we_n       (ddr2_we_n),
+    .mcb3_dram_odt        (ddr2_odt),
+    .mcb3_dram_cke        (ddr2_cke),
+    .mcb3_dram_dm         (ddr2_dm),
+    .mcb3_dram_udqs       (ddr2_udqs),        
+    .mcb3_dram_udqs_n     (ddr2_udqs_n), 
+    .mcb3_rzq             (ddr2_rzq),
+    .mcb3_zio             (ddr2_zio),
+    .mcb3_dram_udm        (ddr2_udm),
+    .c3_sys_clk           (ddr2_if_clk),
+    .c3_sys_rst_n         (ddr2_if_rst),
+    .c3_calib_done        (ddr2_calib_done),
+    .c3_clk0              (ddr2_clk),
+    .c3_rst0              (ddr2_rst),
+    .mcb3_dram_dqs        (ddr2_dqs),
+    .mcb3_dram_dqs_n      (ddr2_dqs_n),
+    .mcb3_dram_ck         (ddr2_ck),          
+    .mcb3_dram_ck_n       (ddr2_ck_n),
+    .c3_p0_cmd_clk        (wb_clk),
+    .c3_p0_cmd_en         (ddr2_px_cmd_en[0]),
+    .c3_p0_cmd_instr      (ddr2_px_cmd_instr[0]),
+    .c3_p0_cmd_bl         (ddr2_px_cmd_bl[0]),
+    .c3_p0_cmd_byte_addr  (ddr2_px_cmd_byte_addr[0]),
+    .c3_p0_cmd_empty      (ddr2_px_cmd_empty[0]),
+    .c3_p0_cmd_full       (ddr2_px_cmd_full[0]),
+    .c3_p0_wr_clk         (wb_clk),
+    .c3_p0_wr_en          (ddr2_px_wr_en[0]),
+    .c3_p0_wr_mask        (ddr2_px_wr_mask[0]),
+    .c3_p0_wr_data        (ddr2_px_wr_data[0]),
+    .c3_p0_wr_full        (ddr2_px_wr_full[0]),
+    .c3_p0_wr_empty       (ddr2_px_wr_empty[0]),
+    .c3_p0_wr_count       (ddr2_px_wr_count[0]),
+    .c3_p0_wr_underrun    (ddr2_px_wr_underrun[0]),
+    .c3_p0_wr_error       (ddr2_px_wr_error[0]),
+    .c3_p0_rd_clk         (wb_clk),
+    .c3_p0_rd_en          (ddr2_px_rd_en[0]),
+    .c3_p0_rd_data        (ddr2_px_rd_data[0]),
+    .c3_p0_rd_full        (ddr2_px_rd_full[0]),
+    .c3_p0_rd_empty       (ddr2_px_rd_empty[0]),
+    .c3_p0_rd_count       (ddr2_px_rd_count[0]),
+    .c3_p0_rd_overflow    (ddr2_px_rd_overflow[0]),
+    .c3_p0_rd_error       (ddr2_px_rd_error[0]),
+    .c3_p1_cmd_clk        (wb_clk),
+    .c3_p1_cmd_en         (ddr2_px_cmd_en[1]),
+    .c3_p1_cmd_instr      (ddr2_px_cmd_instr[1]),
+    .c3_p1_cmd_bl         (ddr2_px_cmd_bl[1]),
+    .c3_p1_cmd_byte_addr  (ddr2_px_cmd_byte_addr[1]),
+    .c3_p1_cmd_empty      (ddr2_px_cmd_empty[1]),
+    .c3_p1_cmd_full       (ddr2_px_cmd_full[1]),
+    .c3_p1_wr_clk         (wb_clk),
+    .c3_p1_wr_en          (ddr2_px_wr_en[1]),
+    .c3_p1_wr_mask        (ddr2_px_wr_mask[1]),
+    .c3_p1_wr_data        (ddr2_px_wr_data[1]),
+    .c3_p1_wr_full        (ddr2_px_wr_full[1]),
+    .c3_p1_wr_empty       (ddr2_px_wr_empty[1]),
+    .c3_p1_wr_count       (ddr2_px_wr_count[1]),
+    .c3_p1_wr_underrun    (ddr2_px_wr_underrun[1]),
+    .c3_p1_wr_error       (ddr2_px_wr_error[1]),
+    .c3_p1_rd_clk         (wb_clk),
+    .c3_p1_rd_en          (ddr2_px_rd_en[1]),
+    .c3_p1_rd_data        (ddr2_px_rd_data[1]),
+    .c3_p1_rd_full        (ddr2_px_rd_full[1]),
+    .c3_p1_rd_empty       (ddr2_px_rd_empty[1]),
+    .c3_p1_rd_count       (ddr2_px_rd_count[1]),
+    .c3_p1_rd_overflow    (ddr2_px_rd_overflow[1]),
+    .c3_p1_rd_error       (ddr2_px_rd_error[1]),
+    .c3_p2_cmd_clk        (wb_clk),
+    .c3_p2_cmd_en         (ddr2_px_cmd_en[2] & !wb_px_we_i[2]),
+    .c3_p2_cmd_instr      (ddr2_px_cmd_instr[2]),
+    .c3_p2_cmd_bl         (ddr2_px_cmd_bl[2]),
+    .c3_p2_cmd_byte_addr  (ddr2_px_cmd_byte_addr[2]),
+    .c3_p2_cmd_empty      (),
+    .c3_p2_cmd_full       (),
+    .c3_p2_rd_clk         (wb_clk),
+    .c3_p2_rd_en          (ddr2_px_rd_en[2]),
+    .c3_p2_rd_data        (ddr2_px_rd_data[2]),
+    .c3_p2_rd_full        (ddr2_px_rd_full[2]),
+    .c3_p2_rd_empty       (ddr2_px_rd_empty[2]),
+    .c3_p2_rd_count       (ddr2_px_rd_count[2]),
+    .c3_p2_rd_overflow    (ddr2_px_rd_overflow[2]),
+    .c3_p2_rd_error       (ddr2_px_rd_error[2]),
+    .c3_p3_cmd_clk        (wb_clk),
+    .c3_p3_cmd_en         (ddr2_px_cmd_en[2] & wb_px_we_i[2]),
+    .c3_p3_cmd_instr      (ddr2_px_cmd_instr[2]),
+    .c3_p3_cmd_bl         (ddr2_px_cmd_bl[2]),
+    .c3_p3_cmd_byte_addr  (ddr2_px_cmd_byte_addr[2]),
+    .c3_p3_cmd_empty      (ddr2_px_cmd_empty[2]),
+    .c3_p3_cmd_full       (ddr2_px_cmd_full[2]),
+    .c3_p3_wr_clk         (wb_clk),
+    .c3_p3_wr_en          (ddr2_px_wr_en[2]),
+    .c3_p3_wr_mask        (ddr2_px_wr_mask[2]),
+    .c3_p3_wr_data        (ddr2_px_wr_data[2]),
+    .c3_p3_wr_full        (ddr2_px_wr_full[2]),
+    .c3_p3_wr_empty       (ddr2_px_wr_empty[2]),
+    .c3_p3_wr_count       (ddr2_px_wr_count[2]),
+    .c3_p3_wr_underrun    (ddr2_px_wr_underrun[2]),
+    .c3_p3_wr_error       (ddr2_px_wr_error[2]),
+    .c3_p4_cmd_clk        (wb_clk),
+    .c3_p4_cmd_en         (ddr2_px_cmd_en[3]),
+    .c3_p4_cmd_instr      (ddr2_px_cmd_instr[3]),
+    .c3_p4_cmd_bl         (ddr2_px_cmd_bl[3]),
+    .c3_p4_cmd_byte_addr  (ddr2_px_cmd_byte_addr[3]),
+    .c3_p4_cmd_empty      (ddr2_px_cmd_empty[3]),
+    .c3_p4_cmd_full       (ddr2_px_cmd_full[3]),
+    .c3_p4_rd_clk         (wb_clk),
+    .c3_p4_rd_en          (ddr2_px_rd_en[3]),
+    .c3_p4_rd_data        (ddr2_px_rd_data[3]),
+    .c3_p4_rd_full        (ddr2_px_rd_full[3]),
+    .c3_p4_rd_empty       (ddr2_px_rd_empty[3]),
+    .c3_p4_rd_count       (ddr2_px_rd_count[3]),
+    .c3_p4_rd_overflow    (ddr2_px_rd_overflow[3]),
+    .c3_p4_rd_error       (ddr2_px_rd_error[3]),
+	 
+    .c3_p5_cmd_clk        (wb_clk),
+    .c3_p5_cmd_en         (ddr2_px_cmd_en[4]),
+    .c3_p5_cmd_instr      (ddr2_px_cmd_instr[4]),
+    .c3_p5_cmd_bl         (ddr2_px_cmd_bl[4]),
+    .c3_p5_cmd_byte_addr  (ddr2_px_cmd_byte_addr[4]),
+    .c3_p5_cmd_empty      (ddr2_px_cmd_empty[4]),
+    .c3_p5_cmd_full       (ddr2_px_cmd_full[4]),
+    .c3_p5_rd_clk         (wb_clk),
+    .c3_p5_rd_en          (ddr2_px_rd_en[4]),
+    .c3_p5_rd_data        (ddr2_px_rd_data[4]),
+    .c3_p5_rd_full        (ddr2_px_rd_full[4]),
+    .c3_p5_rd_empty       (ddr2_px_rd_empty[4]),
+    .c3_p5_rd_count       (ddr2_px_rd_count[4]),
+    .c3_p5_rd_overflow    (ddr2_px_rd_overflow[4]),
+    .c3_p5_rd_error       (ddr2_px_rd_error[4])    
+
+   );
+
+endmodule // atlys_ddr2_if
+
+module wb_to_userport (
+    input  wire         wb_clk,
+    input  wire         wb_rst,
+    input  wire [31:0]  wb_adr_i,
+    input  wire         wb_stb_i,
+    input  wire         wb_cyc_i,
+    input  wire [2:0]   wb_cti_i,
+    input  wire [1:0]   wb_bte_i,
+    input  wire         wb_we_i,
+    input  wire [3:0]   wb_sel_i,
+    input  wire [31:0]  wb_dat_i,
+    output wire [31:0]  wb_dat_o,
+    output wire         wb_ack_o,
+    
+    input  wire         addr_dirty,
+    output wire [31:0]  cache_addr,
+    
+    input  wire         ddr2_px_cmd_full,
+    input  wire         ddr2_px_wr_full,
+    output wire         ddr2_px_wr_en,
+    output wire         ddr2_px_cmd_en,
+    output wire [29:0]  ddr2_px_cmd_byte_addr,
+    output wire [2:0]   ddr2_px_cmd_instr,
+    output wire [31:0]  ddr2_px_wr_data,
+    output wire [3:0]   ddr2_px_wr_mask,
+    input  wire [31:0]  ddr2_px_rd_data,
+    output wire [5:0]   ddr2_px_cmd_bl,
+    output wire         ddr2_px_rd_en,
+    input  wire         ddr2_px_cmd_empty,
+    input  wire         ddr2_px_wr_empty,
+    input  wire         ddr2_px_rd_full,
+    input  wire         ddr2_px_rd_empty,
+    input  wire         ddr2_calib_done
+);
+   parameter BURST_ADDR_WIDTH = 4;
+   parameter BURST_ADDR_ALIGN = BURST_ADDR_WIDTH + 2;
+   parameter BURST_LENGTH     = 2**BURST_ADDR_WIDTH;
+	parameter WB_BURSTING      = "FALSE";
+
+   reg [31:0]                      burst_data_buf[BURST_LENGTH-1:0];
+   reg [31:BURST_ADDR_ALIGN]       burst_addr;
+   reg [BURST_ADDR_WIDTH-1:0]      burst_cnt;
+   reg                             bursting;
+   wire                            addr_match;
+   reg                             burst_start;
+   reg                             read_done;
+   reg                             addr_dirty_r;
+   reg                             wb_ack_read;
+   wire                            wb_req;
+   reg                             wb_req_r;
+   reg                             wb_ack_write;
+   wire                            wb_req_new;
+   wire                            wb_read_req;
+   reg                             wb_bursting;
+   reg [3:0]                       wb_burst_addr;
+   
+   // dummy signal to align address with a variable amount of zeroes
+   wire [BURST_ADDR_ALIGN-1:0]     addr_align_zeroes; 
+   assign addr_align_zeroes = 0;
+   
+   assign cache_addr = {burst_addr, addr_align_zeroes};
+   assign wb_req = wb_stb_i & wb_cyc_i & ddr2_calib_done & !ddr2_px_cmd_full &
+		   (!wb_we_i | !ddr2_px_wr_full);
+   assign wb_req_new  = wb_req & !wb_req_r;
+   
+   always @(posedge wb_clk) begin
+     wb_req_r <= wb_req & !wb_ack_o;
+   end
+   
+   // Wishbone bursting defines
+`define WB_CLASSIC     3'b000
+`define WB_CONST_ADDR  3'b001
+`define WB_INC_BURST   3'b010
+`define WB_END_BURST   3'b111
+
+   // register incoming dirty address signal, and hold it until a new burst read has started
+   always @(posedge wb_clk) begin
+     if (wb_rst)
+       addr_dirty_r <= 1; // Initially dirty to force read in from mem
+     else if (addr_dirty)
+       addr_dirty_r <= 1;
+     else if (burst_start)
+       addr_dirty_r <= 0;          
+   end
+
+   // In case of WB bursting, we can ack on each clock edge
+   // We don't take account for the type of bursting, since we can't perform wrapping bursts anyway
+   // We wait for the wr fifo to be empty, then at least all writes have been
+   // committed to the memory controller.
+   assign wb_read_req = wb_req & !wb_we_i & /*ddr2_px_wr_empty &*/
+			(!wb_ack_read | ((wb_cti_i == `WB_INC_BURST) &
+					 (WB_BURSTING == "TRUE")));
+   assign addr_match  = (burst_addr == wb_adr_i[31:BURST_ADDR_ALIGN]) & !addr_dirty_r;
+   
+   // Check if addr is in read cache, and that no other port have written to that address
+   // If not, start reading it in from ddr2
+   always @(posedge wb_clk) begin
+     burst_start <= 0;
+     wb_ack_read <= 0;
+     if (wb_read_req) begin
+       if (addr_match & !bursting & !burst_start) begin
+         wb_ack_read <= 1;
+// SJK: I had this block commented out for a while
+/*
+       end else if (addr_match & bursting & (burst_cnt > wb_adr_i[BURST_ADDR_ALIGN-1:2])) begin
+         wb_ack_read <= 1;
+ */
+// SJK: Block end
+// SJK: I had this block commented out for a while
+/*
+       end else if (addr_match & read_done) begin
+         wb_ack_read <= 1;
+ */
+// SJK: Block end
+       end else if (!bursting & !burst_start) begin
+         burst_start <= 1;
+       end
+     end
+   end
+   
+   // Read data from ddr2 into read cache
+   always @(posedge wb_clk) begin
+     read_done <= 0;
+     if (wb_rst) begin
+       burst_cnt  <= 0;
+       bursting   <= 0;
+       burst_addr <= 0;
+     end else if (burst_start & !bursting) begin
+       burst_cnt <= 0;
+       bursting  <= 1;
+       burst_addr <= wb_adr_i[31:BURST_ADDR_ALIGN];
+     end else if (!ddr2_px_rd_empty) begin
+       burst_data_buf[burst_cnt] <= ddr2_px_rd_data;
+       burst_cnt <= burst_cnt + 1;
+       if (&burst_cnt)
+         bursting <= 0;      
+       if (burst_cnt >= wb_adr_i[BURST_ADDR_ALIGN-1:2])
+         read_done <= 1;
+     end
+   end
+   
+   always @(posedge wb_clk) begin
+      wb_ack_write <= ddr2_px_wr_en;/*wb_req & wb_we_i & !wb_ack_write & !ddr2_px_wr_full &
+		      !ddr2_px_cmd_full*/;
+   end
+   
+   
+   assign ddr2_px_cmd_byte_addr = wb_ack_write ? {wb_adr_i[29:2],2'b0} : {wb_adr_i[29:BURST_ADDR_ALIGN], addr_align_zeroes};
+//wb_we_i ? {wb_adr_i[29:2],2'b0} : {wb_adr_i[29:BURST_ADDR_ALIGN], addr_align_zeroes};
+   assign ddr2_px_cmd_instr     = {2'b0, !wb_ack_write};//{2'b0, !wb_we_i};
+   assign ddr2_px_cmd_en        = wb_ack_write | burst_start;//wb_we_i ? wb_ack_write : burst_start;
+   assign ddr2_px_cmd_bl        = wb_ack_write ? 0 : BURST_LENGTH-1;//wb_we_i ? 0 : BURST_LENGTH-1;
+   assign ddr2_px_rd_en         = 1;
+   assign ddr2_px_wr_en         = wb_we_i ? wb_req_new : 1'b0;
+   assign ddr2_px_wr_data       = wb_dat_i;
+   assign ddr2_px_wr_mask       = ~wb_sel_i;
+   assign wb_ack_o              = wb_ack_write | wb_ack_read;//(wb_we_i ? wb_ack_write : wb_ack_read) & wb_stb_i;
+   assign wb_dat_o              = burst_data_buf[wb_adr_i[BURST_ADDR_ALIGN-1:2]];
+   
+endmodule // wb_to_userport


### PR DESCRIPTION
OpenRISC system for Digilent Atlys development board.
Basically lifted 'as is' from the orpsocv2 port at:
git://git.openrisc.net/stefan/orpsoc

TODO:
- Rewrite dvi_gen (currently a hacked up Xilinx whitepaper)
- Clean up the Xilinx MIG memory controller wrapper
  (and possibly generate the MIG with coregen on fly)
- General cleanup and de-orpsocv2-fication
