### PR TITLE
Remove the item "name" in section "main" in jp_vpi to avoid a warning.

### DIFF
--- a/cores/jp_vpi/jp_vpi.core
+++ b/cores/jp_vpi/jp_vpi.core
@@ -1,6 +1,5 @@
 CAPI=1
 [main]
-name= jp_vpi
 description = Debug interface GDB server
 
 [verilog]


### PR DESCRIPTION
Whenever I use the command "fusesoc list-systems" I see a warning: 

```
WARN:  Warning: Unknown item "name" in section "main" in jp_vpi
```

I removed the item "name" in jp_vpi.core to avoid that warning.
