### PR TITLE
cores: picorv32: fix Quartus' "Procedural Assignment error"

### DIFF
--- a/cores/picorv32/axi4_memory.v
+++ b/cores/picorv32/axi4_memory.v
@@ -25,7 +25,7 @@ module axi4_memory
 		input [31:0]     mem_axi_araddr,
 		input [ 2:0]     mem_axi_arprot,
 
-		output            mem_axi_rvalid = 0,
+		output reg        mem_axi_rvalid = 0,
 		input             mem_axi_rready,
 		output reg [31:0] mem_axi_rdata);
 


### PR DESCRIPTION
  Error (10137): Verilog HDL Procedural Assignment error at
  axi4_memory.v(103): object "mem_axi_rvalid" on left-hand side of
  assignment must have a variable data type File: ... picorv32_0/axi4_memory.v Line: 103
  Error (10137): Verilog HDL Procedural Assignment error at
  axi4_memory.v(159): object "mem_axi_rvalid" on left-hand side of
  assignment must have a variable data type File: ... picorv32_0/axi4_memory.v Line: 159

Signed-off-by: Antony Pavlov <antonynpavlov@gmail.com>