### PR TITLE
Verilator build errors

### DIFF
--- a/cores/elf-loader/elf-loader.c
+++ b/cores/elf-loader/elf-loader.c
@@ -25,6 +25,7 @@
 #include <unistd.h>
 #include <gelf.h>
 #include <fcntl.h>
+#include "elf-loader.h"
 
 uint8_t big_endian;
 
@@ -58,7 +59,7 @@ uint8_t *dump_program_data(Elf *elf_object, int *size)
 
 		if (phdr.p_paddr + phdr.p_filesz >= max_paddr) {
 			max_paddr = phdr.p_paddr + phdr.p_filesz;
-			buffer = realloc(buffer, max_paddr);
+			buffer = (uint8_t *) realloc(buffer, max_paddr);
 		}
 
 		data = elf_getdata_rawchunk(elf_object, phdr.p_offset, phdr.p_filesz, ELF_T_BYTE);
@@ -114,7 +115,7 @@ uint8_t *dump_section_data(Elf *elf_object, int *size)
 
 			if (shdr.sh_addr + shdr.sh_size >= max_saddr) {
 				max_saddr = shdr.sh_addr + shdr.sh_size;
-				buffer = realloc(buffer, max_saddr);
+				buffer = (uint8_t *) realloc(buffer, max_saddr);
 			}
 
 			data = elf_getdata(cur_section, data);

--- a/cores/verilator_tb_utils/verilator_tb_utils.cpp
+++ b/cores/verilator_tb_utils/verilator_tb_utils.cpp
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <argp.h>
-#include <elf-loader/elf-loader.h>
+#include <elf-loader.h>
 #include "verilator_tb_utils.h"
 #include "jtagServer.h"
 


### PR DESCRIPTION
I've tried to run the or1200-generic simulation on Verilator but I kept stumbling on this error:

```
../src/elf-loader_0/elf-loader.c: In function ‘uint8_t* dump_program_data(Elf*, int*)’:
../src/elf-loader_0/elf-loader.c:61:20: error: invalid conversion from ‘void*’ to ‘uint8_t* {aka unsigned char*}’ [-fpermissive]
    buffer = realloc(buffer, max_paddr);
             ~~~~~~~^~~~~~~~~~~~~~~~~~~
../src/elf-loader_0/elf-loader.c: In function ‘uint8_t* dump_section_data(Elf*, int*)’:
../src/elf-loader_0/elf-loader.c:117:21: error: invalid conversion from ‘void*’ to ‘uint8_t* {aka unsigned char*}’ [-fpermissive]
     buffer = realloc(buffer, max_saddr);
```

This can be fixed with a cast to uint8_t. Also after that g++ wasn't able to link to the functions defined in elf-loader in "verilator_tb_utils": I've noticed that the "elf-loader.h" include is missing in "elf-loader.c". Now everything is working fine.

Currently I'm using gcc 7.1.1 and Verilator 3.902.
